### PR TITLE
Add language tag handling for tweets

### DIFF
--- a/_data/languages.yml
+++ b/_data/languages.yml
@@ -1,0 +1,5 @@
+# Languages should be categorized according to ISO 639-1
+# Language codes (including within data files) should be in lowercase
+en:
+  work_tweet: Security is important, @TWITTERHANDLE. We'd like it if you supported two factor auth.
+  progress_tweet: Thanks for working on support for two factor auth, @TWITTERHANDLE!

--- a/_includes/desktop-table.html
+++ b/_includes/desktop-table.html
@@ -16,6 +16,13 @@
     </thead>
     <tbody class="jets-content">
     {% for website in section_file.websites %}
+    {% if website.lang %}
+      {% assign progress_tweet = site.data.languages[website.lang].progress_tweet %}
+      {% assign workonit_tweet = site.data.languages[website.lang].work_tweet %}
+    {% else %}
+      {% assign progress_tweet = page.progress_tweet %}
+      {% assign workonit_tweet = page.workonit_tweet %}
+    {% endif %}
     <tr class="desktop-tr">
       {% if website.status %}
       <td class="main progress">
@@ -33,7 +40,7 @@
       </td>
       <td class="twitter progress" colspan="6">
         <a class="ui twitter mini button"
-           href="https://twitter.com/share?url={{site.url|cgi_escape}}&amp;text={{page.tweet_progress|replace:'TWITTERHANDLE',website.twitter|cgi_escape}}&amp;hashtags={{page.hash|cgi_escape}}"
+           href="https://twitter.com/share?url={{site.url|cgi_escape}}&amp;text={{progress_tweet|replace:'TWITTERHANDLE',website.twitter|cgi_escape}}&amp;hashtags={{page.hash|cgi_escape}}"
            target="_blank"><i class="twitter icon"></i> {{page.link_progress}}</a>
       </td>
       {% elsif website.tfa %}
@@ -94,7 +101,7 @@
       {% if website.twitter %}
       <td class="twitter negative" colspan="6">
         <a class="ui twitter mini button"
-           href="https://twitter.com/share?url={{site.url|cgi_escape}}&amp;text={{page.tweet|replace:'TWITTERHANDLE',website.twitter|cgi_escape}}&amp;hashtags={{page.hash|cgi_escape}}"
+           href="https://twitter.com/share?url={{site.url|cgi_escape}}&amp;text={{workonit_tweet|replace:'TWITTERHANDLE',website.twitter|cgi_escape}}&amp;hashtags={{page.hash|cgi_escape}}"
            target="_blank"><i class="twitter icon"></i> {{page.link}}</a>
       </td>
       {% else %}

--- a/_includes/mobile-table.html
+++ b/_includes/mobile-table.html
@@ -7,6 +7,13 @@
   </div>
   <div class="jets-content">
     {% for website in section_file.websites %}
+    {% if website.lang %}
+      {% assign progress_tweet = site.data.languages[website.lang].progress_tweet %}
+      {% assign workonit_tweet = site.data.languages[website.lang].work_tweet %}
+    {% else %}
+      {% assign progress_tweet = page.progress_tweet %}
+      {% assign workonit_tweet = page.workonit_tweet %}
+    {% endif %}
     {% if website.status %}
     <div class="main progress">
       <div class="left">
@@ -25,7 +32,7 @@
       </div>
       <div class="right">
         <a class="ui twitter mini button"
-           href="https://twitter.com/share?url={{site.url|cgi_escape}}&amp;text={{page.tweet_progress|replace:'TWITTERHANDLE',website.twitter|cgi_escape}}&amp;hashtags={{page.hash|cgi_escape}}"
+           href="https://twitter.com/share?url={{site.url|cgi_escape}}&amp;text={{progress_tweet|replace:'TWITTERHANDLE',website.twitter|cgi_escape}}&amp;hashtags={{page.hash|cgi_escape}}"
            target="_blank"><i class="twitter icon"></i> {{page.link_progress_mobile}}</a>
       </div>
     </div>
@@ -82,7 +89,7 @@
       {% if website.twitter %}
       <div class="right">
         <a class="ui twitter mini button"
-           href="https://twitter.com/share?url={{site.url|cgi_escape}}&amp;text={{page.tweet|replace:'TWITTERHANDLE',website.twitter|cgi_escape}}&amp;hashtags={{page.hash|cgi_escape}}"
+           href="https://twitter.com/share?url={{site.url|cgi_escape}}&amp;text={{workonit_tweet|replace:'TWITTERHANDLE',website.twitter|cgi_escape}}&amp;hashtags={{page.hash|cgi_escape}}"
            target="_blank"><i class="twitter icon"></i> {{page.link_mobile}}</a>
       </div>
       {% endif %}

--- a/index.html
+++ b/index.html
@@ -3,11 +3,11 @@ layout: default
 
 link: Tell them to support 2FA
 link_mobile: TWEET THEM
-tweet: Security is important, @TWITTERHANDLE. We'd like it if you supported two factor auth.
+workonit_tweet: Security is important, @TWITTERHANDLE. We'd like it if you supported two factor auth.
 
 link_progress: Thank them for working on 2FA
 link_progress_mobile: THANK THEM
-tweet_progress: Thanks for working on support for two factor auth, @TWITTERHANDLE!
+progress_tweet: Thanks for working on support for two factor auth, @TWITTERHANDLE!
 hash: SupportTwoFactorAuth
 ---
 


### PR DESCRIPTION
Hello!

This pull request allows default tweet text to be altered based on a language tag, configurable per website. Language tags are placed under each website within the appropriate data file, and language codes use the [ISO 639-1 standard](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) in lower-case.

Thankyou,
psgs :palm_tree: 
