### PR TITLE
Added Twitter's single account problem

### DIFF
--- a/_data/social.yml
+++ b/_data/social.yml
@@ -103,7 +103,7 @@ websites:
       tfa: Yes
       sms: Yes
       exceptions:
-          text: "SMS only available on select providers, SMS required for 2FA."
+          text: "SMS only available on select providers, SMS required for 2FA, 1 account per phone number, 1 phone number per account"
       software: Yes
       doc: https://support.twitter.com/articles/20170388
 


### PR DESCRIPTION
Many Twitter users have multiple Twitter accounts, and other Twitter accounts are managed by multiple people. Twitter's 2FA is useless for all those people, because they incorrectly assume a one-to-one relationship between a phone number and a Twitter account.
