### PR TITLE
Twitter no longer requires SMS

### DIFF
--- a/_data/social.yml
+++ b/_data/social.yml
@@ -80,7 +80,7 @@ websites:
       tfa: Yes
       sms: Yes
       exceptions:
-          text: "SMS only available on select providers, SMS required for 2FA."
+          text: "SMS only available on select providers."
       software: Yes
       doc: https://support.twitter.com/articles/20170388
 


### PR DESCRIPTION
Twitter supports SW-based 2FA via their Android/iOS App that does not require SMS. ([Details](https://blog.twitter.com/2013/improvements-to-login-verification-photos-and-more) - it's actually quite slick.)

Updating the Exceptions field for Twitter to reflect this.
