### PR TITLE
Fix Cloud9's Twitter

### DIFF
--- a/_data/developer.yml
+++ b/_data/developer.yml
@@ -37,7 +37,7 @@ websites:
 
     - name: Cloud9
       url: https://c9.io
-      twitter: https://twitter.com/cloud9ide
+      twitter: Cloud9IDE
       img: cloud9.png
       tfa: No
       doc: https://docs.c9.io/faq_general.html#can-i-use-two-factor-authentication-with-cloud9?


### PR DESCRIPTION
It had a URL instead of Username which broke the tweet button.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/jdavis/twofactorauth/1176)

<!-- Reviewable:end -->
