### PR TITLE
tumblr works with authy as well

### DIFF
--- a/_data/social.yml
+++ b/_data/social.yml
@@ -87,5 +87,6 @@ websites:
       img: tumblr.png
       tfa: Yes
       goog: Yes
+      authy: Yes
       sms: Yes
       doc: https://www.tumblr.com/docs/en/two_factor_auth


### PR DESCRIPTION
Tumblr's two factor authentication works well with authy as well.  It was missing from the original pull request.
