### PR TITLE
Add note about Amazon

### DIFF
--- a/_data/retail.yml
+++ b/_data/retail.yml
@@ -5,6 +5,8 @@ websites:
       tfa: Yes
       software: Yes
       sms: Yes
+      exceptions:
+          text: "Software token requires backup phone number for voice call or SMS"
       doc: https://www.amazon.com/gp/help/customer/display.html?nodeId=201596330
 
     - name: Apple

--- a/_data/retail.yml
+++ b/_data/retail.yml
@@ -6,7 +6,7 @@ websites:
       software: Yes
       sms: Yes
       exceptions:
-          text: "Software token requires backup phone number for voice call or SMS"
+          text: "SMS/Phone Call required for 2FA"
       doc: https://www.amazon.com/gp/help/customer/display.html?nodeId=201596330
 
     - name: Apple


### PR DESCRIPTION
I think this is relevant because many people prefer software tokens because they **don't** have to share their phone number with the vendor.
Most of (all?) the other sites do not require this extra step and provide a set of backup tokens instead.

![screenshot](https://i.imgur.com/GQRaMxB.png)
