### PR TITLE
no more TFA for OVH

### DIFF
--- a/_data/hosting.yml
+++ b/_data/hosting.yml
@@ -93,7 +93,6 @@ websites:
       url: http://www.ovh.com/
       img: ovh.png
       tfa: No
-      sms: Yes
 
     - name: Rackspace
       url: https://www.rackspace.com/

--- a/_data/hosting.yml
+++ b/_data/hosting.yml
@@ -93,7 +93,7 @@ websites:
       url: http://www.ovh.com/
       img: ovh.png
       tfa: No
-      twitter: OVH
+      twitter: ovh_support_en
 
     - name: Rackspace
       url: https://www.rackspace.com/

--- a/_data/hosting.yml
+++ b/_data/hosting.yml
@@ -92,11 +92,8 @@ websites:
     - name: OVH
       url: http://www.ovh.com/
       img: ovh.png
-      tfa: Yes
+      tfa: No
       sms: Yes
-      exceptions:
-        text: "2FA is only available for the customers who registered on the French version of the website."
-      doc: http://www.ovh.com/us/about-us/security.xml#double-authentification
 
     - name: Rackspace
       url: https://www.rackspace.com/

--- a/_data/hosting.yml
+++ b/_data/hosting.yml
@@ -93,6 +93,7 @@ websites:
       url: http://www.ovh.com/
       img: ovh.png
       tfa: No
+      twitter: OVH
 
     - name: Rackspace
       url: https://www.rackspace.com/


### PR DESCRIPTION
Following up on #870.

It really looks like OVH doesn't offer TFA anymore. The section on their website that used to advertise TFA has been wiped out some time ago.

I think the time has come to revert their state to `tfa: No`.
