### PR TITLE
twitter: Include note about mobile app

### DIFF
--- a/_data/social.yml
+++ b/_data/social.yml
@@ -108,7 +108,7 @@ websites:
       tfa: Yes
       sms: Yes
       exceptions:
-          text: "SMS only available on select providers. SMS required for 2FA. 1 account per phone number, 1 phone number per account."
+          text: "SMS only available on select providers. SMS required for 2FA setup, but Twitter mobile app push approvals can be used as primary after setup. 1 account per phone number, 1 phone number per account."
       software: Yes
       doc: https://support.twitter.com/articles/20170388
 


### PR DESCRIPTION
Twitter's mobile app can function as the primary 2FA via push-based approvals, though to set it up, it's still necessary to set up a mobile number.
