### PR TITLE
Clarify iCloud exceptions/restrictions

### DIFF
--- a/_data/backup.yml
+++ b/_data/backup.yml
@@ -75,7 +75,7 @@ websites:
     sms: Yes
     software: Yes
     exceptions:
-        text: "SMS only available on select providers. 2FA protects Apple ID account changes and iTunes/App Store purchases only. 2FA does not protect iCloud.com logins, synchronized iCloud data, or iCloud backup data."
+        text: "SMS only available on select providers. 2FA for iCloud data is available for select accounts only."
     doc: http://support.apple.com/kb/ht5570
 
   - name: IDrive

--- a/_data/backup.yml
+++ b/_data/backup.yml
@@ -75,7 +75,7 @@ websites:
     sms: Yes
     software: Yes
     exceptions:
-        text: "SMS only available in the US."
+        text: "SMS only available on select providers. 2FA protects Apple ID account changes and iTunes/App Store purchases only. 2FA does not protect iCloud.com logins, synchronized iCloud data, or iCloud backup data."
     doc: http://support.apple.com/kb/ht5570
 
   - name: IDrive

--- a/_data/retail.yml
+++ b/_data/retail.yml
@@ -12,7 +12,7 @@ websites:
       sms: Yes
       software: Yes
       exceptions:
-          text: "SMS only available in the US."
+          text: "SMS only available on select providers."
       doc: http://support.apple.com/kb/ht5570
 
     - name: Comixology


### PR DESCRIPTION
I've added some clarification to how Apple applies 2FA to iCloud data. The list currently implies that personal information stored in iCloud is protected by 2FA, but that's not the case. Per http://support.apple.com/kb/ht5570, 2FA only applies when you take one of these actions with an Apple ID:
- Sign in to My Apple ID to manage your account
- Make an iTunes, App Store, or iBooks Store purchase from a new device
- Get Apple ID related support from Apple

In particular, signing in to iCloud.com on an untrusted device, signing into iCloud via Settings on an untrusted iOS device (to synchronize data), and attempting to restore an iCloud backup onto an untrusted device **will not** trigger 2FA verification. (Additional explanation and implications [here](http://arstechnica.com/security/2013/05/icloud-users-take-note-apple-two-step-protection-wont-protect-your-data/).)

I've added some wording to the "Exceptions/Restrictions" section for iCloud to clarify this. I'm open to rephrasing for clarity, if you think it needs it.

(I've also slightly modified the wording for Apple's SMS support, per #623 and #624. This matches the current wording for Twitter.)
