### PR TITLE
Add Humble Bundle exception

### DIFF
--- a/_data/gaming.yml
+++ b/_data/gaming.yml
@@ -69,6 +69,8 @@ websites:
       sms: Yes
       software: Yes
       doc: https://support.humblebundle.com/hc/en-us/articles/202421374
+      exceptions:
+        text: "TFA can be bypassed using 'Forgot your Password?' link."
 
     - name: League of Legends
       url: http://leagueoflegends.com


### PR DESCRIPTION
For #704. It would be great if someone could confirm that TFA can be bypassed using the forget password flow.
