### PR TITLE
Add exception note to Fidelity

### DIFF
--- a/_data/investing.yml
+++ b/_data/investing.yml
@@ -25,6 +25,8 @@ websites:
       tfa: Yes
       software: Yes
       hardware: Yes
+      exceptions:
+          text: "Only available for some account types"
       doc: /notes/fidelity/
 
     - name: HealthEquity

--- a/notes/fidelity.html
+++ b/notes/fidelity.html
@@ -21,6 +21,12 @@ layout: default
     </p>
 
     <p>
+        Fidelity only offers 2FA on certain account types. For example, they
+        do not support it for institutional retirement accounts of the kind
+        that might be set up through an employer.
+    </p>
+
+    <p>
         It appears there is no information about this service provided
         online and it must be enabled and managed by phone.
     </p>


### PR DESCRIPTION
I just sat on hold for half an hour with Fidelity phone support, following the instructions from https://twofactorauth.org/notes/fidelity/. Finally they told me that 2FA is only available for "personal investment accounts," not "institutional accounts," like the one I have for my 403b retirement plan.
