### PR TITLE
HTTPSify Doc Links and Website Links for Finance

### DIFF
--- a/_data/investing.yml
+++ b/_data/investing.yml
@@ -27,7 +27,7 @@ websites:
       tfa: Yes
       software: Yes
       hardware: Yes
-      doc: http://twofactorauth.org/notes/fidelity/
+      doc: https://twofactorauth.org/notes/fidelity/
 
     - name: Loyal3
       url: https://www.loyal3.com/
@@ -54,7 +54,7 @@ websites:
       url: https://www.optionshouse.com
       tfa: Yes
       software: Yes
-      doc: http://www.optionshouse.com/faq/authenticator/
+      doc: https://www.optionshouse.com/faq/authenticator/
 
     - name: Personal Capital
       url: https://www.personalcapital.com
@@ -90,7 +90,7 @@ websites:
       tfa: No
 
     - name: Vanguard
-      url: http://www.vanguard.com/
+      url: https://www.vanguard.com/
       twitter: Vanguard_Group
       img: vanguard.png
       tfa: No


### PR DESCRIPTION
Changed the following to be HTTPS:
Fidelity Doc Link
OptionsHouse Doc Link
Vanguard Website Link

I tested all of the above to make sure they worked and no mixed content errors were given.

Charles Schwab's doc link was not made HTTPS, because their website gave mixed content warnings.
