### PR TITLE
Launchpad hardware token support 

### DIFF
--- a/_data/developer.yml
+++ b/_data/developer.yml
@@ -154,6 +154,7 @@ websites:
       url: https://launchpad.net
       img: launchpad.png
       tfa: Yes
+      hardware: Yes
       software: Yes
       doc: https://help.ubuntu.com/community/SSO/FAQs/2FA
 


### PR DESCRIPTION
Launchpad supports yubikey and feitian hw tokens. https://help.ubuntu.com/community/SSO/FAQs/2FA#Yubikey, https://help.ubuntu.com/community/SSO/FAQs/2FA#Feitian_OTP_c100
