### PR TITLE
Add NetBenefits Exception to Fidelity

### DIFF
--- a/_data/investing.yml
+++ b/_data/investing.yml
@@ -25,6 +25,8 @@ websites:
       tfa: Yes
       software: Yes
       hardware: Yes
+      exceptions:
+        text: "NetBenefits not supported (e.g. employer sponsored 401k/403b)."
       doc: /notes/fidelity/
 
     - name: HealthEquity


### PR DESCRIPTION
NetBenefits users do not get to use the two factor auth (tried to set up this week and was told no -- worse I have to send land mail to complain).
