### PR TITLE
Update psn link

### DIFF
--- a/_data/gaming.yml
+++ b/_data/gaming.yml
@@ -100,7 +100,7 @@ websites:
       doc: http://help.ea.com/en/article/origin-login-verification-information/
 
     - name: Playstation Network
-      url: https://www.playstation.com/en-gb/explore/playstation-network/
+      url: https://www.playstation.com/
       twitter: AskPlayStation
       img: psn.png
       tfa: No

--- a/_data/gaming.yml
+++ b/_data/gaming.yml
@@ -100,7 +100,7 @@ websites:
       doc: http://help.ea.com/en/article/origin-login-verification-information/
 
     - name: Playstation Network
-      url: http://playstation.com/psn/
+      url: https://www.playstation.com/en-gb/explore/playstation-network/
       twitter: AskPlayStation
       img: psn.png
       tfa: No


### PR DESCRIPTION
So playstation change their psn link. It looks like there's no en-us version so I guess we'll have to use en-gb then.
