### PR TITLE
PayPal: hardware token supported

### DIFF
--- a/_data/payments.yml
+++ b/_data/payments.yml
@@ -56,7 +56,7 @@ websites:
       tfa: Yes
       sms: Yes
       software: Yes
-      hardware: No
+      hardware: Yes
       exceptions:
           text: "2FA only available in the US and Canada. SMS only available in the US. Hardware-based 2FA is no longer available."
       doc: https://www.paypal.com/us/cgi-bin?cmd=xpt/Marketing_CommandDriven/securitycenter/PayPalSecurityKey-outside&bn_r=o


### PR DESCRIPTION
The main issue of https://github.com/jdavis/twofactorauth/issues/1072 was something else, but PayPal also supports hardware token authentication.
