### PR TITLE
Twitter now allows 10 accounts per phone number

### DIFF
--- a/_data/social.yml
+++ b/_data/social.yml
@@ -108,7 +108,7 @@ websites:
       tfa: Yes
       sms: Yes
       exceptions:
-          text: "SMS only available on select providers. SMS required for 2FA. 1 account per phone number, 1 phone number per account."
+          text: "SMS only available on select providers. SMS required for 2FA. 10 accounts per phone number, 1 phone number per account."
       software: Yes
       doc: https://support.twitter.com/articles/20170388
 


### PR DESCRIPTION
Twitter has updated their two-factor authentication policies to allow up to ten Twitter accounts to use a single device for 2FA.

Reference doc for new policy mentioning the newly raised account limit: https://support.twitter.com/articles/110250

I now have several of my Twitter accounts successfully using a single iPhone for 2FA.
