### PR TITLE
Add phone to coinbase

### DIFF
--- a/_data/bitcoin.yml
+++ b/_data/bitcoin.yml
@@ -91,6 +91,7 @@ websites:
       tfa: Yes
       sms: Yes
       software: Yes
+      phone: Yes
       doc: http://blog.coinbase.com/post/25677574019/coinbase-now-offers-two-factor-authentication
 
     - name: CEX.IO


### PR DESCRIPTION
Coinbase supports Authy which also means it supports phone calls
