### PR TITLE
Fix ID Linkage Collision with header. Add Titles to Icons. Remove Border Radius from Nav.

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -26,6 +26,10 @@ p {
   z-index: 1;
 }
 
+.ui.inverted.teal.menu {
+  border-radius: 0;
+}
+
 .ui.dropdown .menu.visible {
   max-height: 90vh;
   overflow-y: scroll;

--- a/css/base.css
+++ b/css/base.css
@@ -4,6 +4,10 @@ img { border: none; }
 ul { list-style: none; }
 a { color: #009FDA; text-decoration: none; }
 
+.section {
+  padding-top: 52px;
+}
+
 body {
   font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
   color: #505050;
@@ -45,7 +49,7 @@ p {
 
 .ui.center.aligned.header {
   display: block;
-  margin: 100px auto 40px auto;
+  margin: 100px auto 0 auto;
 }
 
 .ui.menu .item:before {
@@ -157,7 +161,7 @@ td img.icon {
 }
 
 .ui.divider {
-  margin: 2em 0;
+  margin: 52px 0 0 0;
 }
 
 .ui.popup > .content {

--- a/index.html
+++ b/index.html
@@ -86,31 +86,31 @@ hash: SupportTwoFactorAuth
 
                         <td class="positive icon">
                           {% if website.sms %}
-                          <i class="checkmark large icon"></i>
+                          <i class="checkmark large icon" title="SMS"></i>
                           {% endif %}
                         </td>
 
                         <td class="positive icon">
                           {% if website.phone %}
-                          <i class="checkmark large icon"></i>
+                          <i class="checkmark large icon" title="Phone"></i>
                           {% endif %}
                         </td>
 
                         <td class="positive icon">
                           {% if website.email %}
-                          <i class="checkmark large icon"></i>
+                          <i class="checkmark large icon" title="Email"></i>
                           {% endif %}
                         </td>
 
                         <td class="positive icon">
                           {% if website.hardware %}
-                          <i class="checkmark large icon"></i>
+                          <i class="checkmark large icon" title="Hardware Token"></i>
                           {% endif %}
                         </td>
 
                         <td class="positive icon">
                           {% if website.software %}
-                          <i class="checkmark large icon"></i>
+                          <i class="checkmark large icon" title="Software Token"></i>
                           {% endif %}
                         </td>
                       {% else %}


### PR DESCRIPTION
First off, thank you all for making this site. I've been using it to influence my banking choices. 

Anyways I've pushed three commits here.
- Anytime you link to a section via an id, like https://twofactorauth.org/#banking, the nav is cutting off the table header. I've adding some padding equal to the height of the nav to remedy this. I'm happy to make this a round value, or use em or something. Let me know.
- When far down a list you can sometimes lose track of what column is which. I've added titles to each icon that represents each column which should be useful.
- There was some border radius on the menu that doesn't look too good for a full width fixed nav, so I removed it.

I'm happy to remove/add/tweak any of the commits just let me know. And once again, thank you all for making this, it's awesome and I'm glad something like this exists. 

Thanks!
