### PR TITLE
Remove Netflix and Hulu

### DIFF
--- a/_data/other.yml
+++ b/_data/other.yml
@@ -20,18 +20,6 @@ websites:
       authy: No
       doc: https://delightedapp.com/
 
-    - name: Netflix
-      img: netflix.png
-      url: http://www.netflix.com/
-      tfa: No
-      twitter: netflix
-
-    - name: Hulu
-      img: hulu.png
-      url: http://www.hulu.com
-      tfa: No
-      twitter: hulu
-
     - name: Status.io
       url: https://status.io/
       img: statusio.png


### PR DESCRIPTION
Wanted to start a discussion about what kind of sites should be added to the list. If an attacker gets into your Netflix or Hulu account, what can they really do? Mess up your queue of movies to watch?

I don't think we need to bother sites that don't actually have very sensitive information with implementing two factor.

If you agree feel free to merge this, if not that's totally fine.  @jdavis @mpdavis @zach-taylor 
