### PR TITLE
Add Skype TFA support

### DIFF
--- a/_data/main.yml
+++ b/_data/main.yml
@@ -666,11 +666,15 @@ sections:
     icon: communication
 
     websites:
-        - name: Skype
+        - name: Skype (when linked to Microsoft Account)
           url: https://www.skype.com
           twitter: skype
           img: skype.png
-          tfa: No
+          tfa: Yes
+          sms: Yes
+          goog: Yes
+          authy: No
+          doc: http://windows.microsoft.com/en-au/windows/two-step-verification-faq
 
 #
 # SaaS


### PR DESCRIPTION
Skype usernames are being increasingly migrated to Microsoft Account based sign in instead. When using this newer authentication method, all of the Microsoft Account protections are used. (TOTP, SMS, recovery codes, single use passwords, app passwords, etc.)
