### PR TITLE
Semantic-UI Update Fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,9 @@ source 'https://rubygems.org'
 
 # Freeze to GitHub Pages versions:
 #   https://pages.github.com/versions/
-gem 'github-pages', '~> 28'
+gem 'github-pages', '~> 39'
 gem 'jekyll', '~> 2.4.0'
-gem 'kramdown', '~> 1.3.1'
+gem 'kramdown', '~> 1.5.0'
 
 group :test do
   gem 'rake'

--- a/css/base.css
+++ b/css/base.css
@@ -142,9 +142,7 @@ td img.icon {
   .ui.segment.teal {
     margin: 0 5%;
   }
-}
-
-@media (min-width: 1199px) {
+  
   .ui.grid.container {
     width: 65% !important;
   }


### PR DESCRIPTION
Hello!

This pull request updates the versions of Gems used for integrating with GitHub Pages and ensures that the width of the central column on the main page conforms to 65% when the page width reaches `757px`.

Thankyou,
psgs :palm_tree: 
