### PR TITLE
Bitbucket now has 2FA

### DIFF
--- a/_data/developer.yml
+++ b/_data/developer.yml
@@ -31,10 +31,10 @@ websites:
 
     - name: Bitbucket
       url: https://bitbucket.org
-      twitter: bitbucket
       img: bitbucket.png
-      tfa: No
-      status: https://bitbucket.org/site/master/issues/5811/support-two-factor-authentication-bb-7016#comment-20910749
+      tfa: Yes
+      software: Yes
+      doc: https://confluence.atlassian.com/x/425QLg
 
     - name: Cloud9
       url: https://c9.io


### PR DESCRIPTION
Bitbucket now has 2FA. This PR updates the Bitbucket entry to reflect this
- https://blog.bitbucket.org/2015/09/10/two-step-verification-is-here/
- https://confluence.atlassian.com/bitbucket/two-step-verification-777023203.html
