### PR TITLE
State that RiseUp does not support TFA

### DIFF
--- a/_data/email.yml
+++ b/_data/email.yml
@@ -85,8 +85,7 @@ websites:
       url: https://mail.riseup.net
       twitter: riseupnet
       img: riseup.png
-      tfa: Yes
-      software: Yes
+      tfa: No
       doc: https://help.riseup.net/en/email/webmail/2factorauth
 
     - name: Yahoo Mail


### PR DESCRIPTION
Hello!

This pull request ensures that RiseUp is displayed on twofactorauth.org as not currently supporting Two Factor Authentication, and affects issue #1263.

Thankyou!
psgs :palm_tree: 
