### PR TITLE
Add VeriSign VIP Access.

### DIFF
--- a/_data/main.yml
+++ b/_data/main.yml
@@ -181,6 +181,7 @@ sections:
           url: https://www.paypal.com/
           tfa: Yes
           sms: Yes
+          verisign: Yes
           doc: https://www.paypal.com/us/cgi-bin?cmd=xpt/Marketing_CommandDriven/securitycenter/PayPalSecurityKey-outside&bn_r=o
 
         - name: Stripe

--- a/index.html
+++ b/index.html
@@ -58,6 +58,7 @@ hash: SupportTwoFactorAuth
                             <th>SMS</th>
                             <th>Google Auth</th>
                             <th>Authy</th>
+                            <th>VeriSign VIP</th>
                             <th class="two wide">Custom</th>
                         </tr>
                     </thead>
@@ -103,6 +104,16 @@ hash: SupportTwoFactorAuth
                             {% endif %}
 
                             {% if website.authy %}
+                                <td class="positive icon">
+                                    <i class="checkmark large icon"></i>
+                                </td>
+                            {% else %}
+                                <td class="negative icon">
+                                    <i class="remove large icon"></i>
+                                </td>
+                            {% endif %}
+
+                            {% if website.verisign %}
                                 <td class="positive icon">
                                     <i class="checkmark large icon"></i>
                                 </td>


### PR DESCRIPTION
Many prominent sites, including PayPal and name.com, support two factor
authentication using VeriSign's VIP Access system.

https://idprotect.vip.symantec.com/learnmore.v

I didn't test this at all, so let me know if it looks horrendous / if I can do anything to improve it.
