### PR TITLE
Typo: GMail -> Gmail

### DIFF
--- a/_data/main.yml
+++ b/_data/main.yml
@@ -100,7 +100,7 @@ sections:
     icon: mail
 
     websites:
-        - name: GMail
+        - name: Gmail
           url: https://gmail.com
           img: gmail.png
           tfa: Yes


### PR DESCRIPTION
Google's mail service is spelled Gmail, not GMail.
