### PR TITLE
Dreamhost do support Authy

### DIFF
--- a/_data/domains.yml
+++ b/_data/domains.yml
@@ -53,7 +53,7 @@ websites:
       tfa: Yes
       sms: No
       goog: Yes
-      authy: No
+      authy: Yes
       doc: http://wiki.dreamhost.com/Enabling_Multifactor_Authentication
       custom:
           - icon: key


### PR DESCRIPTION
I am using Authy to deal with Dreamhost 2FA w/o a problem. Made the change to reflect that.
