### PR TITLE
Update Stripe two factor auth doc URL

### DIFF
--- a/_data/payments.yml
+++ b/_data/payments.yml
@@ -24,7 +24,7 @@ websites:
     - name: GoCardless
       img: gocardless.png
       url: https://gocardless.com/
-      twitter: GoCardless
+      twitter: GoCardlesss
       tfa: No
 
     - name: Google Wallet
@@ -73,7 +73,7 @@ websites:
       url: https://www.stripe.com/
       tfa: Yes
       software: Yes
-      doc: https://stripe.com/blog/two-step-verification
+      doc: https://support.stripe.com/questions/how-do-i-enable-two-step-verification
 
     - name: Square
       url: https://squareup.com

--- a/_data/payments.yml
+++ b/_data/payments.yml
@@ -24,7 +24,7 @@ websites:
     - name: GoCardless
       img: gocardless.png
       url: https://gocardless.com/
-      twitter: GoCardlesss
+      twitter: GoCardless
       tfa: No
 
     - name: Google Wallet


### PR DESCRIPTION
Changed the doc from the blog post to dedicated support article with more information.
