### PR TITLE
Remove non-available options from Paypal

### DIFF
--- a/_data/payments.yml
+++ b/_data/payments.yml
@@ -71,8 +71,8 @@ websites:
       img: paypal.png
       tfa: Yes
       sms: Yes
-      software: Yes
-      hardware: Yes
+      software: No
+      hardware: No
       exceptions:
           text: "2FA is only available in the United States, Canada, United Kingdom, Germany, Austria and Australia."
       doc: https://www.paypal.com/us/cgi-bin?cmd=xpt/Marketing_CommandDriven/securitycenter/PayPalSecurityKey-outside&bn_r=o


### PR DESCRIPTION
As best I can find, PayPal only supports SMS based MFA. The wording all over their site makes it sound like they are geared up for other options such as an OTP app or hardware keys, but nowhere can you actually setup anything but SMS based authentication.
