### PR TITLE
Namecheap: Added Yes to Phone support

### DIFF
--- a/_data/domains.yml
+++ b/_data/domains.yml
@@ -140,6 +140,7 @@ websites:
       img: namecheap.png
       tfa: Yes
       sms: Yes
+      phone: Yes
       doc: https://www.namecheap.com/support/knowledgebase/article.aspx/9253/45/how-to-two-factor-authentication
 
     - name: NameSilo.com


### PR DESCRIPTION
Phone support indicated on the same documentation link already provided: https://www.namecheap.com/support/knowledgebase/article.aspx/9253/45/how-to-two-factor-authentication
