### PR TITLE
Codeanywhere changed TFA availability.

### DIFF
--- a/_data/developer.yml
+++ b/_data/developer.yml
@@ -51,7 +51,7 @@ websites:
       sms: Yes
       doc: https://blog.codeanywhere.com/codeanywhere-now-offers-two-factor-authentication/
       exceptions:
-          text: "TFA only available on paid account tiers at $20 or more per month."
+          text: "Only available on paid accounts at $7/$10 per month (annual/monthly)."
 
     - name: Code Climate
       url: https://codeclimate.com


### PR DESCRIPTION
Still only available on paid tiers, but a lower tier now.
