### PR TITLE
Update status for Vanguard

### DIFF
--- a/_data/investing.yml
+++ b/_data/investing.yml
@@ -73,6 +73,7 @@ websites:
       twitter: Vanguard_Group
       img: vanguard.png
       tfa: No
+      status: http://www.nytimes.com/2014/08/09/your-money/how-to-thwart-hackers-from-financial-accounts.html
 
     - name: Wealthfront
       url: https://www.wealthfront.com/

--- a/_data/investing.yml
+++ b/_data/investing.yml
@@ -73,7 +73,7 @@ websites:
       twitter: Vanguard_Group
       img: vanguard.png
       tfa: No
-      status: http://www.nytimes.com/2014/08/09/your-money/how-to-thwart-hackers-from-financial-accounts.html
+      status: https://twitter.com/Vanguard_Group/status/499260535360466944
 
     - name: Wealthfront
       url: https://www.wealthfront.com/


### PR DESCRIPTION
The New York Times article says Vanguard has committed to adding 2FA by the end of 2014.
