### PR TITLE
Added link to Zapier roadmap status

### DIFF
--- a/_data/developer.yml
+++ b/_data/developer.yml
@@ -106,3 +106,4 @@ websites:
       twitter: zapier
       img: zapier.png
       tfa: No
+      status: https://twitter.com/zapier/status/457159880890384384


### PR DESCRIPTION
It's a few months old, but I noticed it wasn't here yet.
