### PR TITLE
Update the status of Kayako 2fa

### DIFF
--- a/_data/other.yml
+++ b/_data/other.yml
@@ -142,7 +142,10 @@ websites:
       url: https://www.kayako.com
       img: kayako.png
       twitter: kayako
-      tfa: No
+      tfa: Yes
+      sms: No
+      phone: No
+      software: Yes
 
     - name: Kickstarter
       url: https://www.kickstarter.com


### PR DESCRIPTION
Available since 4th July 2016 on all plans. Source: me, co-founder
