### PR TITLE
fix USAA apple icon

### DIFF
--- a/_data/finance.yml
+++ b/_data/finance.yml
@@ -178,7 +178,7 @@ websites:
       custom:
         - icon: android
           url: https://play.google.com/store/apps/details?id=com.usaa.mobile.android.usaa&hl=en
-        - icon: iphone
+        - icon: apple
           url: https://itunes.apple.com/us/app/usaa-mobile/id312325565
         - icon: windows phone
           url: http://www.windowsphone.com/en-us/store/app/usaa/6d5694b8-d1d7-df11-a844-00237de2db9e


### PR DESCRIPTION
changing 'iphone' to 'apple' so that the apple logo will display for usaa.
