### PR TITLE
Origin now supports software based 2FA through Google Authenticator

### DIFF
--- a/_data/gaming.yml
+++ b/_data/gaming.yml
@@ -108,6 +108,7 @@ websites:
       tfa: Yes
       email: Yes
       sms: Yes
+      software: Yes
       doc: http://help.ea.com/en/article/origin-login-verification-information/
 
     - name: Playstation Network


### PR DESCRIPTION
Origin added Support for Google Authenticator together with renaming the Origin Accounts to EA Accounts.
