### PR TITLE
Changed GitLab doc link

### DIFF
--- a/_data/developer.yml
+++ b/_data/developer.yml
@@ -102,7 +102,7 @@ websites:
       img: gitlab.png
       tfa: Yes
       software: Yes
-      doc: https://about.gitlab.com/2015/05/22/gitlab-7-11-released/
+      doc: http://doc.gitlab.com/ce/workflow/two_factor_authentication.html
       exceptions:
           text: "Two factor authentication for LDAP is only avaliable in the Enterprise Edition."
 


### PR DESCRIPTION
Now there is a real documentation for GitLabs 2FA feature, [like they said](https://twitter.com/gitlab/status/606200891482456065), so I changed it.
