### PR TITLE
Makes page encoding consistent and standard 'utf-8'.

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8"/>
     <meta name="description" content="{{ site.description }}"/>
     <meta name="author" content="{{ site.author }}"/>
-    <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <meta property="og:title" content="{{ site.title }}">


### PR DESCRIPTION
This should help pass https://validator.w3.org/check?uri=https%3A%2F%2Ftwofactorauth.org%2F&charset=%28detect+automatically%29&doctype=Inline&group=0 with less errors.
