### PR TITLE
Update to Snapchat for Software Auth

### DIFF
--- a/_data/social.yml
+++ b/_data/social.yml
@@ -94,6 +94,7 @@ websites:
       img: snapchat.png
       tfa: Yes
       sms: Yes
+      software: Yes
       doc: https://support.snapchat.com/ca/login-verification
 
     - name: Stack Exchange


### PR DESCRIPTION
Snapchat now supports software based 2fa. 
https://support.snapchat.com/a/enable-authentication-app

I believe we should update the list with this information. 
