### PR TITLE
Ally has disabled 2FA?

### DIFF
--- a/_data/banking.yml
+++ b/_data/banking.yml
@@ -1,11 +1,9 @@
 websites:
     - name: Ally Bank
       url: http://www.ally.com/
+      twitter: allybank
       img: allybank.png
-      tfa: Yes
-      sms: Yes
-      email: Yes
-      doc: http://www.ally.com/messages/sms/index.html
+      tfa: No
 
     - name: Altra Federal Credit Union
       url: https://www.altra.org/


### PR DESCRIPTION
I was informed through an email that Ally has removed 2FA.

I verified by using a completely different browser, turning on a VPN tunnel and logging in. Unless they are using another way to fingerprint "new computers", I can't get Ally to trigger 2FA.

Ally is also working on a new redesign so I wonder if this is part of that.

I might email them as well since I use them and picked Ally because they were online only and had 2FA... :/
