### PR TITLE
Cloudflare doesn't support SMS-based 2FA

### DIFF
--- a/_data/domains.yml
+++ b/_data/domains.yml
@@ -3,7 +3,7 @@ websites:
       url: https://cloudflare.com
       img: cloudflare.png
       tfa: Yes
-      sms: Yes
+      sms: No
       authy: Yes
       doc: https://support.cloudflare.com/hc/en-us/articles/200167866-What-is-Authy-2-Factor-Authentication-
 


### PR DESCRIPTION
Their current implementation of Authy may use SMS to verify a phone
number, but actually logging in requires installation of the Authy app.
A 2FA login using only SMS without the Authy app is not possible at this
time.
