### PR TITLE
Remove travis_wait from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: ruby
+install: bundle install
 cache: bundler
-install: travis_wait bundle install
 rvm:
     - 2.1.1
 notifications:


### PR DESCRIPTION
Removed the `travis_wait` arg since that isn't really needed anyways.
