### PR TITLE
Test more tags in the YAML files

### DIFF
--- a/_data/banking.yml
+++ b/_data/banking.yml
@@ -46,7 +46,7 @@ websites:
       hardware: Yes
       doc: https://www.bankofamerica.com/privacy/online-mobile-banking-privacy/safepass.go
 
-    - name: Barclays
+    - name: Barclays UK
       url: http://www.barclays.co.uk/
       img: barclays.png
       tfa: Yes
@@ -61,7 +61,6 @@ websites:
       sms: Yes
       phone: Yes
       email: Yes
-      twitter: Barclays
 
     - name: BMO Harris Bank
       url: https://www.bmoharris.com/

--- a/_data/developer.yml
+++ b/_data/developer.yml
@@ -170,8 +170,6 @@ websites:
       img: looker.png
       tfa: Yes
       software: Yes
-      sms: No
-      phone: No
       doc: http://www.looker.com/docs/admin/security/two-factor-authentication
 
     - name: Mapbox

--- a/_data/email.yml
+++ b/_data/email.yml
@@ -109,7 +109,6 @@ websites:
       url: https://mail.yahoo.co.jp/
       img: yahoojapanmail.png
       tfa: Yes
-      sms: No
       email: Yes
       software: Yes
       doc: http://id.yahoo.co.jp/security/otp.html

--- a/_data/finance.yml
+++ b/_data/finance.yml
@@ -104,7 +104,6 @@ websites:
 
     - name: Quickbooks Online
       url: http://www.quickbooks.com
-      twitter: quickbooks
       img: quickbooks.png
       tfa: Yes
       sms: Yes
@@ -152,7 +151,6 @@ websites:
 
     - name: Xero
       url: https://www.xero.com/
-      twitter: Xero
       img: xero.png
       tfa: Yes
       software: Yes

--- a/_data/hosting.yml
+++ b/_data/hosting.yml
@@ -203,7 +203,6 @@ websites:
 
     - name: WebFaction
       url: https://www.webfaction.com
-      twitter: webfaction
       img: webfaction.png
       tfa: Yes
       software: Yes

--- a/_data/social.yml
+++ b/_data/social.yml
@@ -77,7 +77,6 @@ websites:
 
     - name: Medium
       url: https://medium.com
-      twitter: medium
       img: medium.png
       tfa: Yes
       email: Yes

--- a/verify.rb
+++ b/verify.rb
@@ -5,7 +5,7 @@ $output=0;
 begin
   def error(msg)
     $output=$output+1;
-    if($output == 1)
+    if ($output == 1)
       puts "<------------ ERROR ------------>\n"
     end
     puts "#{$output}. #{msg}"
@@ -19,26 +19,32 @@ begin
     data = YAML.load_file('_data/' + section[1]['id'] + '.yml')
 
     data['websites'].each do |website|
+      tfa = "#{website['tfa']}"
+      if (tfa != 'true' && tfa != 'false')
+        error("#{website['name']} 'tfa' should be either 'Yes' or 'No' #{tfa}");
+      end
+
       image = "img/#{section[1]['id']}/#{website['img']}"
 
       unless File.exists?(image)
         error("#{website['name']} image not found.")
-      end
+      else
 
-      image_dimensions = [32,32]
+        image_dimensions = [32, 32]
 
-      unless FastImage.size(image) == image_dimensions
-        error("#{image} is not #{image_dimensions.join("x")}")
-      end
+        unless FastImage.size(image) == image_dimensions
+          error("#{image} is not #{image_dimensions.join("x")}")
+        end
 
-      ext = ".png"
-      unless File.extname(image) == ext
-        error("#{image} is not #{ext}")
+        ext = ".png"
+        unless File.extname(image) == ext
+          error("#{image} is not #{ext}")
+        end
       end
     end
   end
 
-  if($output > 0 )
+  if ($output > 0)
     exit 1
   end
 rescue Psych::SyntaxError => e

--- a/verify.rb
+++ b/verify.rb
@@ -2,6 +2,7 @@
 require 'yaml'
 require 'fastimage'
 $output=0;
+$ignore_twitter=0;
 begin
 
   # Send error message
@@ -15,17 +16,36 @@ begin
 
   # Verify that the tfa factors are booleans
   def check_tfa(website)
-    $tfa_forms = ['email', 'hardware', 'software', 'sms', 'phone']
-    for i in 0..($tfa_forms.length-1)
-      form = website[$tfa_forms[i]]
+    tfa_forms = ['email', 'hardware', 'software', 'sms', 'phone']
+    for i in 0..(tfa_forms.length-1)
+      form = website[tfa_forms[i]]
       if (form != nil)
         if (form != true)
-          error("#{website['name']} contains a \'#{$tfa_forms[i]}\' tag. It\'s value should be \'YES\' or not set.")
+          error("#{website['name']} should not contain a \'#{tfa_forms[i]}\' tag when it\'s value isn\'t \'YES\'.")
         end
         if (website['tfa'] != true)
-          error("#{website['name']} contains a \'#{$tfa_forms[i]}\' tag but tfa is not set to \'YES\'")
+          error("#{website['name']} should not contain a \'#{tfa_forms[i]}\' tag when it doesn\'t support TFA.")
         end
       end
+    end
+  end
+
+  def tags_set(website)
+    tags = ['url', 'img', 'name']
+    for i in 0..(tags.length-1)
+      tag = website[tags[i]]
+      if(tag == nil)
+        error("#{website['name']} doesn\'t contain a \'#{tags[i]}\' tag.")
+      end
+    end
+
+    #if(!$ignore_twitter)
+      twitter = website['twitter']
+      if(twitter != nil)
+        if(website['tfa'])
+          error("#{website['name']} should not contain a \'twitter\' tag as it supports TFA.")
+        end
+     # end
     end
   end
 
@@ -39,8 +59,10 @@ begin
       if (tfa != 'true' && tfa != 'false')
         error("#{website['name']} \'tfa\' tag should be either \'Yes\' or \'No\'. (#{tfa})");
       end
-
       check_tfa(website)
+      tags_set(website)
+
+
       image = "img/#{section[1]['id']}/#{website['img']}"
 
       unless File.exists?(image)

--- a/verify.rb
+++ b/verify.rb
@@ -3,13 +3,30 @@ require 'yaml'
 require 'fastimage'
 $output=0;
 begin
+
+  # Send error message
   def error(msg)
     $output=$output+1;
     if ($output == 1)
       puts "<------------ ERROR ------------>\n"
     end
     puts "#{$output}. #{msg}"
+  end
 
+  # Verify that the tfa factors are booleans
+  def check_tfa(website)
+    $tfa_forms = ['email', 'hardware', 'software', 'sms', 'phone']
+    for i in 0..($tfa_forms.length-1)
+      form = website[$tfa_forms[i]]
+      if (form != nil)
+        if (form != true)
+          error("#{website['name']} contains a \'#{$tfa_forms[i]}\' tag. It\'s value should be \'YES\' or not set.")
+        end
+        if (website['tfa'] != true)
+          error("#{website['name']} contains a \'#{$tfa_forms[i]}\' tag but tfa is not set to \'YES\'")
+        end
+      end
+    end
   end
 
   # Load each section, check for errors such as invalid syntax
@@ -17,13 +34,13 @@ begin
   main = YAML.load_file('_data/sections.yml')
   main.each do |section|
     data = YAML.load_file('_data/' + section[1]['id'] + '.yml')
-
     data['websites'].each do |website|
       tfa = "#{website['tfa']}"
       if (tfa != 'true' && tfa != 'false')
-        error("#{website['name']} 'tfa' should be either 'Yes' or 'No' #{tfa}");
+        error("#{website['name']} \'tfa\' tag should be either \'Yes\' or \'No\'. (#{tfa})");
       end
 
+      check_tfa(website)
       image = "img/#{section[1]['id']}/#{website['img']}"
 
       unless File.exists?(image)


### PR DESCRIPTION
Hello,
this is a small PR to add a test of the `tfa:` tag in the verify.rb script.

It checks whether the tfa tag is true/false which yes/no is transformed to.
This means that `tfa: true` also would be okay but I opted for this as I did the pros and cons of the extra work of verifying it is in fact Yes/No and we haven't had any cases yet where people have written true/false instead of Yes/No. (To my knowledge at least)

Most of all this is to stop me from doing the error I did in #1531 again.
