### PR TITLE
Add Mercado Livre, Brazilian branch of Mercado Libre

### DIFF
--- a/_data/retail.yml
+++ b/_data/retail.yml
@@ -139,7 +139,19 @@ websites:
       tfa: Yes
       software: Yes
       sms: Yes
+      exceptions:
+          text: "Mercado Libre only supports 2FA with specifc app"
       doc: https://ayuda.mercadolibre.com.ar/ayuda/Consejos-para-fortalecer-la-se_961
+
+    - name: Mercado Livre
+      url: https://www.mercadolivre.com.br
+      img: mercado-libre.png
+      tfa: Yes
+      software: Yes
+      sms: Yes
+      exceptions:
+          text: "Mercado Livre only supports 2FA with specifc app"
+      doc: http://contato.mercadolivre.com.br/ajuda/como-fortalecer-a-seguranca-da-sua-conta_961
 
     - name: Newegg
       url: http://www.newegg.com


### PR DESCRIPTION
-Add Mercado Livre, a Brazilian branch of Mercado Libre
-Also add remark to Mercado Libre regarding it only supporting 2FA using
Authy app and no others
