### PR TITLE
Fix travis-timeouts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
-install: bundle install
+install: travis_wait bundle install
 rvm:
     - 2.1.1
 notifications:


### PR DESCRIPTION
According to http://docs.travis-ci.com/user/build-timeouts/ the `travis_wait` prefix should fix the timeouts making builds fail for travis.
