### PR TITLE
Fixed GitLab documentation URL

### DIFF
--- a/_data/developer.yml
+++ b/_data/developer.yml
@@ -102,7 +102,7 @@ websites:
       img: gitlab.png
       tfa: Yes
       software: Yes
-      doc: http://doc.gitlab.com/ce/workflow/two_factor_authentication.html
+      doc: http://doc.gitlab.com/ee/workflow/two_factor_authentication.html
       exceptions:
           text: "Two factor authentication for LDAP is only avaliable in the Enterprise Edition."
 


### PR DESCRIPTION
2FA is only described in the Enterprise Edition documentation
