### PR TITLE
Update VanillaForums - status

### DIFF
--- a/_data/social.yml
+++ b/_data/social.yml
@@ -101,7 +101,6 @@ websites:
       url: https://vanillaforums.com
       img: vanilla.png
       tfa: No
-      status: https://twitter.com/vanilla/status/457569186760253440
       twitter: vanilla
 
     - name: Viadeo


### PR DESCRIPTION
It's been on their Roadmap since "19 Apr, 2014".
Plenty of time for them to figure out either way to go with this.
