### PR TITLE
Add Gemfile.lock to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ _site/
 *.DS_Store
 .idea/
 */Thumbs.db
+Gemfile.lock


### PR DESCRIPTION
Add Gemfile.lock to .gitignore to prevent committing Gem parameters specific to certain platforms.
