### PR TITLE
add chase sms auth

### DIFF
--- a/_data/main.yml
+++ b/_data/main.yml
@@ -192,7 +192,8 @@ sections:
           url: https://www.chase.com/
           twitter: chase
           img: chase.png
-          tfa: No
+          tfa: Yes
+          sms: Yes
 
         - name: Mint
           url: https://www.mint.com


### PR DESCRIPTION
Chase does require two factor authentication for adding new devices. I wasn't able to find documentation of the feature on Chase's online security guide, but here is a blog post about it: http://fppad.com/2011/11/29/boost-your-online-security-with-two-factor-authentication/. I can confirm that I need two factor authentication whenever accessing chase from a new device.
