### PR TITLE
Update Ebay in retail.yml

### DIFF
--- a/_data/retail.yml
+++ b/_data/retail.yml
@@ -26,7 +26,6 @@ websites:
       img: ebay.png
       tfa: Yes
       hardware: Yes
-      software: Yes
       doc: https://www.paypal.com/cgi-bin/webscr?cmd=xpt/Marketing_CommandDriven/securitycenter/PayPalSecurityKey-outside
 
     - name: Etsy


### PR DESCRIPTION
Removed software option from eBay.  eBay relies on PayPal, but does not support their software implementation, only their hardware tokens.
