### PR TITLE
Add JetBrains IDE service files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 _site/
 *.DS_Store
+.idea/


### PR DESCRIPTION
It covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, WebStorm
