### PR TITLE
Slack now support 2FA

### DIFF
--- a/_data/communication.yml
+++ b/_data/communication.yml
@@ -87,7 +87,7 @@ websites:
       url: http://www.slack.com
       twitter: SlackHQ
       img: slack.png
-      tfa: No
+      tfa: Yes
 
     - name: ToutApp
       url: http://www1.toutapp.com/


### PR DESCRIPTION
https://slack.zendesk.com/hc/en-us/articles/204509068-Enabling-two-factor-authentication
