### PR TITLE
Dropbox has added U2F support

### DIFF
--- a/_data/backup.yml
+++ b/_data/backup.yml
@@ -61,6 +61,7 @@ websites:
     tfa: Yes
     sms: Yes
     software: Yes
+    hardware: Yes
     doc: https://www.dropbox.com/help/363/en
 
   - name: Evernote


### PR DESCRIPTION
Announced today, Dropbox has added support for U2F security keys. https://blogs.dropbox.com/dropbox/2015/08/u2f-security-keys/
