### PR TITLE
GitLab now supports 2FA (software: OTP)

### DIFF
--- a/_data/developer.yml
+++ b/_data/developer.yml
@@ -101,7 +101,9 @@ websites:
       url: https://gitlab.com
       twitter: gitlab
       img: gitlab.png
-      tfa: No
+      tfa: Yes
+      software: Yes
+      doc: https://about.gitlab.com/2015/05/22/gitlab-7-11-released/
 
     - name: Infobip
       url: http://www.infobip.com/

--- a/_data/developer.yml
+++ b/_data/developer.yml
@@ -99,7 +99,6 @@ websites:
 
     - name: GitLab
       url: https://gitlab.com
-      twitter: gitlab
       img: gitlab.png
       tfa: Yes
       software: Yes

--- a/_data/developer.yml
+++ b/_data/developer.yml
@@ -103,6 +103,8 @@ websites:
       tfa: Yes
       software: Yes
       doc: https://about.gitlab.com/2015/05/22/gitlab-7-11-released/
+      exceptions:
+          text: "Two factor authentication for LDAP is only avaliable in the Enterprise Edition."
 
     - name: Infobip
       url: http://www.infobip.com/


### PR DESCRIPTION
GitLab [let me know](https://twitter.com/gitlab/status/604405976884731905) that they are now supporting 2FA, so here I added it.
For now I've added their blog post as a documentation.
