### PR TITLE
Removed 'in progress' from Slack in communicatoin.yml

### DIFF
--- a/_data/communication.yml
+++ b/_data/communication.yml
@@ -71,7 +71,6 @@ websites:
       twitter: SlackHQ
       img: slack.png
       tfa: No
-      status: https://twitter.com/SlackHQ/status/448214716192538625
 
     - name: ToutApp
       url: http://www1.toutapp.com/


### PR DESCRIPTION
According to https://twitter.com/SlackHQ/status/492192845038895105 they are not actively working on 2FA, but it's on hold while they implement SSO.
