### PR TITLE
Update Dynadot information

### DIFF
--- a/_data/domains.yml
+++ b/_data/domains.yml
@@ -86,7 +86,8 @@ websites:
       tfa: Yes
       sms: Yes
       software: Yes
-      hardware: Yes
+      exceptions:
+          text: "Only protects certain operations like password changes and domain transfers."
       doc: http://dynadot.com/domain/security.html
 
     - name: easyDNS


### PR DESCRIPTION
- As far as I know, it has never supported hardware 2FA; the (now
  deprecated) "Dynadot Token" was just an app for slightly-nonstandard
  OATH-TOTP.
- The second factor is not needed to log in to the website, only for
  some actions (changing the password or exporting a domain).
