### PR TITLE
Update Runescape to reflect new Authenticator support

### DIFF
--- a/_data/gaming.yml
+++ b/_data/gaming.yml
@@ -95,8 +95,8 @@ websites:
       url: http://www.runescape.com/
       img: runescape.png
       tfa: Yes
-      email: Yes
-      doc: http://services.runescape.com/m=rswiki/en/Jagex_Account_Guardian
+      software: Yes
+      doc: http://services.runescape.com/m=rswiki/en/Authenticator_FAQ
 
     - name: "Star Wars: The Old Republic"
       url: http://www.swtor.com/


### PR DESCRIPTION
Runescape has released support for using TOTP apps to implement 2FA and will be phasing out the Jagex Account Guardian.
