### PR TITLE
Looker doc link update

### DIFF
--- a/_data/developer.yml
+++ b/_data/developer.yml
@@ -71,7 +71,7 @@ websites:
       software: Yes
       sms: No
       phone: No
-      doc: https://docs.google.com/document/d/19CVM74XC5S8sDLFH9muzjCzgV7xDA30IZWR4JU4KUNA/edit?usp=sharing
+      doc: http://www.looker.com/docs/admin/two-factor-authentication
 
     - name: MongoHQ
       url: https://www.mongohq.com/


### PR DESCRIPTION
We made our docs public, so this pull request updates the link to the two factor page.
