### PR TITLE
Align site names to the right of icons

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -64,6 +64,24 @@ p {
   box-shadow: none;
 }
 
+.ui.table td {
+  margin: 0.722em;
+  padding: 0;
+}
+
+.ui.table td.main {
+  padding: 0.85em 0.75em;
+}
+
+.ui.table td.main img {
+  display: inline-block;
+}
+
+.ui.table td.main img + a {
+  display: inline-block;
+  width: 50%;
+}
+
 .ui.table td.icon {
   text-align: center;
 }
@@ -87,21 +105,21 @@ td a {
 }
 
 .ui.table td.twitter a,
-.ui.table span.progress a{
+.ui.table span.progress a {
   font-size: 0.8rem;
   text-transform: uppercase;
 }
 
 td img.icon {
-  float: left;
-  border-radius: 50%;
-  padding: 4px 4px;
   -webkit-box-shadow: 0 0 0 .1em rgba(0, 0, 0, .1) inset;
   box-shadow: 0 0 0 .1em rgba(0, 0, 0, .1) inset;
-  line-height: 1;
-  margin-right: 8px;
   background-color: white;
-  height: 32px;
+  border-radius: 50%;
+  float: left;
+  padding: 4px 4px;
+  height: 2em;
+  line-height: 1;
+  margin-right: 0.8em;
 }
 
 .ui.table tr.positive td,
@@ -147,7 +165,7 @@ td img.icon {
   .ui.segment.teal {
     margin: 0 5%;
   }
-  
+
   .ui.grid.container {
     width: 65% !important;
   }

--- a/index.html
+++ b/index.html
@@ -68,8 +68,8 @@ hash: SupportTwoFactorAuth
                                         {% if website.tfa %}
                                             <td class="main positive">
                                             {% if website.img %}
-                                                <img src="/img/placeholder.png" data-src="/img/{{ section.id }}/{{ website.img }}" class="icon" alt="{{ website.name }}">
                                                 <noscript><img src="/img/{{ section.id }}/{{ website.img }}" class="icon" alt="{{ website.name }}"></noscript>
+                                                <img src="/img/placeholder.png" data-src="/img/{{ section.id }}/{{ website.img }}" class="icon" alt="{{ website.name }}">
                                             {% endif %}
                                                 <a href="{{ website.url }}">{{ website.name }}</a>
                                                 {% include exception.html website=website %}
@@ -114,8 +114,8 @@ hash: SupportTwoFactorAuth
                                         {% else %}
                                             <td class="main negative">
                                             {% if website.img %}
-                                                <img src="/img/placeholder.png" data-src="/img/{{ section.id }}/{{ website.img }}" class="icon" alt="{{ website.name }}">
                                                 <noscript><img src="/img/{{ section.id }}/{{ website.img }}" class="icon" alt="{{ website.name }}"></noscript>
+                                                <img src="/img/placeholder.png" data-src="/img/{{ section.id }}/{{ website.img }}" class="icon" alt="{{ website.name }}">
                                             {% endif %}
                                                 <a href="{{ website.url }}">{{ website.name }}</a>
                                             {% if website.status %}
@@ -127,7 +127,7 @@ hash: SupportTwoFactorAuth
                                             {% endif %}
                                             </td>
                                             {% if website.twitter %}
-                                                <td class="twitter main negative" colspan="6">
+                                                <td class="twitter negative" colspan="6">
                                                 {% if website.status %}
                                                     <a class="ui twitter mini button" href="https://twitter.com/share?url={{site.url|cgi_escape}}&amp;text={{page.tweet_progress|replace:'TWITTERHANDLE',website.twitter|cgi_escape}}&amp;hashtags={{page.hash|cgi_escape}}" target="_blank"><i class="twitter icon"></i> {{page.link_progress}}</a>
                                                 {% else %}


### PR DESCRIPTION
Hello!

This pull request ensures that text is not displayed in a fashion that surrounds a particular icon in the website name column of TwoFactorAuth's main table.
This pull request also affects issue #1360.

At the moment, this pull request does not place the "In Progress" button in-line with a cell's text.

Thanks,
psgs :palm_tree: 
