### PR TITLE
Mention Patreon support for Google Authenticator

### DIFF
--- a/_data/other.yml
+++ b/_data/other.yml
@@ -208,9 +208,10 @@ websites:
 
     - name: Patreon
       url: https://www.patreon.com/
-      twitter: Patreon
       img: patreon.png
-      tfa: No
+      tfa: Yes
+      software: Yes
+      doc: https://patreon.zendesk.com/hc/en-us/articles/206538086-How-Do-I-Set-Up-2-Factor-Authorization
 
     - name: PhraseApp
       url: https://phraseapp.com


### PR DESCRIPTION
Hello!

This pull request ensures that [Patreon](https://www.patreon.com/) is shown as supporting software based two factor authentication. This pull request also fixes issue #1545.

Thankyou,
psgs :palm_tree: 
