### PR TITLE
Add exception note for Dyn

### DIFF
--- a/_data/domains.yml
+++ b/_data/domains.yml
@@ -92,7 +92,7 @@ websites:
       sms: Yes
       software: Yes
       exceptions:
-        text: "Only supported for the Managed DNS service."
+        text: "Currently only supported for the Managed DNS & Email Delivery platforms (via DynID). Eventually DynID (and 2FA) will be rolled out to all platforms (no ETA)."
       doc: https://help.dyn.com/2-factor-authentication/
 
     - name: Dynadot

--- a/_data/domains.yml
+++ b/_data/domains.yml
@@ -91,6 +91,8 @@ websites:
       tfa: Yes
       sms: Yes
       software: Yes
+      exceptions:
+        text: "Only supported for the Managed DNS service."
       doc: https://help.dyn.com/2-factor-authentication/
 
     - name: Dynadot


### PR DESCRIPTION
Dyn only support 2FA on their Managed DNS service.
