### PR TITLE
Add note of Blizzard's "hardware token" support

### DIFF
--- a/_data/gaming.yml
+++ b/_data/gaming.yml
@@ -16,7 +16,7 @@ websites:
       hardware: Yes
       doc: http://us.battle.net/en/security/
       exceptions:
-          text: "Hardware token refers only to Blizzard's own physical \"Battle.net Authenticator\" device. They do not support U2F or any other physical tokens."
+          text: "Hardware token refers only to Blizzard's own physical Battle.net Authenticator device. They do not support U2F or any other physical tokens."
 
     - name: Desura
       url: http://www.desura.com/

--- a/_data/gaming.yml
+++ b/_data/gaming.yml
@@ -15,6 +15,8 @@ websites:
       software: Yes
       hardware: Yes
       doc: http://us.battle.net/en/security/
+      exceptions:
+          text: "Hardware token refers only to Blizzard's own physical \"Battle.net Authenticator\" device. They do not support U2F."
 
     - name: Desura
       url: http://www.desura.com/

--- a/_data/gaming.yml
+++ b/_data/gaming.yml
@@ -16,7 +16,7 @@ websites:
       hardware: Yes
       doc: http://us.battle.net/en/security/
       exceptions:
-          text: "Hardware token refers only to Blizzard's own physical \"Battle.net Authenticator\" device. They do not support U2F."
+          text: "Hardware token refers only to Blizzard's own physical \"Battle.net Authenticator\" device. They do not support U2F or any other physical tokens."
 
     - name: Desura
       url: http://www.desura.com/


### PR DESCRIPTION
Blizzard doesn't support the new U2F standard, or any other hardware device other than their own physical authenticator. With the new standard, it's bound to confuse some people (like me), so perhaps a small note can be added to clarify this.
