### PR TITLE
Update Garena Online Exception

### DIFF
--- a/_data/gaming.yml
+++ b/_data/gaming.yml
@@ -56,7 +56,7 @@ websites:
       software: Yes
       doc: http://www.garena.com/account/
       exceptions:
-          text: "As of September 29th 2014, new user enrollment for 2FA is broken. A mobile phone and Garena account level 3 or higher is required for 2FA."
+          text: "A mobile phone and Garena account level 3 or higher is required for 2FA."
 
     - name: GOG.com
       url: http://www.gog.com


### PR DESCRIPTION
New user enrollment for 2FA is no longer broken.
