### PR TITLE
"Copy" twitter account correction

### DIFF
--- a/_data/backup.yml
+++ b/_data/backup.yml
@@ -33,7 +33,7 @@ websites:
 
   - name: Copy
     url: https://www.copy.com
-    twitter: copyapp
+    twitter: copy
     img: copy.png
     tfa: No
 


### PR DESCRIPTION
The @copyapp account is not the correct one. The correct one is simply @copy.
