### PR TITLE
Ensure tweets only use available languages

### DIFF
--- a/_data/backup.yml
+++ b/_data/backup.yml
@@ -126,7 +126,7 @@ websites:
     img: pogoplug.png
     tfa: No
     status: https://twitter.com/pogoplug/status/486192568745476096
-    
+
   - name: QNAP
     url: https://www.qnap.com
     img: qnap.png

--- a/_includes/desktop-table.html
+++ b/_includes/desktop-table.html
@@ -16,7 +16,7 @@
     </thead>
     <tbody class="jets-content">
     {% for website in section_file.websites %}
-    {% if website.lang %}
+    {% if website.lang and site.data.languages[website.lang] %}
       {% assign progress_tweet = site.data.languages[website.lang].progress_tweet %}
       {% assign workonit_tweet = site.data.languages[website.lang].work_tweet %}
     {% else %}

--- a/_includes/mobile-table.html
+++ b/_includes/mobile-table.html
@@ -7,7 +7,7 @@
   </div>
   <div class="jets-content">
     {% for website in section_file.websites %}
-    {% if website.lang %}
+    {% if website.lang and site.data.languages[website.lang] %}
       {% assign progress_tweet = site.data.languages[website.lang].progress_tweet %}
       {% assign workonit_tweet = site.data.languages[website.lang].work_tweet %}
     {% else %}


### PR DESCRIPTION
Hello!

This pull request fixes an issue where using a lang tag that wasn't present in the `languages.yml` file
would result in a partially empty tweet.

Thankyou,
psgs :palm_tree: 
