### PR TITLE
Add image size check

### DIFF
--- a/verify.rb
+++ b/verify.rb
@@ -2,45 +2,67 @@
 require 'yaml'
 require 'fastimage'
 $output=0;
+$image_error_output=0;
+$max_size = 2500 # Max file size (Bytes)
+$max_size_ignore = false #Ignore max file size errors
+$error_ignore = true  #Will output the error but won't make the build fail.
+
 begin
   def error(msg)
     $output=$output+1;
-    if($output == 1)
+    if ($output == 1)
       puts "<------------ ERROR ------------>\n"
     end
     puts "#{$output}. #{msg}"
 
   end
 
-  # Load each section, check for errors such as invalid syntax
-  # as well as if an image is missing
+  def image_size_error(msg)
+    if ($max_size_ignore == false)
+      $output=$output+1;
+    end
+      $image_error_output=$image_error_output+1;
+
+    puts "#{$image_error_output}. #{msg}"
+  end
+
+  def check_image(image)
+    unless File.exists?(image)
+      image_size_error("#{website['name']} image not found.")
+    else
+
+      image_dimensions = [32, 32]
+
+      unless FastImage.size(image) == image_dimensions
+        image_size_error("#{image} is not #{image_dimensions.join("x")}")
+      end
+
+      ext = "\.png"
+      unless File.extname(image) == ext
+        image_size_error("#{image} is not #{ext}")
+      end
+
+      file_size = File.size(image)
+      unless file_size < $max_size
+        image_size_error("#{image} is larger than #{$max_size} Bytes. (#{file_size} Bytes)")
+      end
+    end
+  end
+
+
+# Load each section, check for errors such as invalid syntax
+# as well as if an image is missing
   main = YAML.load_file('_data/main.yml')
   main["sections"].each do |section|
     data = YAML.load_file('_data/' + section["id"] + '.yml')
 
     data['websites'].each do |website|
       image = "img/#{section['id']}/#{website['img']}"
+      check_image(image)
 
-      unless File.exists?(image)
-        error("#{website['name']} image not found.")
-      end
-
-      image_dimensions = [32,32]
-
-      unless FastImage.size(image) == image_dimensions
-        error("#{image} is not #{image_dimensions.join("x")}")
-      end
-
-      ext = ".png"
-      unless File.extname(image) == ext
-        error("#{image} is not #{ext}")
-      end
     end
   end
 
-  if($output > 0 )
-    exit 1
-  end
 rescue Psych::SyntaxError => e
   puts 'Error in the YAML'
   puts e


### PR DESCRIPTION
Hi,
I mentioned in #1112 that I were working on a image size checker for the verify.rb code.
Here it is.

Right now it exits with 1 (As in the build fails) when an image is larger than 2500 B.
I didn't know if we wanted it to fail and therefor I added the option to disable that by setting `$max_size_ignore` to true.
I also added an `$error_ignore` just in case we'd need that. (that would useful for debugging)
