### PR TITLE
Remove software token support from Wells Fargo

### DIFF
--- a/_data/banking.yml
+++ b/_data/banking.yml
@@ -504,7 +504,6 @@ websites:
       img: wellsfargo.png
       tfa: Yes
       sms: Yes
-      software: Yes
       phone: Yes
       hardware: Yes
       doc: https://www.wellsfargo.com/privacy-security/advanced-access


### PR DESCRIPTION
In their FAQ, they only mention an RSA token or sms/calls. There's no mention
of Google authenticator, Symantec vip, or other software tokens.

https://www.wellsfargo.com/help/faqs/advanced-access
