### PR TITLE
Set table column widths for desktop

### DIFF
--- a/_includes/desktop-table.html
+++ b/_includes/desktop-table.html
@@ -4,13 +4,13 @@
   <table class="ui celled table content-wrapper">
     <thead>
     <tr>
-      <th class="single line"><h3>{{ section.title }}</h3></th>
-      <th>Docs</th>
-      <th>SMS</th>
-      <th>Phone Call</th>
-      <th>Email</th>
-      <th>Hardware Token</th>
-      <th>Software Token</th>
+      <th class="single line four wide"><h3>{{ section.title }}</h3></th>
+      <th class="two wide">Docs</th>
+      <th class="two wide">SMS</th>
+      <th class="two wide">Phone Call</th>
+      <th class="two wide">Email</th>
+      <th class="two wide">Hardware Token</th>
+      <th class="two wide">Software Token</th>
     </tr>
     </thead>
     <tbody class="jets-content">


### PR DESCRIPTION
Set table widths so that they're fixed, not dependent on table content.

Before:
![screen shot 2016-01-17 at 1 33 32 pm](https://cloud.githubusercontent.com/assets/867840/12376320/971adc44-bd1f-11e5-81fc-05ef946bc6f7.png)

After:
![screen shot 2016-01-17 at 1 26 20 pm](https://cloud.githubusercontent.com/assets/867840/12376305/d3d3ee06-bd1e-11e5-9c78-d145c307bafb.png)

I'm using Semantics' 16 grid system. I can change them to `px` widths to be more flexible if you guys prefer that.
