### PR TITLE
Loop through categories using Jekyll

### DIFF
--- a/_data/sections.yml
+++ b/_data/sections.yml
@@ -1,119 +1,95 @@
-backup:
-  id: backup
+- id: backup
   title: Backup and Sync
   icon: disk outline
 
-banking:
-  id: banking
+- id: banking
   title: Banking
   icon: dollar
 
-cloud:
-  id: cloud
+- id: cloud
   title: Cloud Computing
   icon: cloud
 
-communication:
-  id: communication
+- id: communication
   title: Communication
   icon: chat
 
-bitcoin:
-  id: bitcoin
+- id: bitcoin
   title: Cryptocurrencies
   icon: bitcoin
 
-developer:
-  id: developer
+- id: developer
   title: Developer
   icon: code
 
-domains:
-  id: domains
+- id: domains
   title: Domains
   icon: globe
 
-education:
-  id: education
+- id: education
   title: Education
   icon: book
 
-email:
-  id: email
+- id: email
   title: Email
   icon: mail
 
-entertainment:
-  id: entertainment
+- id: entertainment
   title: Entertainment
   icon: music
 
-finance:
-  id: finance
+- id: finance
   title: Finance
   icon: money
 
-gaming:
-  id: gaming
+- id: gaming
   title: Gaming
   icon: gamepad
 
-health:
-  id: health
+- id: health
   title: Health
   icon: medkit
 
-hosting:
-  id: hosting
+- id: hosting
   title: Hosting/VPS
   icon: sitemap
 
-identity:
-  id: identity
+- id: identity
   title: Identity Management
   icon: user
 
-investing:
-  id: investing
+- id: investing
   title: Investing
   icon: basic money
 
-other:
-  id: other
+- id: other
   title: Other
   icon: lab
 
-payments:
-  id: payments
+- id: payments
   title: Payments
   icon: payment
 
-remote:
-  id: remote
+- id: remote
   title: Remote Access
   icon: desktop
 
-retail:
-  id: retail
+- id: retail
   title: Retail
   icon: cart
 
-security:
-  id: security
+- id: security
   title: Security
   icon: lock
 
-social:
-  id: social
+- id: social
   title: Social
   icon: users
 
-transport:
-  id: transport
+- id: transport
   title: Transport
   icon: car
 
-utilities:
-  id: utilities
+- id: utilities
   title: Utilities
   icon: phone

--- a/_includes/desktop-table.html
+++ b/_includes/desktop-table.html
@@ -1,10 +1,11 @@
-{% assign section = include.variable-param %}
-{% assign section_file = site.data[section.id] %}
-<div class="website-table desktop-table {{ section.id }}-table" id="{{ section.id }}-desktoptable" style="display:none">
+{% assign section_id = include.id-param %}
+{% assign section_title = include.title-param %}
+{% assign section_file = site.data[section_id] %}
+<div class="website-table desktop-table {{ section_id }}-table" id="{{ section_id }}-desktoptable" style="display:none">
   <table class="ui celled table content-wrapper">
     <thead>
     <tr>
-      <th class="single line four wide"><h3>{{ section.title }}</h3></th>
+      <th class="single line four wide"><h3>{{ section_title }}</h3></th>
       <th class="two wide">Docs</th>
       <th class="two wide">SMS</th>
       <th class="two wide">Phone Call</th>
@@ -19,8 +20,8 @@
       {% if website.status %}
       <td class="main progress">
         {% if website.img %}
-        <noscript><img src="/img/{{ section.id }}/{{ website.img }}" class="icon" alt="{{ website.name }}"></noscript>
-        <img src="/img/placeholder.png" data-src="/img/{{ section.id }}/{{ website.img }}" class="icon"
+        <noscript><img src="/img/{{ section_id }}/{{ website.img }}" class="icon" alt="{{ website.name }}"></noscript>
+        <img src="/img/placeholder.png" data-src="/img/{{ section_id }}/{{ website.img }}" class="icon"
              alt="{{ website.name }}">
         {% endif %}
         <a href="{{ website.url }}">{{ website.name }}</a>
@@ -38,8 +39,8 @@
       {% elsif website.tfa %}
       <td class="main positive">
         {% if website.img %}
-        <noscript><img src="/img/{{ section.id }}/{{ website.img }}" class="icon" alt="{{ website.name }}"></noscript>
-        <img src="/img/placeholder.png" data-src="/img/{{ section.id }}/{{ website.img }}" class="icon"
+        <noscript><img src="/img/{{ section_id }}/{{ website.img }}" class="icon" alt="{{ website.name }}"></noscript>
+        <img src="/img/placeholder.png" data-src="/img/{{ section_id }}/{{ website.img }}" class="icon"
              alt="{{ website.name }}">
         {% endif %}
         <a href="{{ website.url }}">{{ website.name }}</a>
@@ -84,8 +85,8 @@
       {% else %}
       <td class="main negative">
         {% if website.img %}
-        <noscript><img src="/img/{{ section.id }}/{{ website.img }}" class="icon" alt="{{ website.name }}"></noscript>
-        <img src="/img/placeholder.png" data-src="/img/{{ section.id }}/{{ website.img }}" class="icon"
+        <noscript><img src="/img/{{ section_id }}/{{ website.img }}" class="icon" alt="{{ website.name }}"></noscript>
+        <img src="/img/placeholder.png" data-src="/img/{{ section_id }}/{{ website.img }}" class="icon"
              alt="{{ website.name }}">
         {% endif %}
         <a href="{{ website.url }}">{{ website.name }}</a>

--- a/_includes/mobile-table.html
+++ b/_includes/mobile-table.html
@@ -1,8 +1,9 @@
-{% assign section = include.variable-param %}
-{% assign section_file = site.data[section.id] %}
-<div class="website-table mobile-table {{ section.id }}-table" id="{{ section.id }}-mobiletable" style="display:none">
+{% assign section_id = include.id-param %}
+{% assign section_title = include.title-param %}
+{% assign section_file = site.data[section_id] %}
+<div class="website-table mobile-table {{ section_id }}-table" id="{{ section_id }}-mobiletable" style="display:none">
   <div class="label">
-    <h3>{{ section.title }}</h3>
+    <h3>{{ section_title }}</h3>
   </div>
   <div class="jets-content">
     {% for website in section_file.websites %}
@@ -10,8 +11,8 @@
     <div class="main progress">
       <div class="left">
         {% if website.img %}
-        <noscript><img src="/img/{{ section.id }}/{{ website.img }}" class="icon" alt="{{ website.name }}"></noscript>
-        <img src="/img/placeholder.png" data-src="/img/{{ section.id }}/{{ website.img }}" class="icon"
+        <noscript><img src="/img/{{ section_id }}/{{ website.img }}" class="icon" alt="{{ website.name }}"></noscript>
+        <img src="/img/placeholder.png" data-src="/img/{{ section_id }}/{{ website.img }}" class="icon"
              alt="{{ website.name }}">
         {% endif %}
         <a href="{{ website.url }}" class="name">{{ website.name }}</a>
@@ -32,8 +33,8 @@
     <div class="main positive">
       <div class="left">
         {% if website.img %}
-        <noscript><img src="/img/{{ section.id }}/{{ website.img }}" class="icon" alt="{{ website.name }}"></noscript>
-        <img src="/img/placeholder.png" data-src="/img/{{ section.id }}/{{ website.img }}" class="icon"
+        <noscript><img src="/img/{{ section_id }}/{{ website.img }}" class="icon" alt="{{ website.name }}"></noscript>
+        <img src="/img/placeholder.png" data-src="/img/{{ section_id }}/{{ website.img }}" class="icon"
              alt="{{ website.name }}">
         {% endif %}
         <a href="{{ website.url }}" class="name">{{ website.name }}</a>
@@ -70,8 +71,8 @@
     <div class="main negative">
       <div class="left">
         {% if website.img %}
-        <noscript><img src="/img/{{ section.id }}/{{ website.img }}" class="icon" alt="{{ website.name }}"></noscript>
-        <img src="/img/placeholder.png" data-src="/img/{{ section.id }}/{{ website.img }}" class="icon"
+        <noscript><img src="/img/{{ section_id }}/{{ website.img }}" class="icon" alt="{{ website.name }}"></noscript>
+        <img src="/img/placeholder.png" data-src="/img/{{ section_id }}/{{ website.img }}" class="icon"
              alt="{{ website.name }}">
         {% endif %}
         <a href="{{ website.url }}" class="name">{{ website.name }}</a>

--- a/index.html
+++ b/index.html
@@ -64,205 +64,31 @@ hash: SupportTwoFactorAuth
 
 <div class="ui stackable grid container">
   <div class="five column row">
-    <div id="backup" class="category column">
+    {% for section in site.data.sections %}
+    {% assign rowend = forloop.index | modulo: 5 %}
+    {% if rowend == 0 or forloop.index == forloop.length %}
+    <div id="{{ section.id }}" class="category column">
       <h5 class="ui icon header">
-        <i class="circular disk outline icon"></i>
-        <small>Backup and Sync</small>
+        <i class="circular {{ section.icon }} icon"></i>
+        <small>{{ section.title }}</small>
       </h5>
     </div>
-    {% include mobile-table.html variable-param=site.data.sections.backup %}
-    <div id="developer" class="category column">
-      <h5 class="ui icon header">
-        <i class="circular code icon"></i>
-        <small>Developer</small>
-      </h5>
-    </div>
-    {% include mobile-table.html variable-param=site.data.sections.developer %}
-    <div id="finance" class="category column">
-      <h5 class="ui icon header">
-        <i class="circular money icon"></i>
-        <small>Finance</small>
-      </h5>
-    </div>
-    {% include mobile-table.html variable-param=site.data.sections.finance %}
-    <div id="investing" class="category column">
-      <h5 class="ui icon header">
-        <i class="circular line chart icon"></i>
-        <small>Investing</small>
-      </h5>
-    </div>
-    {% include mobile-table.html variable-param=site.data.sections.investing %}
-    <div id="security" class="category column">
-      <h5 class="ui icon header">
-        <i class="circular lock icon"></i>
-        <small>Security</small>
-      </h5>
-    </div>
-    {% include mobile-table.html variable-param=site.data.sections.security %}
-    {% include desktop-table.html variable-param=site.data.sections.backup %}
-    {% include desktop-table.html variable-param=site.data.sections.developer %}
-    {% include desktop-table.html variable-param=site.data.sections.finance %}
-    {% include desktop-table.html variable-param=site.data.sections.investing %}
-    {% include desktop-table.html variable-param=site.data.sections.security %}
+    {% include mobile-table.html id-param=section.id title-param=section.title %}
+    {% assign offcount = forloop.index | minus: 5 %}
+    {% for section in site.data.sections limit: 5 offset: offcount %}
+    {% include desktop-table.html id-param=section.id title-param=section.title %}
+    {% endfor %}
   </div>
   <div class="five column row">
-    <div id="banking" class="category column">
+    {% else %}
+    <div id="{{ section.id }}" class="category column">
       <h5 class="ui icon header">
-        <i class="circular dollar icon"></i>
-        <small>Banking</small>
+        <i class="circular {{ section.icon }} icon"></i>
+        <small>{{ section.title }}</small>
       </h5>
     </div>
-    {% include mobile-table.html variable-param=site.data.sections.banking %}
-    <div id="domains" class="category column">
-      <h5 class="ui icon header">
-        <i class="circular globe icon"></i>
-        <small>Domains</small>
-      </h5>
-    </div>
-    {% include mobile-table.html variable-param=site.data.sections.domains %}
-    <div id="gaming" class="category column">
-      <h5 class="ui icon header">
-        <i class="circular gamepad icon"></i>
-        <small>Gaming</small>
-      </h5>
-    </div>
-    {% include mobile-table.html variable-param=site.data.sections.gaming %}
-    <div id="other" class="category column">
-      <h5 class="ui icon header">
-        <i class="circular lab icon"></i>
-        <small>Other</small>
-      </h5>
-    </div>
-    {% include mobile-table.html variable-param=site.data.sections.other %}
-    <div id="social" class="category column">
-      <h5 class="ui icon header">
-        <i class="circular users icon"></i>
-        <small>Social</small>
-      </h5>
-    </div>
-    {% include mobile-table.html variable-param=site.data.sections.social %}
-    {% include desktop-table.html variable-param=site.data.sections.banking %}
-    {% include desktop-table.html variable-param=site.data.sections.domains %}
-    {% include desktop-table.html variable-param=site.data.sections.gaming %}
-    {% include desktop-table.html variable-param=site.data.sections.other %}
-    {% include desktop-table.html variable-param=site.data.sections.social %}
-  </div>
-  <div class="five column row">
-    <div id="cloud" class="category column">
-      <h5 class="ui icon header">
-        <i class="circular cloud icon"></i>
-        <small>Cloud Computing</small>
-      </h5>
-    </div>
-    {% include mobile-table.html variable-param=site.data.sections.cloud %}
-    <div id="education" class="category column">
-      <h5 class="ui icon header">
-        <i class="circular book icon"></i>
-        <small>Education</small>
-      </h5>
-    </div>
-    {% include mobile-table.html variable-param=site.data.sections.education %}
-    <div id="health" class="category column">
-      <h5 class="ui icon header">
-        <i class="circular medkit icon"></i>
-        <small>Health</small>
-      </h5>
-    </div>
-    {% include mobile-table.html variable-param=site.data.sections.health %}
-    <div id="payments" class="category column">
-      <h5 class="ui icon header">
-        <i class="circular payment icon"></i>
-        <small>Payments</small>
-      </h5>
-    </div>
-    {% include mobile-table.html variable-param=site.data.sections.payments %}
-    <div id="transport" class="category column">
-      <h5 class="ui icon header">
-        <i class="circular car icon"></i>
-        <small>Transport</small>
-      </h5>
-    </div>
-    {% include mobile-table.html variable-param=site.data.sections.transport %}
-    {% include desktop-table.html variable-param=site.data.sections.cloud %}
-    {% include desktop-table.html variable-param=site.data.sections.education %}
-    {% include desktop-table.html variable-param=site.data.sections.health %}
-    {% include desktop-table.html variable-param=site.data.sections.payments %}
-    {% include desktop-table.html variable-param=site.data.sections.transport %}
-  </div>
-  <div class="five column row">
-    <div id="communication" class="category column">
-      <h5 class="ui icon header">
-        <i class="circular comment icon"></i>
-        <small>Communication</small>
-      </h5>
-    </div>
-    {% include mobile-table.html variable-param=site.data.sections.communication %}
-    <div id="email" class="category column">
-      <h5 class="ui icon header">
-        <i class="circular mail icon"></i>
-        <small>Email</small>
-      </h5>
-    </div>
-    {% include mobile-table.html variable-param=site.data.sections.email %}
-    <div id="hosting" class="category column">
-      <h5 class="ui icon header">
-        <i class="circular sitemap icon"></i>
-        <small>Hosting/VPS</small>
-      </h5>
-    </div>
-    {% include mobile-table.html variable-param=site.data.sections.hosting %}
-    <div id="remote" class="category column">
-      <h5 class="ui icon header">
-        <i class="circular desktop icon"></i>
-        <small>Remote Access</small>
-      </h5>
-    </div>
-    {% include mobile-table.html variable-param=site.data.sections.remote %}
-    <div id="utilities" class="category column">
-      <h5 class="ui icon header">
-        <i class="circular phone icon"></i>
-        <small>Utilities</small>
-      </h5>
-    </div>
-    {% include mobile-table.html variable-param=site.data.sections.utilities %}
-    {% include desktop-table.html variable-param=site.data.sections.communication %}
-    {% include desktop-table.html variable-param=site.data.sections.email %}
-    {% include desktop-table.html variable-param=site.data.sections.hosting %}
-    {% include desktop-table.html variable-param=site.data.sections.remote %}
-    {% include desktop-table.html variable-param=site.data.sections.utilities %}
-  </div>
-  <div class="five column row">
-    <div id="bitcoin" class="category column">
-      <h5 class="ui icon header">
-        <i class="circular bitcoin icon"></i>
-        <small>Cryptocurrencies</small>
-      </h5>
-    </div>
-    {% include mobile-table.html variable-param=site.data.sections.bitcoin %}
-    <div id="entertainment" class="category column">
-      <h5 class="ui icon header">
-        <i class="circular music icon"></i>
-        <small>Entertainment</small>
-      </h5>
-    </div>
-    {% include mobile-table.html variable-param=site.data.sections.entertainment %}
-    <div id="identity" class="category column">
-      <h5 class="ui icon header">
-        <i class="circular user icon"></i>
-        <small>Identity Management</small>
-      </h5>
-    </div>
-    {% include mobile-table.html variable-param=site.data.sections.identity %}
-    <div id="retail" class="category column">
-      <h5 class="ui icon header">
-        <i class="circular cart icon"></i>
-        <small>Retail</small>
-      </h5>
-    </div>
-    {% include mobile-table.html variable-param=site.data.sections.retail %}
-    {% include desktop-table.html variable-param=site.data.sections.bitcoin %}
-    {% include desktop-table.html variable-param=site.data.sections.entertainment %}
-    {% include desktop-table.html variable-param=site.data.sections.identity %}
-    {% include desktop-table.html variable-param=site.data.sections.retail %}
+    {% include mobile-table.html id-param=section.id title-param=section.title %}
+    {% endif %}
+    {% endfor %}
   </div>
 </div>

--- a/verify.rb
+++ b/verify.rb
@@ -51,7 +51,7 @@ begin
   # as well as if an image is missing
   main = YAML.load_file('_data/sections.yml')
   main.each do |section|
-    data = YAML.load_file('_data/' + section[1]['id'] + '.yml')
+    data = YAML.load_file('_data/' + section['id'] + '.yml')
     data['websites'].each do |website|
       tfa = "#{website['tfa']}"
       if tfa != 'true' && tfa != 'false'
@@ -60,7 +60,7 @@ begin
       check_tfa(website)
       tags_set(website)
 
-      image = "img/#{section[1]['id']}/#{website['img']}"
+      image = "img/#{section['id']}/#{website['img']}"
       if File.exist?(image)
         image_dimensions = [32, 32]
 


### PR DESCRIPTION
Hello!

This pull request changes the way in which categories are displayed on the main page. Instead of hard-coding category names in `index.html`, categories are now looped through using Jekyll. This is possible without altering the positioning of tables below their respective category labels due to the way in which desktop and mobile tables have been previously separated into different files.

This pull request also sorts categories alphabetically and thus fixes #1558.
@Carlgo11 This pull request ensures that `sections.yml` is essential to the website's correct functioning.

Thankyou,
psgs :palm_tree: 
