### PR TITLE
Update Bitbucket

### DIFF
--- a/_data/developer.yml
+++ b/_data/developer.yml
@@ -34,6 +34,7 @@ websites:
       twitter: bitbucket
       img: bitbucket.png
       tfa: No
+      status: https://bitbucket.org/site/master/issues/5811/support-two-factor-authentication-bb-7016#comment-20910749
 
     - name: Cloud9
       url: https://c9.io


### PR DESCRIPTION
Bitbucket is planning on releasing “_an earlier, Bitbucket-only, multi-factor / two-step authentication implementation_” before September 30th. Source: https://bitbucket.org/site/master/issues/5811/support-two-factor-authentication-bb-7016#comment-20910749

Entire comment by Dan Bennett, 2015-08-14:

> A quick update from Bitbucket engineering:
> 
> An earlier, Bitbucket-only, multi-factor / two-step authentication implementation is being defrosted and readied for production release ahead of the launch of Atlassian SSO service. The ETA is currently less than six weeks and if the feature is not released by September 30th I will return to explain precisely why we failed to deliver (though, it is unlikely that I will have to do so).
> 
> Note: this will not be the final implementation and, as stated in comments above, there will be an Atlassian-wide two-step process rolled out that will supplant our version and provide expanded capabilities. This implementation will only serve to bridge the gap.
> 
> Thanks,
> 
> Dan Bennett, Bitbucket Development Manager
