### PR TITLE
Adding Square Cash

### DIFF
--- a/_data/payments.yml
+++ b/_data/payments.yml
@@ -120,6 +120,11 @@ websites:
       exceptions:
         text: "Currently only US merchants, protects only Dashboard access"
       doc: https://squareup.com/help/us/en/article/5593-2-step-verification
+      
+    - name: Square Cash
+      url: https://cash.me
+      twitter: SquareCash
+      tfa: No
 
     - name: Venmo
       url: https://venmo.com


### PR DESCRIPTION
Square Cash currently doesn't have proper two-factor authentication. By default single-factor authentication occurs using a 6 digit code that's sent via SMS or email to the user. An additional knowledge factor, debit card CVV code, is required for some transactions (when I tested three transactions, the first didn't ask for CVV, the second did, and the third didn't). Users can optionally create a 4-digit passcode, which is only required when a user sends money with their account or change security options on their account - it's not required to sign in. Also TouchID can be used on the iOS app instead of this passcode.
