### PR TITLE
Fidelity now supports two factor authentication

### DIFF
--- a/_data/finance.yml
+++ b/_data/finance.yml
@@ -121,7 +121,10 @@ websites:
       url: https://www.fidelity.com
       twitter: fidelity
       img: fidelity.png
-      tfa: No
+      tfa: Yes
+      hardware: Yes
+      phone: Yes
+      doc: "http://thefinancebuff.com/security-token-fidelity-schwab-etrade.html"
 
     - name: GE Capital Bank
       url: https://www.gecapitalbank.com


### PR DESCRIPTION
Fidelity doesn’t advertise security tokens on its website, but if you call customer service, they will tell you how to do it.
