### PR TITLE
Remove GoDaddy exception

### DIFF
--- a/_data/domains.yml
+++ b/_data/domains.yml
@@ -155,8 +155,6 @@ websites:
       tfa: yes
       sms: Yes
       doc: https://www.godaddy.com/help/enabling-two-step-authentication-for-your-godaddy-account-7502
-      exceptions:
-          text: "US numbers only"
 
     - name: Google Domains
       url: https://domains.google.com


### PR DESCRIPTION
Godaddy now allows TFA in (almost all countries in the world*)
http://domainnamewire.com/2015/08/27/godaddy-introduces-two-factor-authentication-outside-u-s/

I can confirm that GoDaddy TFA works in Sweden as I just enabled it.

> \* As there isn't a real black and white list of what nations really are countries it's hard to say that they allow it everywhere. They do however allow TFA in 185 countries which are about all countries\* that have internet access.
> So basically, if you live at "[Sealand](https://en.wikipedia.org/wiki/Principality_of_Sealand)" you're out of luck. However Seeland is just out of the coast of England so if you live there you probably have an English phone carrier and network provider.
