### PR TITLE
Removed Amazon's exception

### DIFF
--- a/_data/retail.yml
+++ b/_data/retail.yml
@@ -5,8 +5,6 @@ websites:
       tfa: Yes
       software: Yes
       sms: Yes
-      exceptions:
-          text: "SMS/Phone Call required for 2FA"
       doc: https://www.amazon.com/gp/help/customer/display.html?nodeId=201596330
 
     - name: Apple


### PR DESCRIPTION
No need for a phone call any more. Per the documentation, "You can receive this security code in a variety of ways depending on the option you select during sign up, including text message, voice call, or authenticator app."
