### PR TITLE
Update PayPal exception message

### DIFF
--- a/_data/payments.yml
+++ b/_data/payments.yml
@@ -72,7 +72,7 @@ websites:
       software: Yes
       hardware: Yes
       exceptions:
-          text: "2FA is only available in a few countries. Contact PayPal on twitter for a up to date list of available countries."
+          text: "2FA is only available in a few countries. Contact PayPal on twitter for an up to date list of available countries."
       doc: https://www.paypal.com/us/cgi-bin?cmd=xpt/Marketing_CommandDriven/securitycenter/PayPalSecurityKey-outside&bn_r=o
 
     - name: Paysafecard

--- a/_data/payments.yml
+++ b/_data/payments.yml
@@ -72,7 +72,7 @@ websites:
       software: Yes
       hardware: Yes
       exceptions:
-          text: "2FA is only available in the United States, Canada, United Kingdom, Germany, Austria and Australia."
+          text: "2FA is only available in a few countries. Contact PayPal on twitter for a up to date list of available countries."
       doc: https://www.paypal.com/us/cgi-bin?cmd=xpt/Marketing_CommandDriven/securitycenter/PayPalSecurityKey-outside&bn_r=o
 
     - name: Paysafecard


### PR DESCRIPTION
As PayPal's TFA system is available in many more countries nowadays I propose that we change the exception message to encourage people to tweet PayPal to know if PayPal supports TFA in their country.

It doesn't look like PayPal has a list of all countries they support TFA in and they don't seem to want to give one out on Twitter; Rather they ask what region you're in and then tell you what kind of TFA solution that is available for your region.

It also looks like SMS based TFA is available in +100 countries now, however the specific countries it's available in seems to change very often.

Please make a comment or commit to the `Carlgo11-paypal-exception` branch if you want to change the phrasing of this exception text.  

<br>
_This PR closes #1694_
