### PR TITLE
html-proofer 2.1.0 > 2.3.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,7 +47,7 @@ GEM
     html-pipeline (1.9.0)
       activesupport (>= 2)
       nokogiri (~> 1.4)
-    html-proofer (2.1.0)
+    html-proofer (2.3.0)
       addressable (~> 2.3)
       colored (~> 1.2)
       mercenary (~> 0.3.2)


### PR DESCRIPTION
Updating html-proofer to 2.3.0 apparently should fix the 403 errors that o' so often appear.
