### PR TITLE
Add email method to Discord

### DIFF
--- a/_data/communication.yml
+++ b/_data/communication.yml
@@ -23,6 +23,7 @@ websites:
       url: https://discordapp.com/
       img: discord.png
       tfa: Yes
+      email: Yes
       software: Yes
       doc: https://support.discordapp.com/hc/en-us/articles/219576828
 


### PR DESCRIPTION
Discord verifies via email when your account is accessed from an unrecognized IP address. Email 2nd step is disabled when software token is enabled.
