### PR TITLE
Removed Trello from In Progress

### DIFF
--- a/_data/other.yml
+++ b/_data/other.yml
@@ -105,7 +105,6 @@ websites:
       twitter: trello
       img: trello.png
       tfa: No
-      status: https://trello.com/c/O6DrHazq/1532-two-factor-authentication
 
     - name: US Social Security Administration
       url: http://www.ssa.gov


### PR DESCRIPTION
After 3 months of being "In Progress," now 2FA is just an "Idea" for Trello. https://trello.com/c/O6DrHazq/1532-two-factor-authentication
