### PR TITLE
Ally Bank supports 2FA via SMS

### DIFF
--- a/_data/finance.yml
+++ b/_data/finance.yml
@@ -3,7 +3,9 @@ websites:
       url: http://www.ally.com/
       twitter: AllyBank
       img: allybank.png
-      tfa: No
+      tfa: Yes
+      sms: Yes
+      doc: https://www.ally.com/help/bank/login.html
 
     - name: American Express
       url: https://www.americanexpress.com/


### PR DESCRIPTION
They call them 'Security Codes' in the linked FAQ.
