### PR TITLE
eBay & PayPal support Verisign Identity Protection

### DIFF
--- a/_data/main.yml
+++ b/_data/main.yml
@@ -123,6 +123,11 @@ sections:
           tfa: Yes
           sms: Yes
           doc: https://www.paypal.com/cgi-bin/webscr?cmd=xpt/Marketing_CommandDriven/securitycenter/PayPalSecurityKey-outside
+          custom:
+            - icon: android
+              url: https://play.google.com/store/apps/details?id=com.verisign.mvip.main
+            - icon: apple
+              url: https://itunes.apple.com/app/vip-access-for-iphone/id307658513
 
         - name: Newegg
           url: http://www.newegg.com
@@ -323,6 +328,11 @@ sections:
           tfa: Yes
           sms: Yes
           doc: https://www.paypal.com/us/cgi-bin?cmd=xpt/Marketing_CommandDriven/securitycenter/PayPalSecurityKey-outside&bn_r=o
+          custom:
+            - icon: android
+              url: https://play.google.com/store/apps/details?id=com.verisign.mvip.main
+            - icon: apple
+              url: https://itunes.apple.com/app/vip-access-for-iphone/id307658513
 
         - name: Stripe
           img: stripe.png


### PR DESCRIPTION
PayPal (and, by extension, eBay), both support 2FA using the [Verisign Identity Protection](https://idprotect.verisign.com/mainmenu.v) app/token.

Admittedly, they could do a lot better in terms of documenting how to add it to your account. But the existing links in the repository point out that it is possible, I'm merely adding in the links present on the name.com entry (since they're the same app).
