### PR TITLE
Trello announced support for 2FA

### DIFF
--- a/_data/other.yml
+++ b/_data/other.yml
@@ -148,8 +148,9 @@ websites:
       url: https://trello.com
       twitter: trello
       img: trello.png
-      tfa: No
-      status: https://trello.com/c/O6DrHazq/1532-two-factor-authentication
+      tfa: Yes
+      sms: Yes
+      doc: http://help.trello.com/article/993-enabling-two-factor-authentication-for-your-trello-account
 
     - name: US Internal Revenue Service
       url: http://www.irs.gov/Individuals/Get-Transcript


### PR DESCRIPTION
Currently limited to SMS

http://help.trello.com/article/993-enabling-two-factor-authentication-for-your-trello-account
