### PR TITLE
Update Keeper doc link

### DIFF
--- a/_data/identity.yml
+++ b/_data/identity.yml
@@ -27,7 +27,7 @@ websites:
       software: Yes
       phone: Yes
       sms: Yes
-      docs: https://keepersecurity.com/support/faq#faq35622
+      docs: https://www.keepersecurity.com/security#twoFactor
 
     - name: LastPass
       url: https://lastpass.com/

--- a/_data/identity.yml
+++ b/_data/identity.yml
@@ -27,7 +27,7 @@ websites:
       software: Yes
       phone: Yes
       sms: Yes
-      docs: https://www.keepersecurity.com/security#twoFactor
+      doc: https://www.keepersecurity.com/security#twoFactor
 
     - name: LastPass
       url: https://lastpass.com/


### PR DESCRIPTION
Should be "doc" instead of "docs"

The old link only took me to their FAQ page, not to a specific Q/A. The correct FAQ link is https://keepersecurity.com/support/faq#faq36802 but in case it gets moved around (maybe why the old link no longer works), I used their 2FA page.
