### PR TITLE
Tumblr now supports 2FA

### DIFF
--- a/_data/social.yml
+++ b/_data/social.yml
@@ -84,4 +84,7 @@ websites:
       url: https://www.tumblr.com/
       twitter: tumblr
       img: tumblr.png
-      tfa: No
+      tfa: Yes
+      goog: Yes
+      sms: Yes
+      doc: https://www.tumblr.com/docs/en/two_factor_auth


### PR DESCRIPTION
Tumblr announced today that they now support two factor auth via SMS and Google Authenticator. (http://staff.tumblr.com/post/80583764030)
