### PR TITLE
Changed PayPal exception, added more countries

### DIFF
--- a/_data/payments.yml
+++ b/_data/payments.yml
@@ -58,7 +58,7 @@ websites:
       software: Yes
       hardware: No
       exceptions:
-          text: "2FA only available in the US and Canada. SMS only available in the US. Hardware-based 2FA is no longer available."
+          text: "2FA is only available in the United States, Canada, United Kingdom, Germany, Austria and Australia."
       doc: https://www.paypal.com/us/cgi-bin?cmd=xpt/Marketing_CommandDriven/securitycenter/PayPalSecurityKey-outside&bn_r=o
 
     - name: Skrill

--- a/_data/retail.yml
+++ b/_data/retail.yml
@@ -28,7 +28,7 @@ websites:
       hardware: Yes
       software: Yes
       exceptions:
-          text: "While PayPal supports hardware and software 2FA in all locales, eBay only supports 2FA in some locales."
+          text: "eBay only supports 2FA in some countries."
       doc: https://www.paypal.com/cgi-bin/webscr?cmd=xpt/Marketing_CommandDriven/securitycenter/PayPalSecurityKey-outside
 
     - name: Etsy


### PR DESCRIPTION
As described in https://github.com/jdavis/twofactorauth/issues/1072 PayPal supports 2FA in more countries than US/Canada.
Because of this I added this information.
