### PR TITLE
Update Paypal doc

### DIFF
--- a/_data/payments.yml
+++ b/_data/payments.yml
@@ -73,7 +73,7 @@ websites:
       hardware: Yes
       exceptions:
           text: "2FA is only available in the United States, Canada, United Kingdom, Germany, Austria and Australia."
-      doc: https://www.paypal.com/us/cgi-bin?cmd=xpt/Marketing_CommandDriven/securitycenter/PayPalSecurityKey-outside&bn_r=o
+      doc: https://www.paypal.com/?cmd=_setup-security-key
 
     - name: Paysafecard
       url: https://www.paysafecard.com/


### PR DESCRIPTION
The old Paypal doc did not require sign-in; it described the Paypal SMS key and linked to the SMS key setup page, but did not describe the software (Symantec VIP) or hardware keys or provide any way to set up software or hardware keys.  This new link requires sign-in but provides buttons to set up SMS, software, or hardware keys.
