### PR TITLE
Removing margin from the icons in the tables so that they are centered.

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -48,6 +48,10 @@ td.icon {
     text-align: center;
 }
 
+td i.icon{
+  margin: 0em 0em 0em 0em;
+}
+
 td span.progress {
     float: right;
 }


### PR DESCRIPTION
There is a .25em right margin on icons that appears to be used to separate them from text that is placed next to them.  I removed this from the icons in the tables so that they are centered in the column. 
