### PR TITLE
add Hetzner (no image, no twitter)

### DIFF
--- a/_data/hosting.yml
+++ b/_data/hosting.yml
@@ -55,6 +55,11 @@ websites:
       software: Yes
       hardware: Yes
 
+    - name: Hetzner Online
+      url: https://www.hetzner.de/
+      img: ../placeholder.png
+      tfa: No
+
     - name: iPage
       url: http://www.ipage.com/ipage/index.html
       twitter: iPage
@@ -129,7 +134,7 @@ websites:
       twitter: squarespace
       img: squarespace.png
       tfa: No
-      
+
     - name: UKFast
       url: http://www.ukfast.co.uk/
       img: ukfast.png


### PR DESCRIPTION
Add hosting provider Hetzner.
- Due to copyright law I'm not allowed to contribute a logo (#1038)
- They don't have an official twitter handle 
