### PR TITLE
Twitch.tv now supports two factor authentication

### DIFF
--- a/_data/entertainment.yml
+++ b/_data/entertainment.yml
@@ -55,9 +55,11 @@ websites:
 
     - name: Twitch
       url: http://www.twitch.tv/
-      twitter: TwitchSupport
       img: twitch.png
-      tfa: No
+      tfa: Yes
+      sms: Yes
+      software: Yes
+      doc: http://blog.twitch.tv/2015/11/two-factor-authentication-now-available-on-your-twitch-account/
 
     - name: Ustream
       url: http://www.ustream.tv/


### PR DESCRIPTION
Finally! Twitch.tv now supports TFA for all users (not just Twitch-partners).
They use Authy but with phone calls turned off.

Now let's try and get them to use https... :unamused:
