### PR TITLE
Update tweet link text and tweet (#1813)

### DIFF
--- a/_data/languages.yml
+++ b/_data/languages.yml
@@ -1,11 +1,11 @@
 # Languages should be categorized according to ISO 639-1
 # Language codes (including within data files) should be in lowercase
 de:
-  work_tweet: Hallo! Was sind Ihre Gedanken auf Zwei-Faktor-Authentifizierung? Ich würde es gerne, weil ich
+  work_tweet: Hallo @TWITTERHANDLE! Was sind Ihre Gedanken auf Zwei-Faktor-Authentifizierung? Ich würde es gerne, weil ich
   progress_tweet: Vielen Dank für die Fortschritte bei der Zwei-Faktor-Authentifizierung, @TWITTERHANDLE!
 en:
-  work_tweet: Hi! What are your thoughts on two factor auth? I'd like it because I
+  work_tweet: Hi @TWITTERHANDLE! What are your thoughts on two factor auth? I'd like it because I
   progress_tweet: Thanks for working on support for two factor auth, @TWITTERHANDLE!
 sv:
-  work_tweet: Hej! Vad är dina tankar om två faktor auth? Jag skulle vilja det eftersom jag
+  work_tweet: Hej @TWITTERHANDLE! Vad är dina tankar om två faktor auth? Jag skulle vilja det eftersom jag
   progress_tweet: Tack för att ni arbetar på two factor authentication, @TWITTERHANDLE!

--- a/_data/languages.yml
+++ b/_data/languages.yml
@@ -1,12 +1,11 @@
 # Languages should be categorized according to ISO 639-1
 # Language codes (including within data files) should be in lowercase
 de:
-  work_tweet: Sicherheit ist wichtig, @TWITTERHANDLE. Bitte aktiviert Zwei-Faktor-Authentifizierung auf eurer Webseite.
+  work_tweet: Hallo! Was sind Ihre Gedanken auf Zwei-Faktor-Authentifizierung? Ich würde es gerne, weil ich
   progress_tweet: Vielen Dank für die Fortschritte bei der Zwei-Faktor-Authentifizierung, @TWITTERHANDLE!
 en:
-  work_tweet: Security is important, @TWITTERHANDLE. We'd like it if you supported two factor auth.
+  work_tweet: Hi! What are your thoughts on two factor auth? I'd like it because I
   progress_tweet: Thanks for working on support for two factor auth, @TWITTERHANDLE!
 sv:
-  work_tweet: Säkerhet är viktigt, @TWITTERHANDLE. Vänligen lägg till two factor authentication på er hemsida.
+  work_tweet: Hej! Vad är dina tankar om två faktor auth? Jag skulle vilja det eftersom jag
   progress_tweet: Tack för att ni arbetar på two factor authentication, @TWITTERHANDLE!
-  

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@ layout: default
 
 link: Ask about 2FA plans
 link_mobile: TWEET INQUIRY
-workonit_tweet: Hi! What are your thoughts on two factor auth? I'd like it because
+workonit_tweet: Hi! What are your thoughts on two factor auth? I'd like it because I
 
 link_progress: Thank them for working on 2FA
 link_progress_mobile: THANK THEM

--- a/index.html
+++ b/index.html
@@ -1,9 +1,9 @@
 ---
 layout: default
 
-link: Tell them to support 2FA
-link_mobile: TWEET THEM
-workonit_tweet: Security is important, @TWITTERHANDLE. We'd like it if you supported two factor auth.
+link: Ask about 2FA plans
+link_mobile: TWEET INQUIRY
+workonit_tweet: Hi! What are your thoughts on two factor auth? I'd like it because
 
 link_progress: Thank them for working on 2FA
 link_progress_mobile: THANK THEM

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@ layout: default
 
 link: Ask about 2FA plans
 link_mobile: TWEET INQUIRY
-workonit_tweet: Hi! What are your thoughts on two factor auth? I'd like it because I
+workonit_tweet: Hi @TWITTERHANDLE! What are your thoughts on two factor auth? I'd like it because I
 
 link_progress: Thank them for working on 2FA
 link_progress_mobile: THANK THEM


### PR DESCRIPTION
See #1813. This:
- makes the tweet more constructive, and updates the link label to reflect that
- lets the user finish the tweet with why they want it or how they'd use it
- removes the `@TWITTERHANDLE` fake personalization, which is (a) cheesy when repeated in many tweets (looks like a spambot) and (b) a waste of characters now, since the changes above make it much more personal
- updates the translations
