### PR TITLE
Drugs.com is working on 2FA

### DIFF
--- a/_data/health.yml
+++ b/_data/health.yml
@@ -17,6 +17,7 @@ websites:
       twitter: DrugsCom
       img: drugscom.png
       tfa: No
+      status: https://twitter.com/Drugscom/status/493856207572975620
 
     - name: FitBit
       url: http://www.fitbit.com


### PR DESCRIPTION
Added status that shows Drugs.com is working on 2FA
