### PR TITLE
Paypal supports Verisign VIP Access

### DIFF
--- a/_data/payments.yml
+++ b/_data/payments.yml
@@ -10,7 +10,8 @@ websites:
       url: https://www.paypal.com/
       tfa: Yes
       sms: Yes
-      doc: https://www.paypal.com/us/cgi-bin?cmd=xpt/Marketing_CommandDriven/securitycenter/PayPalSecurityKey-outside&bn_r=o
+      verisign: Yes
+      doc: https://www.paypal.com/cgi-bin/webscr?cmd=xpt/Marketing_CommandDriven/securitycenter/PayPalSecurityKey-outside
 
     - name: Stripe
       img: stripe.png


### PR DESCRIPTION
Paypal supports VeriSign Identity Protection (VIP); it's not clear from the public documentation page, but here's what appears when you try to active 2FA: http://cl.ly/image/3g030A082F3r
I also simplified the link to the documentation; the previous one linked to a US-specific version, while this one should be generic.
