### PR TITLE
Add section.id as a real DIV id for deeplinks

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@ hash: SupportTwoFactorAuth
         <div class="column">
 
         {% for section in site.data.main.sections %}
-            <div class="section">
+            <div class="section" id="{{ section.id }}">
                 <table class="ui celled unstackable table">
                     <thead>
                         <tr>

--- a/index.html
+++ b/index.html
@@ -150,7 +150,7 @@ hash: SupportTwoFactorAuth
                 </table>
 
             {% unless forloop.last %}
-                <div class="ui divider" id="{{ site.data.main.sections[forloop.index].id }}" ></div>
+                <div class="ui divider"></div>
             {% endunless %}
             </div><!-- Section -->
         {% endfor %}


### PR DESCRIPTION
Right now, it's a little difficult to share a link to someone else, due to the lack of deeplinks.

With this pull request, I can send my friend a link along the lines of, "Hey friend, check out https://twofactorauth.org/#banking and see if your bank is on the list!"

Without deeplinks, I have to tell them to go to tfa.org, then scroll down or Ctrl-F for "banking."

![Ain't nobody got time for that.](https://i.imgur.com/lSPykCQ.jpg)
