### PR TITLE
Make verify.rb more Ruby-like

### DIFF
--- a/verify.rb
+++ b/verify.rb
@@ -1,52 +1,46 @@
 # Load Yaml
 require 'yaml'
 require 'fastimage'
-$output=0;
-$ignore_twitter=0;
+@output = 0
+@ignore_twitter = 0
+
 begin
 
   # Send error message
   def error(msg)
-    $output=$output+1;
-    if ($output == 1)
-      puts "<------------ ERROR ------------>\n"
-    end
-    puts "#{$output}. #{msg}"
+    @output += 1
+    puts "<------------ ERROR ------------>\n" if @output == 1
+    puts "#{@output}. #{msg}"
   end
 
   # Verify that the tfa factors are booleans
   def check_tfa(website)
-    tfa_forms = ['email', 'hardware', 'software', 'sms', 'phone']
-    for i in 0..(tfa_forms.length-1)
-      form = website[tfa_forms[i]]
-      if (form != nil)
-        if (form != true)
-          error("#{website['name']} should not contain a \'#{tfa_forms[i]}\' tag when it\'s value isn\'t \'YES\'.")
-        end
-        if (website['tfa'] != true)
-          error("#{website['name']} should not contain a \'#{tfa_forms[i]}\' tag when it doesn\'t support TFA.")
-        end
+    tfa_forms = %w(email hardware software sms phone)
+    tfa_forms.each do |tfa_form|
+      next if website[tfa_form].nil?
+      unless website[tfa_form]
+        error("#{website['name']} should not contain a \'#{tfa_forms[i]}\' tag when it\'s value isn\'t \'YES\'.")
+      end
+      unless website['tfa']
+        error("#{website['name']} should not contain a \'#{tfa_forms[i]}\' tag when it doesn\'t support TFA.")
       end
     end
   end
 
   def tags_set(website)
-    tags = ['url', 'img', 'name']
-    for i in 0..(tags.length-1)
-      tag = website[tags[i]]
-      if(tag == nil)
-        error("#{website['name']} doesn\'t contain a \'#{tags[i]}\' tag.")
-      end
+    tags = %w(url img name)
+    tags.each do |t|
+      tag = website[t]
+      next unless tag.nil?
+      error("#{website['name']} doesn\'t contain a \'#{tags[i]}\' tag.")
     end
 
-    #if(!$ignore_twitter)
-      twitter = website['twitter']
-      if(twitter != nil)
-        if(website['tfa'])
-          error("#{website['name']} should not contain a \'twitter\' tag as it supports TFA.")
-        end
-     # end
-    end
+    # if(!@ignore_twitter)
+    twitter = website['twitter']
+    return if twitter.nil?
+    return unless website['tfa']
+    error("#{website['name']} should not contain a \'twitter\' tag as it supports TFA.")
+    # end
   end
 
   # Load each section, check for errors such as invalid syntax
@@ -56,36 +50,31 @@ begin
     data = YAML.load_file('_data/' + section[1]['id'] + '.yml')
     data['websites'].each do |website|
       tfa = "#{website['tfa']}"
-      if (tfa != 'true' && tfa != 'false')
-        error("#{website['name']} \'tfa\' tag should be either \'Yes\' or \'No\'. (#{tfa})");
+      if tfa != 'true' && tfa != 'false'
+        error("#{website['name']} \'tfa\' tag should be either \'Yes\' or \'No\'. (#{tfa})")
       end
       check_tfa(website)
       tags_set(website)
 
-
       image = "img/#{section[1]['id']}/#{website['img']}"
 
-      unless File.exists?(image)
-        error("#{website['name']} image not found.")
-      else
-
+      if File.exist?(image)
         image_dimensions = [32, 32]
 
         unless FastImage.size(image) == image_dimensions
-          error("#{image} is not #{image_dimensions.join("x")}")
+          error("#{image} is not #{image_dimensions.join('x')}")
         end
 
-        ext = ".png"
-        unless File.extname(image) == ext
-          error("#{image} is not #{ext}")
-        end
+        ext = '.png'
+        error("#{image} is not #{ext}") unless File.extname(image) == ext
+      else
+        error("#{website['name']} image not found.")
       end
     end
   end
 
-  if ($output > 0)
-    exit 1
-  end
+  exit 1 if @output > 0
+
 rescue Psych::SyntaxError => e
   puts 'Error in the YAML'
   puts e


### PR DESCRIPTION
Hey @Carlgo11, I see that you've recently updated this file to include more checks. What I did here was just rewriting bits of the code to make it more Ruby... so it's unnecessary, but I like it :no_mouth: 

I also changed the `$global_variables` to `@instance_variables` for no particular reason except for rubocop warnings. It doesn't really matter here since it's just a script but for RoR webapps, global variables are bad.

I'm almost certain I didn't break anything. But let me know if I've written :bug: here :worried: 
