### PR TITLE
Add Internet Slowdown banner

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -19,6 +19,10 @@
     <link rel="stylesheet" href="/lib/semantic/css/semantic.no-resp.css" />
     <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Open+Sans:400,700" />
     <link rel="stylesheet" href="/css/base.css" />
+    <script type="text/javascript">
+    var _bftn_options = { animation: 'banner' }
+    </script>
+    <script src="//fightforthefuture.github.io/battleforthenet-widget/widget.min.js" async></script>
 </head>
 
 <body>


### PR DESCRIPTION
The 10th September BattleForTheNet are having a campaign on the net neutrality agenda.
Since we all love the internet I think it would be excellent to spread the word through this site.

The banner will only be shown on the 10th of sept and I can remove the script the day after.

https://www.battleforthenet.com/sept10th/
