### PR TITLE
ProtonMail has announced that they are working on 2fa and plan to sup…

### DIFF
--- a/_data/email.yml
+++ b/_data/email.yml
@@ -86,10 +86,11 @@ websites:
       doc: https://posteo.de/en/help/what-is-two-factor-authentication-and-how-do-i-set-it-up
 
     - name: ProtonMail
-      url: https://protonmail.ch/
+      url: https://protonmail.com/
       twitter: ProtonMail
       img: protonmail.png
       tfa: No
+      status: https://protonmail.com/blog/secure-email-roadmap/
 
     - name: Riseup Mail
       url: https://mail.riseup.net


### PR DESCRIPTION
…port

it in 2016. They also changed their primary domain from protonmail.ch to
protonmail.com. This commit updates their URL, 2fa status, and links to
their 2016 Security Roadmap blog post (where they commit to 2fa support).
