### PR TITLE
Rename Google Auth to something more accurate

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@ hash: SupportTwoFactorAuth
                             <th class="eleven wide"><h2>{{ section.title }}</h2></th>
                             <th>Docs</th>
                             <th>SMS</th>
-                            <th>Google Auth</th>
+                            <th><a href="http://en.wikipedia.org/wiki/Time-based_One-time_Password_Algorithm#Client_implementations">TOTP App</a></th>
                             <th>Authy</th>
                             <th class="two wide">Custom</th>
                         </tr>


### PR DESCRIPTION
Google Auth is a single, specific implementation, on a fixed number of platforms. Really, it's just an implementation of RFC6238 which other apps also support, like Microsoft's Authenticator: http://www.windowsphone.com/en-us/store/app/authenticator/e7994dbc-2336-4950-91ba-ca22d653759b
