### PR TITLE
Remove HP Cloud

### DIFF
--- a/_data/cloud.yml
+++ b/_data/cloud.yml
@@ -78,12 +78,6 @@ websites:
       software: Yes
       doc: https://devcenter.heroku.com/articles/two-factor-authentication
 
-    - name: HP Cloud
-      url: https://www.hpcloud.com/
-      twitter: hpcloud
-      img: hp.png
-      tfa: No
-
     - name: Joyent
       url: http://www.joyent.com/
       img: joyent.png


### PR DESCRIPTION
HP Cloud is being discontinued as a product in the next couple months. There is no reason to push them for 2FA or expect that they will ever have it.
