### PR TITLE
Updated Guild Wars 2

### DIFF
--- a/_data/gaming.yml
+++ b/_data/gaming.yml
@@ -81,10 +81,12 @@ websites:
     - name: Guild Wars 2
       url: https://www.guildwars2.com
       img: guildwars2.png
+      sms: Yes
       tfa: Yes
       email: Yes
+      phone: Yes
       software: Yes
-      doc: https://help.guildwars2.com/entries/27626157-Two-Factor-Authentication
+      doc: http://help.guildwars2.com/entries/95446157-Securing-Your-Account-With-Authentication
 
     - name: Humble Bundle
       url: https://www.humblebundle.com/


### PR DESCRIPTION
Guild Wars 2 supports both SMS and phone calls in addition to TOTP. I also changed the link to a support page that explains all methods, not just TOTP.
