### PR TITLE
Update WiseBanyan with an exception

### DIFF
--- a/_data/investing.yml
+++ b/_data/investing.yml
@@ -168,4 +168,6 @@ websites:
       img: wisebanyan.png
       tfa: Yes
       sms: Yes
+      exceptions:
+          text: "Two-step verification code not required for login. It's only required after login when you request to update your password, update your profile information, or download your tax documents"
       doc: https://wisebanyan.com/faq/my-account/how-does-two-step-verification-work

--- a/_data/investing.yml
+++ b/_data/investing.yml
@@ -165,9 +165,9 @@ websites:
 
     - name: WiseBanyan
       url: https://www.wisebanyan.com/
+      twitter: WiseBanyan
       img: wisebanyan.png
-      tfa: Yes
-      sms: Yes
+      tfa: No
       exceptions:
-          text: "Two-step verification code not required for login. It's only required after login when you request to update your password, update your profile information, or download your tax documents"
+          text: "Two-step verification code not required for authentication. It's only required after login when you request to update your password, update your profile information, or download your tax documents"
       doc: https://wisebanyan.com/faq/my-account/how-does-two-step-verification-work

--- a/_data/investing.yml
+++ b/_data/investing.yml
@@ -168,5 +168,3 @@ websites:
       twitter: WiseBanyan
       img: wisebanyan.png
       tfa: No
-      exceptions:
-          text: "Two-step verification code not required for authentication. It's only required after login when you request to update your password, update your profile information, or download your tax documents"

--- a/_data/investing.yml
+++ b/_data/investing.yml
@@ -170,4 +170,3 @@ websites:
       tfa: No
       exceptions:
           text: "Two-step verification code not required for authentication. It's only required after login when you request to update your password, update your profile information, or download your tax documents"
-      doc: https://wisebanyan.com/faq/my-account/how-does-two-step-verification-work


### PR DESCRIPTION
WiseBanyan doesn't enforce 2FA for initial login. It only enforces 2FA when an authenticated user attempts to update profile information, security information, or access tax documents. See more here: https://wisebanyan.com/faq/my-account/how-does-two-step-verification-work
