### PR TITLE
Add exception for amazon retail (amazon uk does not support)

### DIFF
--- a/_data/retail.yml
+++ b/_data/retail.yml
@@ -5,6 +5,8 @@ websites:
       tfa: Yes
       software: Yes
       sms: Yes
+      exceptions:
+          text: "Amazon retail only supports 2FA in some countries."
       doc: https://www.amazon.com/gp/help/customer/display.html?nodeId=201596330
 
     - name: Apple


### PR DESCRIPTION
As per title - amazon.co.uk does not support 2fa (I suspect only amazon.com/US does)
