### PR TITLE
Added email support to token2

### DIFF
--- a/_data/providers.yml
+++ b/_data/providers.yml
@@ -147,6 +147,7 @@ providers:
   - name: Token2
     url: https://token2.com
     img: token2.png
+    email: Yes
     software: Yes
     hardware: Yes
     sms: Yes


### PR DESCRIPTION
Email based OTP deliver is offered, but used for debugging only and not recommended . But since you have that field in the table, should be mentioned for token2
