### PR TITLE
Add a column for account recovery documentation

### DIFF
--- a/_data/backup.yml
+++ b/_data/backup.yml
@@ -5,6 +5,7 @@ websites:
     software: Yes
     img: aerofs.png
     doc: https://blog.aerofs.com/two-factor-authentication-for-hybrid-and-private-cloud/
+    recovery: https://support.aerofs.com/hc/en-us/articles/202645974-How-Can-I-Recover-Access-To-My-Two-Factor-Authentication-Enabled-Account-
 
   - name: Apple iCloud
     url: https://www.icloud.com
@@ -15,6 +16,7 @@ websites:
     exceptions:
         text: "See http://support.apple.com/kb/HT5593 for a list of supported SMS carriers."
     doc: http://support.apple.com/kb/ht5570
+    recovery: https://support.apple.com/en-us/HT202649
 
   - name: Backblaze
     url: http://www.backblaze.com/
@@ -63,6 +65,7 @@ websites:
     software: Yes
     hardware: Yes
     doc: https://www.dropbox.com/help/363/en
+    recovery: https://www.dropbox.com/en/help/364
 
   - name: Evernote
     url: https://evernote.com
@@ -88,6 +91,7 @@ websites:
     software: Yes
     hardware: Yes
     doc: http://www.google.com/intl/en-US/landing/2step/features.html
+    recovery: https://support.google.com/accounts/answer/185834?hl=en#phone
 
   - name: IDrive
     url: https://www.idrive.com
@@ -177,6 +181,7 @@ websites:
     exceptions:
         text: "SMS-capable phone required for initial setup."
     doc: https://yandex.com/support/passport/authorization/twofa.xml
+    recovery: https://yandex.com/support/passport/authorization/twofa-restore.xml
 
   - name: Zetta.net
     url: http://zetta.net/

--- a/_data/banking.yml
+++ b/_data/banking.yml
@@ -45,6 +45,7 @@ websites:
       sms: Yes
       hardware: Yes
       doc: https://www.bankofamerica.com/privacy/online-mobile-banking-privacy/safepass.go
+      recovery: https://www.bankofamerica.com/privacy/faq/safepass-faq.go
 
     - name: Barclays
       url: http://www.barclays.co.uk/
@@ -53,6 +54,7 @@ websites:
       hardware: Yes
       software: Yes
       doc: https://ask.barclays.co.uk/help/security/protection
+      recovery: http://www.help.barclays.co.uk/faq/mobile-banking/using-mobile-banking/new-lost-phone.html
 
     - name: Barclays US
       url: https://www.banking.barclaysus.com/index.html
@@ -122,6 +124,7 @@ websites:
       exceptions:
             text: "Available only for credit cards, not for savings accounts. By providing your phone number, you are automatically opted in."
       doc: https://www.discover.com/credit-cards/help-center/faqs/enhancing-account-security.html
+      recovery: https://www.discover.com/credit-cards/help-center/faqs/enhancing-account-security.html#q11
 
     - name: everbank.com
       url: https://everbank.com
@@ -173,6 +176,7 @@ websites:
       hardware: Yes
       software: Yes
       doc: https://www.hsbc.co.uk/1/2/customer-support/online-banking-security/secure-key
+      recovery: https://www.hsbc.co.uk/1/2/internet-banking-support/lost-your-details
 
     - name: Intesa Sanpaolo
       url: https://www.intesasanpaolo.com

--- a/_data/cloud.yml
+++ b/_data/cloud.yml
@@ -130,7 +130,8 @@ websites:
       tfa: Yes
       sms: Yes
       doc: https://www.packet.net/help/kb/account-management-and-billing/how-do-i-enable-two-factor-authentication-/
-    
+      recover: https://twitter.com/packethost/status/650398426731970560   
+ 
     - name: Rackspace
       url: https://www.rackspace.com/
       img: rackspace.png

--- a/_data/cloud.yml
+++ b/_data/cloud.yml
@@ -130,7 +130,7 @@ websites:
       tfa: Yes
       sms: Yes
       doc: https://www.packet.net/help/kb/account-management-and-billing/how-do-i-enable-two-factor-authentication-/
-      recover: https://twitter.com/packethost/status/650398426731970560   
+      recover: https://www.packet.net/help/kb/account-management-and-billing/how-do-i-enable-two-factor-authentication-/ 
  
     - name: Rackspace
       url: https://www.rackspace.com/

--- a/_data/cloud.yml
+++ b/_data/cloud.yml
@@ -7,6 +7,7 @@ websites:
       software: Yes
       hardware: Yes
       doc: http://aws.amazon.com/iam/details/mfa/
+      recovery: http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_mfa_lost-or-broken.html
 
     - name: appFog
       url: https://www.appfog.com/
@@ -54,6 +55,7 @@ websites:
       exceptions:
           text: "Currently in beta as of June 5th 2014. Create a support ticket to request 2FA added to your organization"
       doc: https://support.cloud.engineyard.com/entries/40538256-Two-factor-authentication
+      recovery: https://support.cloud.engineyard.com/hc/communities/public/questions/203752678-Two-factor-authentication
 
     - name: fortrabbit
       url: http://www.fortrabbit.com/
@@ -73,6 +75,7 @@ websites:
       phone: Yes
       hardware: Yes
       doc: http://www.google.com/intl/en-US/landing/2step/features.html
+      recovery: https://support.google.com/accounts/answer/185834?hl=en#phone
 
     - name: Heroku
       url: https://www.heroku.com/
@@ -81,6 +84,7 @@ websites:
       tfa: Yes
       software: Yes
       doc: https://devcenter.heroku.com/articles/two-factor-authentication
+      recovery: https://devcenter.heroku.com/articles/two-factor-authentication#recovering-from-lock-out
 
     - name: HP Cloud
       url: https://www.hpcloud.com/
@@ -101,6 +105,7 @@ websites:
       tfa: Yes
       software: Yes
       doc: https://www.linode.com/docs/security/linode-manager-security-controls 
+      recovery: https://www.linode.com/docs/security/linode-manager-security-controls
 
     - name: Microsoft Azure
       url: http://azure.microsoft.com/
@@ -110,6 +115,7 @@ websites:
       phone: Yes
       software: Yes
       doc: http://msdn.microsoft.com/en-us/library/azure/dn249471.aspx
+      recovery: https://azure.microsoft.com/en-us/documentation/articles/multi-factor-authentication-faq/
 
     - name: OpenShift
       url: https://www.openshift.com/
@@ -131,6 +137,7 @@ websites:
       tfa: Yes
       sms: Yes
       doc: http://www.rackspace.com/knowledge_center/article/multi-factor-authentication-from-the-cloud-control-panel
+      recovery: http://www.rackspace.com/knowledge_center/article/multi-factor-authentication-from-the-cloud-control-panel#troubleshoot
 
     - name: RightScale
       url: http://www.rightscale.com/
@@ -144,6 +151,7 @@ websites:
       tfa: Yes
       software: Yes
       doc: https://scalr-wiki.atlassian.net/wiki/display/docs/Two-Factor+Authentication
+      recovery: https://scalr-wiki.atlassian.net/wiki/display/docs/Resetting+Two-Factor+Authentication
 
     - name: SingleHop
       url: http://www.singlehop.com

--- a/_data/communication.yml
+++ b/_data/communication.yml
@@ -5,6 +5,7 @@ websites:
       tfa: Yes
       sms: Yes
       doc: https://basecamp.com/help/guides/you/phone-verification
+      recovery: https://basecamp.com/help/guides/you/phone-verification
 
     - name: Campfire
       url: https://campfirenow.com/
@@ -12,6 +13,7 @@ websites:
       tfa: Yes
       sms: Yes
       doc: https://help.37signals.com/sign-in/questions/460-how-do-i-set-up-and-use-phone-verification-for-logging-in
+      recovery: https://help.37signals.com/sign-in/questions/460-how-do-i-set-up-and-use-phone-verification-for-logging-in
 
     - name: Customer.io
       url: http://customer.io
@@ -45,6 +47,7 @@ websites:
       software: Yes
       hardware: Yes
       doc: https://blog.mailchimp.com/alterego-integrations-for-easy-authentication/
+      recovery: http://kb.mailchimp.com/accounts/management/i-cant-log-in
 
     - name: Mailgun
       url: https://mailgun.com
@@ -74,6 +77,7 @@ websites:
       software: Yes
       email: Yes
       doc: https://help.salesforce.com/HTViewHelpDoc?id=security_require_two_factor_authentication.htm
+      recovery: https://help.salesforce.com/HTViewHelpDoc?id=security_removing_two_factor_key.htm
 
     - name: SendGrid
       url: https://sendgrid.com/
@@ -88,6 +92,7 @@ websites:
       tfa: Yes
       software: Yes
       doc: http://app.sendloop.com/help/article/account-003/how-can-i-make-my-account-more-secure
+      recovery: http://app.sendloop.com/help/article/account-003/how-can-i-make-my-account-more-secure
 
     - name: Skype (via Microsoft Account)
       url: https://www.skype.com
@@ -105,6 +110,7 @@ websites:
       tfa: Yes
       software: Yes
       doc: https://slack.zendesk.com/hc/en-us/articles/204509068-Enabling-two-factor-authentication
+      recovery: https://slack.zendesk.com/hc/en-us/articles/204509068-Enabling-two-factor-authentication
 
     - name: SocketLabs
       url: https://socketlabs.com/

--- a/_data/developer.yml
+++ b/_data/developer.yml
@@ -97,6 +97,7 @@ websites:
       sms: Yes
       software: Yes
       doc: https://help.github.com/articles/about-two-factor-authentication
+      recovery: https://help.github.com/articles/recovering-your-account-if-you-lost-your-2fa-credentials/
 
     - name: GitLab
       url: https://gitlab.com
@@ -135,6 +136,7 @@ websites:
       tfa: Yes
       software: Yes
       doc: https://help.ubuntu.com/community/SSO/FAQs/2FA
+      recovery: https://help.ubuntu.com/community/SSO/FAQs/2FA#No.2C_I.27m_really_locked_out_of_my_account.__What_should_I_do.3F
 
     - name: Looker
       url: http://looker.com/

--- a/index.html
+++ b/index.html
@@ -38,6 +38,7 @@ hash: SupportTwoFactorAuth
                             <th>Email</th>
                             <th>Hardware Token</th>
                             <th>Software Implementation</th>
+			    <th>Account Recovery</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -110,6 +111,12 @@ hash: SupportTwoFactorAuth
                                                 <i class="checkmark large icon"></i>
                                             {% endif %}
                                             </td>
+
+					    <td class="positive icon">
+					    {% if website.recovery %}
+						<a href="{{ website.recovery }}"><i class="external url link large icon"></i></a>
+				    	    {% endif %}
+					    </td>
                                         </tr>
                                         {% else %}
                                             <td class="main negative">
@@ -127,7 +134,7 @@ hash: SupportTwoFactorAuth
                                             {% endif %}
                                             </td>
                                             {% if website.twitter %}
-                                                <td class="twitter main negative" colspan="6">
+                                                <td class="twitter main negative" colspan="7">
                                                 {% if website.status %}
                                                     <a class="ui twitter mini button" href="https://twitter.com/share?url={{site.url|cgi_escape}}&amp;text={{page.tweet_progress|replace:'TWITTERHANDLE',website.twitter|cgi_escape}}&amp;hashtags={{page.hash|cgi_escape}}" target="_blank"><i class="twitter icon"></i> {{page.link_progress}}</a>
                                                 {% else %}
@@ -141,6 +148,7 @@ hash: SupportTwoFactorAuth
                                                 <td class="negative icon"><i class="remove large icon"></i></td>
                                                 <td class="negative icon"><i class="remove large icon"></i></td>
                                                 <td class="negative icon"><i class="remove large icon"></i></td>
+						<td class="negative icon"><i class="remove large icon"></i></td>
                                             {% endif %}
                                         {% endif %}
                                 {% endif %}


### PR DESCRIPTION
Two-factor authentication is great until you lose the device. I wanted to help users get through the recovery process faster by specifically linking to the recovery documentation for the different services.
