### PR TITLE
Updating Duo Security entry

### DIFF
--- a/_data/providers.yml
+++ b/_data/providers.yml
@@ -12,8 +12,8 @@ providers:
     software: Yes
     hardware: Yes
 
-  - name: Duo
-    url: https://duosecurity.com
+  - name: Duo Security
+    url: https://www.duosecurity.com
     img: duo.png
     hardware: Yes
     phone: Yes


### PR DESCRIPTION
Just a quick edit to list our formal name, "Duo Security" rather than the existing shorthand, "Duo". Also, URL pedantry.
