### PR TITLE
Remove 2FA status for Lloyds Bank

### DIFF
--- a/_data/banking.yml
+++ b/_data/banking.yml
@@ -171,9 +171,7 @@ websites:
       url: http://www.lloydsbank.com/
       twitter: AskLloydsBank
       img: lloydsbank.png
-      tfa: Yes
-      phone: Yes
-      doc: http://www.lloydsbank.com/help-guidance/security/authentication-procedure.asp
+      tfa: No
 
     - name: Natwest UK
       url: https://www.natwest.com/personal.ashx


### PR DESCRIPTION
Their 2FA support is only for adding a new payee to your account, not for logging in to online banking.

Replaces PR #1042, see there for previous discussion.
