### PR TITLE
Update iCloud - exceptions text

### DIFF
--- a/_data/backup.yml
+++ b/_data/backup.yml
@@ -82,7 +82,7 @@ websites:
     sms: Yes
     software: Yes
     exceptions:
-        text: "SMS only available on select providers. 2FA for iCloud data is available for select accounts only."
+        text: "SMS only available on select providers."
     doc: http://support.apple.com/kb/ht5570
 
   - name: IDrive


### PR DESCRIPTION
This is being reported in a couple of places:
- [Apple Insider](http://appleinsider.com/articles/14/09/16/apple-activates-two-step-authentication-for-icloud-web-portal)
- [Ars Technica](http://arstechnica.com/security/2014/09/apples-two-factor-authentication-now-protects-icloud-backups/)

I received an email from Apple confirming this, as well. :tada:

The email reads, in part:

> **Two-step verification now protects iCloud**
> 
> Starting today, in addition to protecting your Apple ID account information, two-step verification also protects all of the data you store and keep up to date with iCloud. For more information, read the [Two-Step Verification FAQ](http://support.apple.com/kb/HT5570).
> 
> **Sign in securely with app-specific passwords**
> 
> If you use iCloud with any third party apps such as Microsoft Outlook, Mozilla Thunderbird, or BusyCal, you can now generate app-specific passwords that allow you to sign in securely even if the app you are using does not support two-step verification.
> 
> [...]
> 
> App-Specific passwords will be required starting on **October 1, 2014.**
> 
> For complete instructions and answers to common questions, read [Using App‑Specific Passwords](http://support.apple.com/kb/HT6186).
