### PR TITLE
Update Aha!'s doc url + add https to a couple of other sites

### DIFF
--- a/_data/developer.yml
+++ b/_data/developer.yml
@@ -1,13 +1,13 @@
 websites:
     - name: Aha!
-      url: http://aha.io
+      url: https://www.aha.io/
       img: aha.png
       tfa: Yes
       sms: Yes
       phone: Yes
       hardware: Yes
       software: Yes
-      doc: http://support.aha.io/hc/en-us/articles/202000967-Two-factor-authentication-2FA-user-set-up
+      doc: http://support.aha.io/hc/en-us/articles/202000957-Add-two-factor-authentication-2FA-
 
     - name: Airbrake
       url: https://airbrake.io
@@ -16,7 +16,7 @@ websites:
       tfa: No
 
     - name: aTech Media
-      url: http://atechmedia.com
+      url: https://atechmedia.com
       img: atechmedia.png
       tfa: Yes
       software: Yes
@@ -24,7 +24,7 @@ websites:
       doc: https://atechmedia.com/blog/general/launches/two-factor-authentication
 
     - name: Balsamiq
-      url: http://balsamiq.com
+      url: https://balsamiq.com
       twitter: balsamiq
       img: balsamiq.png
       tfa: No


### PR DESCRIPTION
Right now Travis outputs an error for Aha!'s doc link so I replaced that one with a new link describing how to add TFA to your Aha! account.
I also changed a couple of http links to https for sites that support https.
