### PR TITLE
Remove Schwab doc link

### DIFF
--- a/_data/investing.yml
+++ b/_data/investing.yml
@@ -10,7 +10,6 @@ websites:
       img: charlesschwab.png
       tfa: Yes
       hardware: Yes
-      doc: http://www.schwab.com/public/schwab/nn/legal_compliance/schwabsafe/protect_your_account
 
     - name: E*Trade
       url: https://www.etrade.com/


### PR DESCRIPTION
After some hair-ripping moments with their support I can confirm that Schwab doesn't have a valid doc link about their hardware token.

This closes #1270.
