### PR TITLE
update OVH exceptions

### DIFF
--- a/_data/hosting.yml
+++ b/_data/hosting.yml
@@ -93,7 +93,7 @@ websites:
       tfa: Yes
       sms: Yes
       exceptions:
-        text: "2FA is only available for the customers who registered on the french version of the website."
+        text: "2FA is only available for the customers who registered on the French version of the website."
       doc: http://www.ovh.com/us/about-us/security.xml#double-authentification
 
     - name: Rackspace

--- a/_data/hosting.yml
+++ b/_data/hosting.yml
@@ -92,6 +92,8 @@ websites:
       img: ovh.png
       tfa: Yes
       sms: Yes
+      exceptions:
+        text: "2FA is only available for the customers who registered on the french version of the website."
       doc: http://www.ovh.com/us/about-us/security.xml#double-authentification
 
     - name: Rackspace


### PR DESCRIPTION
OVH only provides secured accounts to its French customers.

This was confirmed by their Italian support team, on a private ticket I opened 2014-10-15.

I was tempted to simply switch "tfa" to "No", given they sell their IaaS worldwide.
