### PR TITLE
Update Bitbucket - Add Hardware Support

### DIFF
--- a/_data/developer.yml
+++ b/_data/developer.yml
@@ -34,6 +34,7 @@ websites:
       img: bitbucket.png
       tfa: Yes
       software: Yes
+      hardware: Yes
       doc: https://confluence.atlassian.com/x/425QLg
 
     - name: Bugsnag


### PR DESCRIPTION
Add hardware support to Bitbucket - now supports U2F keys
