### PR TITLE
Rework site to show the two-factor usage method

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,8 +6,8 @@ markdown: liquid
 title: Two Factor Auth List
 author: Josh Davis
 description:
-    List of sites with Two Factor Auth support which includes SMS, Google
-    Authenticator, and other methods.
+    List of sites with Two Factor Auth support which includes SMS, email,
+    phone calls, hardware, and software.
 url: http://twofactorauth.org
 repo: https://github.com/jdavis/twofactorauth
 img: img/logo.png

--- a/_data/backup.yml
+++ b/_data/backup.yml
@@ -17,7 +17,7 @@ websites:
     img: copy.png
     tfa: No
     twitter: copyapp
-    
+
   - name: CrashPlan
     url: http://www.crashplan.com
     img: crashplan.png
@@ -29,8 +29,7 @@ websites:
     url: https://www.dropbox.com
     tfa: Yes
     sms: Yes
-    goog: Yes
-    authy: Yes
+    software: Yes
     doc: https://www.dropbox.com/help/363/en
 
   - name: Evernote
@@ -38,29 +37,20 @@ websites:
     url: https://evernote.com
     tfa: Yes
     sms: Yes
-    goog: Yes
-    authy: Yes
+    software: Yes
     doc: http://blog.evernote.com/blog/2013/10/04/two-step-verification-available-to-all-users/
 
   - name: Frostbox
     url: http://frostbox.com
     img: frostbox.png
     tfa: Yes
-    sms: No
-    authy: No
-    goog: No
-    custom:
-      - icon: shield
-        url: "https://rublon.com/"
-      - icon: text file outline
-        url: "https://app.frostbox.com/main.php?action=2fa"
+    software: Yes
 
   - name: OneDrive
     img: onedrive.png
     url: https://www.onedrive.com
     tfa: Yes
-    goog: Yes
-    authy: Yes
+    software: Yes
     sms: Yes
     doc: http://windows.microsoft.com/en-us/windows/two-step-verification-faq
 
@@ -69,8 +59,6 @@ websites:
     url: https://spideroak.com
     tfa: Yes
     sms: Yes
-    goog: No
-    authy: No
     doc: https://spideroak.com/blog/20110620235134-2-factor-authentication-to-your-spideroak-account
 
   - name: SugarSync
@@ -83,7 +71,6 @@ websites:
     url: https://drive.google.com
     img: drive.png
     tfa: Yes
-    goog: Yes
-    authy: Yes
     sms: Yes
+    software: Yes
     doc: https://support.google.com/accounts/answer/180744?hl=en

--- a/_data/bitcoin.yml
+++ b/_data/bitcoin.yml
@@ -4,7 +4,7 @@ websites:
       url: https://bips.me/
       tfa: Yes
       sms: No
-      email: Yes
+      software: Yes
       doc: https://bips.me/security
 
     - name: Bitstamp
@@ -21,6 +21,7 @@ websites:
       tfa: Yes
       sms: Yes
       software: Yes
+      hardware: Yes
       doc: https://blockchain.info/wallet/support-pages
 
     - name: Coinbase

--- a/_data/bitcoin.yml
+++ b/_data/bitcoin.yml
@@ -4,20 +4,15 @@ websites:
       url: https://bips.me/
       tfa: Yes
       sms: No
-      goog: Yes
-      authy: No
+      email: Yes
       doc: https://bips.me/security
-      custom:
-          - icon: key
-            url: https://bips.me/security
 
     - name: Bitstamp
       img: bitstamp.png
       url: https://bitstamp.net
       tfa: Yes
       sms: No
-      goog: Yes
-      authy: Yes
+      software: Yes
       doc: https://www.bitstamp.net/s/documents/bitstamp_2_factor_authentication_guide.pdf
 
     - name: Blockchain
@@ -25,19 +20,15 @@ websites:
       url: https://blockchain.info/
       tfa: Yes
       sms: Yes
-      goog: Yes
+      software: Yes
       doc: https://blockchain.info/wallet/support-pages
-      custom:
-          - icon: key
-            url: https://blockchain.info/wallet/yubikey
 
     - name: Coinbase
       url: https://coinbase.com/
       img: coinbase.png
       tfa: Yes
       sms: Yes
-      goog: Yes
-      authy: Yes
+      software: Yes
       doc: http://blog.coinbase.com/post/25677574019/coinbase-now-offers-two-factor-authentication
 
     - name: Cryptsy
@@ -45,8 +36,7 @@ websites:
       img: cryptsy.png
       tfa: Yes
       sms: No
-      goog: Yes
-      authy: Yes
+      software: Yes
       doc: https://www.cryptsy.com/pages/security
 
     - name: LocalBitcoins
@@ -54,8 +44,7 @@ websites:
       img: localbitcoins.png
       tfa: Yes
       sms: No
-      goog: Yes
-      authy: No
+      software: Yes
       doc: http://localbitcoins.blogspot.fi/2013/05/using-two-factor-authentication-on.html
 
     - name: Justcoin Exchange
@@ -63,8 +52,7 @@ websites:
       img: justcoinexchange.png
       tfa: Yes
       sms: No
-      goog: Yes
-      authy: No
+      software: Yes
       doc: https://twitter.com/jstcoin/status/445900548743897088
 
     - name: WeMineLTC.com
@@ -72,6 +60,5 @@ websites:
       img: wemineltc.png
       tfa: Yes
       sms: No
-      goog: Yes
-      authy: No
+      software: Yes
       doc: https://twitter.com/jstcoin/status/445900548743897088

--- a/_data/communication.yml
+++ b/_data/communication.yml
@@ -5,6 +5,5 @@ websites:
       img: skype.png
       tfa: Yes
       sms: Yes
-      goog: Yes
-      authy: No
+      software: Yes
       doc: http://windows.microsoft.com/en-au/windows/two-step-verification-faq

--- a/_data/developer.yml
+++ b/_data/developer.yml
@@ -3,21 +3,15 @@ websites:
       img: aws.png
       url: https://aws.amazon.com
       tfa: Yes
-      goog: Yes
-      authy: Yes
+      software: Yes
       sms: Yes
       doc: http://aws.amazon.com/iam/details/mfa/
-      custom:
-          - icon: android
-            url: http://www.amazon.com/gp/product/B0061MU68M
-          - icon: windows
-            url: http://www.windowsphone.com/en-us/store/app/authenticator/021dd79f-0598-e011-986b-78e7d1fa76f8
 
     - name: MaxCDN
       url: https://www.maxcdn.com
       img: maxcdn.png
       tfa: Yes
-      goog: Yes
+      software: Yes
       doc: http://support.maxcdn.com/tutorials/enabling-2-step-verification/
 
     - name: Bitbucket
@@ -31,15 +25,14 @@ websites:
       url: https://www.digitalocean.com/
       img: digitalocean.png
       tfa: Yes
-      goog: Yes
+      software: Yes
       doc: https://www.digitalocean.com/company/blog/introducing-two-factor-authentication/
 
     - name: GitHub
       img: github.png
       url: https://github.com
       tfa: Yes
-      goog: Yes
-      authy: Yes
+      software: Yes
       sms: Yes
       doc: https://help.github.com/articles/about-two-factor-authentication
 
@@ -54,9 +47,7 @@ websites:
       img: linode.png
       twitter: linode
       tfa: Yes
-      goog: Yes
-      sms: No
-      authy: Yes
+      software: Yes
       doc: https://library.linode.com/linode-manager-security#sph_two-factor-authentication
 
     - name: NearlyFreeSpeech.NET
@@ -64,9 +55,8 @@ websites:
       img: nfsn.png
       twitter: nfsn
       tfa: Yes
-      goog: Yes
+      software: Yes
       sms: Yes
-      authy: No
       doc: https://blog.nearlyfreespeech.net/2014/02/28/price-cuts-more-se
 
     - name: Rackspace
@@ -79,17 +69,16 @@ websites:
       url: http://www.scalr.com
       img: scalr.png
       tfa: Yes
-      goog: Yes
+      software: Yes
       sms: No
-      authy: No
+      phone: No
       doc: https://scalr-wiki.atlassian.net/wiki/display/docs/Two-Factor+Authentication
 
     - name: Google Cloud Platform
       url: https://cloud.google.com
       img: google-cloud.png
       tfa: Yes
-      goog: Yes
-      authy: Yes
+      software: Yes
       sms: Yes
       doc: https://support.google.com/accounts/answer/180744?hl=en
 

--- a/_data/domains.yml
+++ b/_data/domains.yml
@@ -40,6 +40,7 @@ websites:
       img: dreamhost.png
       tfa: Yes
       software: Yes
+      hardware: Yes
       doc: http://wiki.dreamhost.com/Enabling_Multifactor_Authentication
 
     - name: easyDNS

--- a/_data/domains.yml
+++ b/_data/domains.yml
@@ -4,59 +4,49 @@ websites:
       img: cloudflare.png
       tfa: Yes
       sms: Yes
-      authy: Yes
+      software: Yes
       doc: https://support.cloudflare.com/hc/en-us/articles/200167866-What-is-Authy-2-Factor-Authentication-
 
     - name: Directnic
       url: https://directnic.com
       img: directnic.png
       tfa: Yes
-      sms: No
-      authy: No
-      goog: Yes
+      software: Yes
       doc: https://directnic.com/knowledge/article/137:how+do+i+set+up+two-factor+authentication%3F
+
+    - name: DNS Made Easy
+      url: http://www.dnsmadeeasy.com
+      img: dnsmadeeasy.png
+      tfa: Yes
+      software: Yes
+      doc: http://www.dnsmadeeasy.com/press-release/dns-made-easy-adds-two-factor-authentication-with-time-based-passwords/
 
     - name: DNSimple
       url: https://dnsimple.com/
       img: dnsimple.png
       tfa: Yes
-      sms: No
-      authy: Yes
-      goog: No
+      software: Yes
       doc: http://blog.dnsimple.com/2012/08/protect-your-dnsimple-account-with-two-factor-authentication-from-authy/
 
     - name: Domeny.tv
       url: http://www.domeny.tv/en
       img: domenytv.png
       tfa: Yes
-      sms: No
-      authy: No
-      goog: No
-      custom:
-          - icon: shield
-            url: "https://rublon.com/"
-          - icon: text file outline
-            url: "http://www.domeny.tv/en/two-factor-authentication"
+      software: Yes
+      doc: http://www.domeny.tv/en/two-factor-authentication
 
     - name: Dreamhost
       url: https://dreamhost.com
       img: dreamhost.png
       tfa: Yes
-      sms: No
-      goog: Yes
-      authy: No
+      software: Yes
       doc: http://wiki.dreamhost.com/Enabling_Multifactor_Authentication
-      custom:
-          - icon: key
-            url: "http://wiki.dreamhost.com/Enabling_Multifactor_Authentication#Getting_A_YubiKey"
 
     - name: easyDNS
       url: https://easydns.com
       img: easydns.png
       tfa: Yes
       sms: Yes
-      goog: No
-      authy: No
       doc: http://docs.easydns.com/2-factor-authentication/
 
     - name: Gandi
@@ -64,8 +54,7 @@ websites:
       img: gandi.png
       tfa: Yes
       sms: No
-      authy: Yes
-      goog: Yes
+      software: Yes
       doc: https://wiki.gandi.net/en/contacts/login/2-factor-activation
 
     - name: GoDaddy
@@ -80,19 +69,15 @@ websites:
       url: http://www.hover.com/
       tfa: Yes
       sms: Yes
-      goog: Yes
+      software: Yes
       doc: https://help.hover.com/entries/26677644
 
     - name: Name.com
       url: http://www.name.com/
       img: namecom.png
       tfa: Yes
+      software: Yes
       doc: https://www.name.com/services/namesafe
-      custom:
-        - icon: android
-          url: https://play.google.com/store/apps/details?id=com.verisign.mvip.main
-        - icon: apple
-          url: https://itunes.apple.com/app/vip-access-for-iphone/id307658513
 
     - name: Namecheap
       img: namecheap.png
@@ -106,14 +91,13 @@ websites:
       twitter: netsolcares
       img: networksolutions.png
       tfa: No
-      sms: No
 
     - name: iWantMyName
       url: https://iwantmyname.com/
       img: iwantmyname.png
       twitter: iWantMyName
-      tfa: yes
-      authy: yes
+      tfa: Yes
+      software: Yes
       doc: http://help.iwantmyname.com/customer/portal/articles/1139898
 
     - name: Loopia

--- a/_data/email.yml
+++ b/_data/email.yml
@@ -3,7 +3,7 @@ websites:
       url: https://www.fastmail.fm/
       img: fastmail.png
       tfa: Yes
-      sms: No
+      sms: Yes
       software: Yes
       doc: https://www.fastmail.fm/help/features_alternative_logins.html
 

--- a/_data/email.yml
+++ b/_data/email.yml
@@ -3,40 +3,31 @@ websites:
       url: https://www.fastmail.fm/
       img: fastmail.png
       tfa: Yes
-      goog: Yes
-      sms: Yes
+      sms: No
+      software: Yes
       doc: https://www.fastmail.fm/help/features_alternative_logins.html
-      custom:
-          - icon: key
-            url: https://www.fastmail.fm/help/login_yubikey.html
-          - icon: text file outline
-            url: https://www.fastmail.fm/help/features_alternative_logins.html#idp2602704
 
     - name: Gmail
       url: https://gmail.com
       img: gmail.png
       tfa: Yes
-      goog: Yes
-      authy: Yes
       sms: Yes
+      software: Yes
       doc: https://support.google.com/accounts/answer/180744?hl=en
 
     - name: Outlook.com
       url: https://outlook.com
       img: outlook.png
       tfa: Yes
-      goog: Yes
-      authy: Yes
       sms: Yes
+      software: Yes
       doc: http://windows.microsoft.com/en-us/windows/two-step-verification-faq
 
     - name: Pobox
       url: https://www.pobox.com/
       img: pobox.png
       tfa: Yes
-      goog: Yes
-      authy: Yes
-      sms: No
+      software: Yes
       doc: https://pobox.com/helpspot/index.php?pg=kb.chapter&id=65
 
     - name: Yahoo Mail
@@ -50,7 +41,6 @@ websites:
       url: https://www.zoho.com/mail/
       img: zoho.png
       tfa: Yes
-      goog: Yes
-      authy: No
       sms: Yes
+      software: Yes
       doc: https://adminconsole.wiki.zoho.com/mail/Two-Factor-Authentication.html

--- a/_data/finance.yml
+++ b/_data/finance.yml
@@ -47,6 +47,7 @@ websites:
       twitter: etrade
       tfa: Yes
       hardware: Yes
+      software: Yes
       doc: https://us.etrade.com/e/t/estation/pricing?id=1220801000
 
     - name: Fidelity Investments

--- a/_data/finance.yml
+++ b/_data/finance.yml
@@ -16,10 +16,9 @@ websites:
       img: bankofamerica.png
       tfa: Yes
       sms: Yes
+      hardware: Yes
+      software: Yes
       doc: https://www.bankofamerica.com/privacy/online-mobile-banking-privacy/safepass.go
-      custom:
-        - icon: key
-          url: https://www.bankofamerica.com/privacy/faq/safepass-faq.go
 
     - name: CapitalOne 360
       url: https://home.capitalone360.com/
@@ -31,10 +30,8 @@ websites:
       img: charlesschwab.png
       url: https://www.schwab.com/
       tfa: Yes
+      hardware: Yes
       doc: http://www.schwab.com/public/schwab/nn/legal_compliance/schwabsafe/protect_your_account
-      custom:
-        - icon: key
-          url: http://www.schwab.com/public/schwab/nn/legal_compliance/schwabsafe/protect_your_account
 
     - name: Chase
       url: https://www.chase.com/
@@ -42,26 +39,22 @@ websites:
       img: chase.png
       tfa: Yes
       sms: Yes
+      phone: Yes
 
     - name: E*Trade
       img: etrade.png
       url: https://www.etrade.com/
       twitter: etrade
       tfa: Yes
-      sms: No
-      goog: No
-      authy: No
+      hardware: Yes
       doc: https://us.etrade.com/e/t/estation/pricing?id=1220801000
-      custom:
-        - icon: key
-          url: https://us.etrade.com/e/t/estation/pricing?id=1220801000
 
     - name: Fidelity Investments
       url: https://www.fidelity.com
       twitter: fidelity
       img: fidelity.png
       tfa: No
-      
+
     - name: Mint
       url: https://www.mint.com
       twitter: mint
@@ -73,9 +66,7 @@ websites:
       url: http://www.seb.se/pow/default.asp
       tfa: Yes
       doc: http://www.seb.se/pow/wcp/index.asp?ss=/pow/wcp/templates/sebcollection.cfmc.asp%3FDUID%3DDUID_623697DCF55C4576C1256DEF00637BE3
-      custom:
-        - icon: key
-          url: http://www.seb.se/pow/wcp/index.asp?ss=/pow/wcp/templates/sebcollection.cfmc.asp%3FDUID%3DDUID_623697DCF55C4576C1256DEF00637BE3
+      hardware: Yes
 
     - name: Simple
       url: https://www.simple.com/
@@ -107,27 +98,23 @@ websites:
       url: https://www.optionshouse.com
       doc: http://www.optionshouse.com/faq/authenticator/
       tfa: Yes
-      custom:
-          - icon: android
-            url: https://play.google.com/store/apps/details?id=com.peak6.oh.authenticator
-          - icon: apple
-            url: https://itunes.apple.com/us/app/optionshouse-authenticator/id604114246?mt=8
+      software: Yes
 
     - name: Discover
       url: https://www.discover.com/
       twitter: Discover
       img: discover.png
-      tfa: yes
-      sms: yes
+      tfa: Yes
+      sms: Yes
+      email: Yes
+      phone: Yes
       doc: https://www.discover.com/credit-cards/help-center/faqs/enhancing-account-security.html
-      custom:
-        - icon: mail
 
     - name: Citibank
       url: https://online.citibank.com/US/Welcome.c
       twitter: Citibank
       img: citibank.png
-      tfa: no
+      tfa: No
 
     - name: US Bank
       url: https://www.usbank.com/

--- a/_data/gaming.yml
+++ b/_data/gaming.yml
@@ -4,16 +4,9 @@ websites:
       url: http://blizzard.com
       tfa: Yes
       sms: Yes
+      hardware: Yes
+      software: Yes
       doc: http://us.battle.net/en/security/
-      custom:
-          - icon: android
-            url: https://market.android.com/details?id=com.blizzard.bma
-          - icon: apple
-            url: https://itunes.apple.com/app/battle.net-mobile-authenticator/id306862897
-          - icon: windows
-            url: http://www.windowsphone.com/en-us/store/app/battle-net-authenticator/1347bbfb-bca2-e011-986b-78e7d1fa76f8?type=phoneapp&id=1347bbfb-bca2-e011-986b-78e7d1fa76f8
-          - icon: mobile
-            url: http://appworld.blackberry.com/webstore/content/13011/?countrycode=US&lang=en
 
     - name: GOG.com
       url: http://www.gog.com
@@ -25,18 +18,14 @@ websites:
       img: guild_wars_2.png
       url: https://www.guildwars2.com
       tfa: Yes
-      goog: Yes
-      authy: Yes
+      software: Yes
       doc: https://help.guildwars2.com/entries/27626157-Two-Factor-Authentication
-      custom:
-          - icon: mail
 
     - name: Humble Bundle
       img: humble.png
       url: https://www.humblebundle.com/
       tfa: Yes
-      goog: No
-      authy: Yes
+      software: Yes
       sms: Yes
       doc: http://support.humblebundle.com/customer/portal/articles/1412106
 
@@ -51,17 +40,15 @@ websites:
       twitter: OriginInsider
       img: origin.png
       tfa: Yes
+      email: Yes
       doc: http://help.ea.com/en/article/origin-login-verification-information/
-      custom:
-          - icon: mail
 
     - name: Steam
       img: steam.png
       url: http://store.steampowered.com/
       tfa: Yes
+      email: Yes
       doc: https://support.steampowered.com/kb_article.php?ref=4020-ALZM-5519
-      custom:
-          - icon: mail
 
     - name: Uplay
       url: http://uplay.ubi.com/

--- a/_data/health.yml
+++ b/_data/health.yml
@@ -14,8 +14,7 @@ websites:
       url: https://www.drchrono.com
       tfa: Yes
       sms: No
-      goog: No
-      authy: Yes
+      software: Yes
       doc: https://www.drchrono.com/blog/two-factor-authentication-extra-security-for-your-health-records/
 
     - name: Drugs.com

--- a/_data/other.yml
+++ b/_data/other.yml
@@ -4,19 +4,12 @@ websites:
       img: automater.png
       tfa: Yes
       sms: No
-      authy: No
-      goog: No
-      custom:
-        - icon: shield
-          url: "https://rublon.com/"
-        - icon: play
-          url: "http://www.youtube.com/watch?v=5OLcvjVhhuI"
+      software: Yes
+      doc: http://www.youtube.com/watch?v=5OLcvjVhhuI
 
     - name: Delighted
       img: delighted.png
       url: https://delightedapp.com/
       tfa: Yes
       sms: Yes
-      goog: No
-      authy: No
       doc: https://delightedapp.com/

--- a/_data/payments.yml
+++ b/_data/payments.yml
@@ -10,22 +10,20 @@ websites:
       url: https://www.paypal.com/
       tfa: Yes
       sms: Yes
+      hardware: Yes
       doc: https://www.paypal.com/us/cgi-bin?cmd=xpt/Marketing_CommandDriven/securitycenter/PayPalSecurityKey-outside&bn_r=o
 
     - name: Stripe
       img: stripe.png
       url: https://www.stripe.com/
       tfa: Yes
-      goog: Yes
-      authy: Yes
-      sms: No
+      software: Yes
       doc: https://stripe.com/blog/two-step-verification
 
     - name: Google Wallet
       url: http://www.google.se/wallet/
       img: google-wallet.png
       tfa: Yes
-      goog: Yes
-      authy: Yes
+      software: Yes
       sms: Yes
       doc: https://support.google.com/accounts/answer/180744?hl=en

--- a/_data/retail.yml
+++ b/_data/retail.yml
@@ -24,6 +24,7 @@ websites:
       img: ebay.png
       tfa: Yes
       sms: Yes
+      hardware: Yes
       doc: https://www.paypal.com/cgi-bin/webscr?cmd=xpt/Marketing_CommandDriven/securitycenter/PayPalSecurityKey-outside
 
     - name: Newegg
@@ -37,7 +38,5 @@ websites:
       img: apple.png
       tfa: Yes
       sms: Yes
+      software: Yes
       doc: http://support.apple.com/kb/ht5570
-      custom:
-        - icon: apple
-          url: https://www.apple.com/ios/

--- a/_data/social.yml
+++ b/_data/social.yml
@@ -3,9 +3,7 @@ websites:
       url: https://join.app.net
       img: app.net.png
       tfa: Yes
-      goog: Yes
-      authy: Yes
-      sms: No
+      software: Yes
       doc: https://mml.desk.com/customer/portal/articles/1039728-how-do-i-set-up-two-factor-authentication-
 
     - name: Buffer
@@ -13,29 +11,22 @@ websites:
       img: bufferapp.png
       tfa: Yes
       sms: Yes
-      goog: Yes
+      software: Yes
       doc: http://blog.bufferapp.com/introducing-the-safest-social-media-publishing-on-the-web
 
     - name: Facebook
       url: https://facebook.com
       img: facebook.png
       tfa: Yes
-      goog: Yes
-      authy: Yes
+      software: Yes
       sms: Yes
       doc: https://www.facebook.com/help/148233965247823
-      custom:
-          - icon: android
-            url: https://play.google.com/store/apps/details?id=com.facebook.katana
-          - icon: apple
-            url: http://itunes.apple.com/app/facebook/id284882215
 
     - name: Google+
       url: https://plus.google.com
       img: g+.png
       tfa: Yes
-      goog: Yes
-      authy: Yes
+      software: Yes
       sms: Yes
       doc: https://support.google.com/accounts/answer/180744?hl=en
 
@@ -43,7 +34,7 @@ websites:
       url: https://hootsuite.com
       img: hootsuite.png
       tfa: Yes
-      goog: Yes
+      software: Yes
       doc: https://help.hootsuite.com/entries/22527304-Managing-Google-Authenticator
 
     - name: LinkedIn
@@ -58,18 +49,13 @@ websites:
       img: twitter.png
       tfa: Yes
       sms: Yes
-      custom:
-          - icon: android
-            url: https://play.google.com/store/apps/details?id=com.twitter.android
-          - icon: apple
-            url: https://itunes.apple.com/us/app/twitter/id333903271
+      software: Yes
       doc: https://support.twitter.com/articles/20170388
 
     - name: WordPress.com
       url: https://wordpress.com
       img: wordpress.png
       tfa: Yes
-      goog: Yes
-      authy: Yes
+      software: Yes
       sms: Yes
       doc: http://en.support.wordpress.com/security/two-step-authentication/

--- a/index.html
+++ b/index.html
@@ -94,65 +94,51 @@ hash: SupportTwoFactorAuth
                                                 <a href="{{ website.url }}">{{ website.name }}</a>
                                             </td>
 
+                                            <td class="positive icon">
                                             {% if website.doc %}
-                                                <td class="positive icon">
-                                                    <a href="{{ website.doc }}">
-                                                        <i class="external url link icon"></i>
-                                                    </a>
-                                                </td>
-                                            {% else %}
-                                                <td class="positive icon"></td>
+                                                <a href="{{ website.doc }}"><i class="external url link large icon"></i></a>
                                             {% endif %}
+                                            </td>
 
+                                            <td class="positive icon">
                                             {% if website.sms %}
-                                                <td class="positive icon">
-                                                    <i class="checkmark large icon"></i>
-                                                </td>
+                                                <i class="checked checkbox large icon"></i>
                                             {% else %}
-                                                <td class="negative icon">
-                                                    <i class="remove large icon"></i>
-                                                </td>
+                                                <i class="empty checkbox large icon"></i>
                                             {% endif %}
+                                            </td>
 
+                                            <td class="positive icon">
                                             {% if website.phone %}
-                                                <td class="positive icon">
-                                                    <i class="checkmark large icon"></i>
-                                                </td>
+                                                <i class="checked checkbox large icon"></i>
                                             {% else %}
-                                                <td class="negative icon">
-                                                    <i class="remove large icon"></i>
-                                                </td>
+                                                <i class="empty checkbox large icon"></i>
                                             {% endif %}
+                                            </td>
 
+                                            <td class="positive icon">
                                             {% if website.email %}
-                                                <td class="positive icon">
-                                                    <i class="checkmark large icon"></i>
-                                                </td>
+                                                <i class="checked checkbox large icon"></i>
                                             {% else %}
-                                                <td class="negative icon">
-                                                    <i class="remove large icon"></i>
-                                                </td>
+                                                <i class="empty checkbox large icon"></i>
                                             {% endif %}
+                                            </td>
 
+                                            <td class="positive icon">
                                             {% if website.hardware %}
-                                                <td class="positive icon">
-                                                    <i class="checkmark large icon"></i>
-                                                </td>
+                                                <i class="checked checkbox large icon"></i>
                                             {% else %}
-                                                <td class="negative icon">
-                                                    <i class="remove large icon"></i>
-                                                </td>
+                                                <i class="empty checkbox large icon"></i>
                                             {% endif %}
+                                            </td>
 
+                                            <td class="positive icon">
                                             {% if website.software %}
-                                                <td class="positive icon">
-                                                    <i class="checkmark large icon"></i>
-                                                </td>
+                                                <i class="checked checkbox large icon"></i>
                                             {% else %}
-                                                <td class="negative icon">
-                                                    <i class="remove large icon"></i>
-                                                </td>
+                                                <i class="empty checkbox large icon"></i>
                                             {% endif %}
+                                            </td>
                                         </tr>
                                         {% else %}
                                             <td class="main negative">

--- a/index.html
+++ b/index.html
@@ -61,10 +61,10 @@ hash: SupportTwoFactorAuth
                             <th class="eleven wide"><h2>{{ section.title }}</h2></th>
                             <th>Docs</th>
                             <th>SMS</th>
-                            <th>Google Auth</th>
-                            <th>Authy</th>
-                            <th>VeriSign VIP</th>
-                            <th class="two wide">Custom</th>
+                            <th>Phone Call</th>
+                            <th>Email</th>
+                            <th>Hardware Token</th>
+                            <th>Software Implementation</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -114,7 +114,7 @@ hash: SupportTwoFactorAuth
                                                 </td>
                                             {% endif %}
 
-                                            {% if website.goog %}
+                                            {% if website.phone %}
                                                 <td class="positive icon">
                                                     <i class="checkmark large icon"></i>
                                                 </td>
@@ -124,7 +124,7 @@ hash: SupportTwoFactorAuth
                                                 </td>
                                             {% endif %}
 
-                                            {% if website.authy %}
+                                            {% if website.email %}
                                                 <td class="positive icon">
                                                     <i class="checkmark large icon"></i>
                                                 </td>
@@ -134,7 +134,7 @@ hash: SupportTwoFactorAuth
                                                 </td>
                                             {% endif %}
 
-                                            {% if website.verisign %}
+                                            {% if website.hardware %}
                                                 <td class="positive icon">
                                                     <i class="checkmark large icon"></i>
                                                 </td>
@@ -144,19 +144,13 @@ hash: SupportTwoFactorAuth
                                                 </td>
                                             {% endif %}
 
-                                            {% if website.custom %}
+                                            {% if website.software %}
                                                 <td class="positive icon">
-                                                {% for item in website.custom %}
-                                                    {% if item.url %}
-                                                        <a href="{{ item.url }}"><i class="{{ item.icon }} link small icon"></i></a>
-                                                    {% else %}
-                                                        <i class="{{ item.icon }} small icon"></i>
-                                                    {% endif %}
-                                                {% endfor %}
+                                                    <i class="checkmark large icon"></i>
                                                 </td>
                                             {% else %}
-                                                <td class="disabled icon">
-                                                    <i class="minus large icon"></i>
+                                                <td class="negative icon">
+                                                    <i class="remove large icon"></i>
                                                 </td>
                                             {% endif %}
                                         </tr>


### PR DESCRIPTION
This pull request changes the columns from 

```
Site | Docs | SMS | Google Auth | Authy | VeriSign VIP | Custom
```

to

```
Site | Docs | SMS | Phone Call | Email | Hardware Token | Software Implementation
```

![Imgur](http://i.imgur.com/F6Kj0n7.png)

See [PR #320](https://github.com/jdavis/twofactorauth/issues/320) and [PR #208](https://github.com/jdavis/twofactorauth/issues/208) for more context about these changes.

I updated every `.yaml` file; anywhere there was a `Yes` for `authy` or `goog` or `verisign` there should now simply be `software: Yes`. For `custom` entries I added the appropriate `hardware` or `software` entry. I visited every `doc` link and tried to capture the data, but I welcome the community to fix anything I missed. I also removed stray white space and capitalized `Yes` and `No` where appropriate.

I think it turned out well.

---

Now that I've done all this work, I have a new idea that might be cleaner:

```
Site | Docs | Implementation
```

We then place the appropriate icons for each of the five categories. Perhaps

```
SMS: mobile icon
Phone Call: phone icon
Email: mail icon
Hardware Token: lock icon
Software Implementation: shield icon
```

Here's what that might look like:

![Imgur](http://i.imgur.com/RH6UwAy.png)

See PR #334 for the code.
