### PR TITLE
CapitalOne360: Add notice about ability to view sensitive personal information

### DIFF
--- a/_data/banking.yml
+++ b/_data/banking.yml
@@ -45,6 +45,7 @@ websites:
       twitter: CapitalOne
       img: capitalone.png
       tfa: No
+      doc: http://twofactorauth.org/notes/capitalone360/
 
     - name: Capital One 360
       url: https://home.capitalone360.com/

--- a/_data/banking.yml
+++ b/_data/banking.yml
@@ -45,13 +45,13 @@ websites:
       twitter: CapitalOne
       img: capitalone.png
       tfa: No
-      doc: http://twofactorauth.org/notes/capitalone360/
 
     - name: Capital One 360
       url: https://home.capitalone360.com/
       twitter: CapitalOne360
       img: capitalone360.png
       tfa: No
+      doc: http://twofactorauth.org/notes/capitalone360/
 
     - name: Chase
       url: https://www.chase.com/

--- a/notes/capitalone360.html
+++ b/notes/capitalone360.html
@@ -1,0 +1,80 @@
+---
+layout: default
+---
+
+<div class="ui fixed transparent inverted teal main menu">
+    <div class="menu">
+        <div class="right menu">
+            <a href="{{ site.repo }}" class="item">
+                <i class="github icon"></i>
+                Contribute
+            </a>
+        </div>
+
+        <a href="/" class="item">
+            <i class="home icon"></i>
+            Home
+        </a>
+
+        <a href="/providers" class="item">
+            <i class="play sign icon"></i>
+            Providers
+        </a>
+    </div>
+</div>
+
+<div class="main container">
+    <div class="ui grid">
+        <div class="column">
+            <div class="banner ui icon header">
+                <i class="circular mobile icon"></i>
+                <h2>Security Notes</h2>
+            </div>
+            <div class="ui segment teal">
+                <h2 class="ui header">
+                    Capital One 360
+                    <div class="sub header">
+                        Information regarding Capital One 360 security.
+                    </div>
+                </h2>
+                <p>
+                    Capital One 360 protects accounts with self-selected
+                    6-10 digit PIN.  PINs provide less protection than a
+                    password or pass-phrase. This is especially notable
+                    in the absence of two-factor authentication.
+                </p>
+
+                <p>
+                    Once a user is logged in they can create a new account.
+                    The web page for new accounts includes a fully populated
+                    form with personal information that includes name, address,
+                    phone number, date of birth, and social security number.
+                </p>
+
+                <div class="ui info message">
+                    <div class="header">
+                        Note on security after account closure
+                    </div>
+                    <p>
+                        Even after a user closes all of their banking
+                        accounts, their login will remain active.  The login
+                        can not be deactivated by Capital One 360 support.
+                        If the PIN for the closed account is ever compromised
+                        the attacker will have access to personally identifying
+                        information including the user's social security
+                        number through the new account creation process
+                        outlined above.
+                    </p>
+
+                    <p>
+                        Unfortunately, the social security number and other
+                        information surfaced during account creation can
+                        not be changed to invalid values by a user and
+                        customer support is unable to change them as well.
+                    </p>
+                </div>
+            </div><!-- Section -->
+
+        </div><!-- Column -->
+    </div><!-- UI Grid -->
+</div><!-- Main Container -->


### PR DESCRIPTION
Capital One 360 accounts are secured by a 6-10 digit, self-selected PIN.  Accounts can not be fully closed / locked.  Access to the account leaks sensitive personal information (SPI) through the process of opening a new sub-account including SSN.  This information can not be removed or locked down.  These issues have been added to notes for this banking service.
