### PR TITLE
Update banking.yml

### DIFF
--- a/_data/banking.yml
+++ b/_data/banking.yml
@@ -49,6 +49,7 @@ websites:
       img: bankofamerica.png
       tfa: Yes
       sms: Yes
+      email: Yes
       hardware: Yes
       doc: https://www.bankofamerica.com/privacy/online-mobile-banking-privacy/safepass.go
 


### PR DESCRIPTION
Adding email to Bank of America authentication method.
Bank of America (BofA) does support two factor authentication through registered email addresses.
