### PR TITLE
Removed SW Token for Mint

### DIFF
--- a/_data/finance.yml
+++ b/_data/finance.yml
@@ -69,7 +69,6 @@ websites:
       tfa: Yes
       sms: Yes
       email: Yes
-      software: Yes
 
     - name: Mint Bills (formerly Check)
       url: https://bills.mint.com


### PR DESCRIPTION
Contacted Mint via Twitter and they indicated that they only support SMS and email for 2FA. Response linked me to the following page for confirmation of just sms and email. https://mint.lc.intuit.com/announcements/1286158
