### PR TITLE
Add hardware 2FA note to PayPal

### DIFF
--- a/_data/payments.yml
+++ b/_data/payments.yml
@@ -50,7 +50,7 @@ websites:
       software: Yes
       hardware: Yes
       exceptions:
-          text: "2FA only available in the US and Canada. SMS only available in the US."
+          text: "2FA only available in the US and Canada. SMS only available in the US. Hardware-based 2FA is no longer available."
       doc: https://www.paypal.com/us/cgi-bin?cmd=xpt/Marketing_CommandDriven/securitycenter/PayPalSecurityKey-outside&bn_r=o
 
     - name: Skrill

--- a/_data/payments.yml
+++ b/_data/payments.yml
@@ -48,7 +48,7 @@ websites:
       tfa: Yes
       sms: Yes
       software: Yes
-      hardware: Yes
+      hardware: No
       exceptions:
           text: "2FA only available in the US and Canada. SMS only available in the US. Hardware-based 2FA is no longer available."
       doc: https://www.paypal.com/us/cgi-bin?cmd=xpt/Marketing_CommandDriven/securitycenter/PayPalSecurityKey-outside&bn_r=o


### PR DESCRIPTION
Add a note to PayPal's section in _data\payments.yml, explaining that
hardware based two-factor authentication is no longer available. Fixes
#880.
