### PR TITLE
"Custom" column should not appear negative

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -98,6 +98,19 @@ td img.icon {
     background-color: #f2dede !important;
 }
 
+.ui.table tr.neutral td,
+.ui.table td.neutral {
+    background-color: #ffffff !important;
+}
+
+.ui.celled.table tr.neutral:hover td,
+.ui.celled.table tr:hover td.neutral,
+.ui.table tr.neutral:hover td,
+.ui.table td:hover.neutral,
+.ui.table th:hover.neutral {
+    background-color: #ffffff !important;
+}
+
 @media only screen and (max-width: 1199px) {
   .ui.menu.desktop {
       display: block;

--- a/index.html
+++ b/index.html
@@ -129,8 +129,8 @@ hash: SupportTwoFactorAuth
                                 {% endfor %}
                                 </td>
                             {% else %}
-                                <td class="negative icon">
-                                    <i class="remove large icon"></i>
+                                <td class="neutral icon">
+                                    <i class="minus large icon"></i>
                                 </td>
                             {% endif %}
                         </tr>


### PR DESCRIPTION
*Adding neutral class.
*Custom column is now "neutral" with a minus icon instead of red with an 'x'

**Example:**
![neutral](http://content.screencast.com/users/max.peterson/folders/Jing/media/af567f77-73fe-4fe4-aec4-abe961e13dab/00001057.png)

fixes #25 
