### PR TITLE
Add exception for Facebook

### DIFF
--- a/_data/social.yml
+++ b/_data/social.yml
@@ -43,6 +43,8 @@ websites:
       tfa: Yes
       sms: Yes
       software: Yes
+      exceptions:
+          text: "SMS required for 2FA. 1 account per phone number, 1 phone number per account."
       doc: https://www.facebook.com/help/148233965247823
 
     - name: Foursquare
@@ -116,7 +118,7 @@ websites:
       tfa: Yes
       sms: Yes
       exceptions:
-          text: "SMS only available on select providers, SMS required for 2FA, 1 account per phone number, 1 phone number per account"
+          text: "SMS only available on select providers. SMS required for 2FA. 1 account per phone number, 1 phone number per account."
       software: Yes
       doc: https://support.twitter.com/articles/20170388
 


### PR DESCRIPTION
Adds an exception stating how Facebook requires SMS and only supports one phone per account.
Also corrected punctuation for Twitter exception.
Closes #1181.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/jdavis/twofactorauth/1250)

<!-- Reviewable:end -->
