### PR TITLE
Update CAcert status

### DIFF
--- a/_data/security.yml
+++ b/_data/security.yml
@@ -1,12 +1,12 @@
 websites:
     - name: CAcert
-      url: https://www.cacert.org/
+      url: http://www.cacert.org/
       twitter: CAcert_News
       img: cacert.png
       tfa: Yes
       hardware: Yes
       exceptions:
-          text: "Requires X.509-capable cryptotoken or smardcard."
+          text: "Requires X.509-capable cryptotoken or smartcard."
 
     - name: DigiCert
       url: http://www.digicert.com/

--- a/_data/security.yml
+++ b/_data/security.yml
@@ -3,7 +3,10 @@ websites:
       url: https://www.cacert.org/
       twitter: CAcert_News
       img: cacert.png
-      tfa: No
+      tfa: Yes
+      hardware: Yes
+      exceptions:
+          text: "Requires X.509-capable cryptotoken or smardcard."
 
     - name: DigiCert
       url: http://www.digicert.com/


### PR DESCRIPTION
This includes some information regarding 2FA support by CAcert.

2FA is not currently enforced on accounts but optional to be used. To be used a valid client certificate issued to that account must be available for which the "allow certificate login" flag is set.
