### PR TITLE
Update links for Fastmail

### DIFF
--- a/_data/email.yml
+++ b/_data/email.yml
@@ -10,13 +10,13 @@ websites:
       doc: https://help.aol.com/articles/2-factor-authentication-stronger-than-your-password-alone
 
     - name: FastMail
-      url: https://www.fastmail.fm/
+      url: https://www.fastmail.com/
       img: fastmail.png
       tfa: Yes
       sms: Yes
       software: Yes
       hardware: Yes
-      doc: https://www.fastmail.fm/help/features_alternative_logins.html
+      doc: https://www.fastmail.com/help/account/2fa.html
 
     - name: Gmail
       url: https://gmail.com


### PR DESCRIPTION
Currently linked 2FA doc is 404, TLD has changed.
