### PR TITLE
Reduces wording on thanks Twitter badge.

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@ layout: default
 link: Tell them to support 2FA
 tweet: Security is important, @TWITTERHANDLE. We'd like if you supported two factor auth.
 
-link_progress: Tell them thanks for working on 2FA
+link_progress: Thank them for working on 2FA
 tweet_progress: Thanks for working on support for two factor auth, @TWITTERHANDLE!
 hash: SupportTwoFactorAuth
 ---


### PR DESCRIPTION
Badge felt long compared to the “Tell them to support 2FA” badge, so perhaps this is a good compromise.
