### PR TITLE
replacing http with https where available

### DIFF
--- a/_data/social.yml
+++ b/_data/social.yml
@@ -7,7 +7,7 @@ websites:
       doc: http://university.zocle.com/2015/03/30/new-security-feature-two-step-verification/
 
     - name: about.me
-      url: http://about.me
+      url: https://about.me
       twitter: aboutdotme
       img: aboutme.png
       tfa: No
@@ -20,7 +20,7 @@ websites:
       doc: https://mml.desk.com/customer/portal/articles/1039728-how-do-i-set-up-two-factor-authentication-
 
     - name: Bitly
-      url: http://www.bitly.com/
+      url: https://bitly.com/
       twitter: bitly
       img: bitly.png
       tfa: Yes
@@ -35,7 +35,7 @@ websites:
       tfa: Yes
       sms: Yes
       software: Yes
-      doc: http://blog.bufferapp.com/introducing-the-safest-social-media-publishing-on-the-web
+      doc: https://blog.bufferapp.com/introducing-the-safest-social-media-publishing-on-the-web
 
     - name: Facebook
       url: https://facebook.com
@@ -53,7 +53,7 @@ websites:
       phone: Yes
       software: Yes
       hardware: Yes
-      doc: http://www.google.com/intl/en-US/landing/2step/features.html
+      doc: https://www.google.com/intl/en-US/landing/2step/features.html
 
     - name: HootSuite
       url: https://hootsuite.com
@@ -92,7 +92,7 @@ websites:
       doc: https://support.snapchat.com/ca/login-verification
 
     - name: Stack Exchange
-      url: http://stackexchange.com/
+      url: https://stackexchange.com/
       twitter: StackExchange
       img: stack_exchange.png
       tfa: No
@@ -125,7 +125,7 @@ websites:
       url: http://www.viadeo.com
       img: viadeo.png
       tfa: No
-      doc: http://www.viadeo.com/aide/security/
+      doc: https://www.viadeo.com/aide/security/
       twitter: Viadeo
       
     - name: VK
@@ -144,4 +144,4 @@ websites:
       software: Yes
       exceptions:
           text: "SMS-capable phone required."
-      doc: http://en.support.wordpress.com/security/two-step-authentication/
+      doc: https://en.support.wordpress.com/security/two-step-authentication/


### PR DESCRIPTION
If available, replacing http with https for URL of service and doc URL.
Additionally, if by default the page redirects from www to non-www, removing the www.
