### PR TITLE
Add SMS-required exceptions

### DIFF
--- a/_data/hosting.yml
+++ b/_data/hosting.yml
@@ -28,6 +28,8 @@ websites:
       img: digitalocean.png
       tfa: Yes
       software: Yes
+      exceptions:
+          text: "SMS-capable phone required."
       doc: https://www.digitalocean.com/company/blog/introducing-two-factor-authentication/
 
     - name: Dreamhost

--- a/_data/payments.yml
+++ b/_data/payments.yml
@@ -11,6 +11,8 @@ websites:
       tfa: Yes
       software: Yes
       sms: Yes
+      exceptions:
+          text: "SMS-capable phone required."
       doc: http://server.buycraft.net/tfa
 
     - name: GoCardless

--- a/_data/social.yml
+++ b/_data/social.yml
@@ -18,6 +18,8 @@ websites:
       img: bitly.png
       tfa: Yes
       sms: Yes
+      exceptions:
+          text: "SMS-capable phone required."
       doc: http://blog.bitly.com/post/90381427894/introducing-2-step-verification-for-all-users
 
     - name: Buffer
@@ -117,4 +119,6 @@ websites:
       tfa: Yes
       sms: Yes
       software: Yes
+      exceptions:
+          text: "SMS-capable phone required."
       doc: http://en.support.wordpress.com/security/two-step-authentication/


### PR DESCRIPTION
Add SMS-required exceptions for DigitalOcean, BuyCraft, BitLy and
Wordpress.com.
This pull request affects issue #851.
