### PR TITLE
Add exception for Lloyds Bank

### DIFF
--- a/_data/banking.yml
+++ b/_data/banking.yml
@@ -173,6 +173,8 @@ websites:
       img: lloydsbank.png
       tfa: Yes
       phone: Yes
+      exceptions:
+            text: "Only for adding a new payee to your account, not for logging in to online banking."
       doc: http://www.lloydsbank.com/help-guidance/security/authentication-procedure.asp
 
     - name: Natwest UK


### PR DESCRIPTION
2FA is only used for confirming the addition of new payees, not for logging in to online banking (see issue #948).

The docs link stays as-is as it seems to be most descriptive of the behaviour.  This still shows Lloyds as supporting 2FA - perhaps it may be more suitable to consider it non-2FA altogether.
