### PR TITLE
Options house no longer supports Two Factor Authentication 

### DIFF
--- a/_data/investing.yml
+++ b/_data/investing.yml
@@ -70,6 +70,7 @@ websites:
       img: optionshouse.png
       url: https://www.optionshouse.com
       tfa: No
+      twitter: OptionsHouse
 
     - name: OptionsXpress
       url: http://www.optionsxpress.com/

--- a/_data/investing.yml
+++ b/_data/investing.yml
@@ -69,9 +69,7 @@ websites:
     - name: OptionsHouse
       img: optionshouse.png
       url: https://www.optionshouse.com
-      tfa: Yes
-      software: Yes
-      doc: https://www.optionshouse.com/faq/authenticator/
+      tfa: No
 
     - name: OptionsXpress
       url: http://www.optionsxpress.com/


### PR DESCRIPTION
Options house no longer supports Two Factor Authentication since their merger with trade monster.
