### PR TITLE
Escaped &amp; characters

### DIFF
--- a/index.html
+++ b/index.html
@@ -133,9 +133,9 @@ hash: SupportTwoFactorAuth
                                             {% if website.twitter %}
                                                 <td class="twitter main negative" colspan="6">
                                                 {% if website.status %}
-                                                    <a class="ui twitter mini button" href="https://twitter.com/share?url={{site.url|cgi_escape}}&text={{page.tweet_progress|replace:'TWITTERHANDLE',website.twitter|cgi_escape}}&hashtags={{page.hash|cgi_escape}}" target="_blank"><i class="twitter icon"></i> {{page.link_progress}}</a>
+                                                    <a class="ui twitter mini button" href="https://twitter.com/share?url={{site.url|cgi_escape}}&amp;text={{page.tweet_progress|replace:'TWITTERHANDLE',website.twitter|cgi_escape}}&amp;hashtags={{page.hash|cgi_escape}}" target="_blank"><i class="twitter icon"></i> {{page.link_progress}}</a>
                                                 {% else %}
-                                                    <a class="ui twitter mini button" href="https://twitter.com/share?url={{site.url|cgi_escape}}&text={{page.tweet|replace:'TWITTERHANDLE',website.twitter|cgi_escape}}&hashtags={{page.hash|cgi_escape}}" target="_blank"><i class="twitter icon"></i> {{page.link}}</a>
+                                                    <a class="ui twitter mini button" href="https://twitter.com/share?url={{site.url|cgi_escape}}&amp;text={{page.tweet|replace:'TWITTERHANDLE',website.twitter|cgi_escape}}&amp;hashtags={{page.hash|cgi_escape}}" target="_blank"><i class="twitter icon"></i> {{page.link}}</a>
                                                 </td>
                                                 {% endif %}
                                             {% else %}


### PR DESCRIPTION
#935

http://validator.w3.org/check?uri=https://twofactorauth.org/#error_loop

Fixed the W3 HTML validator errors that say:
`& did not start a character reference. (& probably should have been escaped as &amp;.)`
