### PR TITLE
Cleanup verify

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,4 +9,5 @@ gem 'kramdown', '~> 1.10.0'
 group :test do
   gem 'rake'
   gem 'fastimage'
+  gem 'rubocop'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,9 @@
-task :default => [:verify]
+require 'rubocop/rake_task'
+
+RuboCop::RakeTask.new
+
+task default: %w(verify rubocop)
 
 task :verify do
-    ruby "./verify.rb"
+  ruby './verify.rb'
 end

--- a/verify.rb
+++ b/verify.rb
@@ -17,122 +17,111 @@ require 'fastimage'
 # TFA forms
 @tfa_forms = %w(email hardware software sms phone)
 
-# Should the script ignore checking the image size?
-@ignore_image_size = false
-
 # Image max size (in bytes)
-@image_max_size = 2500
+@img_max_size = 2500
+
+# Image dimensions
+@img_dimensions = [32, 32]
 
 # Image format used for all images in the 'img/' directories.
-@image_extension = ".png"
+@img_extension = '.png'
+
+# Send error message
+def error(msg)
+  @output += 1
+  puts "<------------ ERROR ------------>\n" if @output == 1
+  puts "#{@output}. #{msg}"
+end
+
+# Test an individual YAML tag
+# rubocop:disable AbcSize,CyclomaticComplexity,MethodLength,PerceivedComplexity
+def test_tag(tag, required, tfa_state, website, only_true = false)
+  if website[tag].nil?
+    error("#{website['name']}: The required YAML tag \'#{tag}\' tag is "\
+          'not present.') if website['tfa'] == tfa_state && required
+    return
+  end
+  error("#{website['name']}: The YAML tag \'#{tag}\' should NOT be "\
+        "present when TFA is #{website['tfa'] ? 'enabled' : 'disabled'}.")\
+        if website['tfa'] != tfa_state
+  error("#{website['name']}: The YAML tag \'#{tag}\' should either have"\
+        " a value set to \'Yes\' or not be used at all. (Current value:"\
+        " \'#{website[tag]}\')") if only_true && website[tag] != true
+end
+# rubocop:enable PerceivedComplexity
+
+# Check the YAML tags
+def test_tags(website)
+  tfa = website['tfa']
+  # rubocop:disable DoubleNegation
+  error("#{website['name']}: The YAML tag \'{tfa}\' should be either "\
+        "\'Yes\' or \'No\'. (#{tfa})") if !!tfa != tfa
+  # rubocop:endable DoubleNegation
+
+  # Test tags that are obligatory
+  @obligatory_tags.each do |t|
+    next unless website[t].nil?
+    error("#{website['name']}: The required YAML tag \'#{t}\' tag is not"\
+          ' present.')
+  end
+
+  # Test tags associated with TFA 'YES'
+  @tfa_yes_tags.each { |tfa_form| test_tag(tfa_form, false, true, website) }
+
+  # Test TFA form tags'
+  @tfa_forms.each { |tfa_form| test_tag(tfa_form, false, true, website, true) }
+
+  # Test tags associated with TFA 'NO'
+  @tfa_no_tags.each { |tfa_form| test_tag(tfa_form, false, false, website) }
+end
+# rubocop:enable MethodLength
+
+def test_img(img, name, imgs)
+  # Exception if image file not found
+  raise "#{name} image not found." unless File.exist?(img)
+  # Remove img from array unless it doesn't exist (double reference case)
+  imgs.delete_at(imgs.index(img)) unless imgs.index(img).nil?
+
+  # Check image dimensions
+  error("#{img} is not #{@img_dimensions.join('x')} pixels.")\
+    unless FastImage.size(img) == @img_dimensions
+
+  # Check image file extension and type
+  error("#{img} is not using the #{@img_extension} format.")\
+    unless File.extname(img) == @img_extension && FastImage.type(img) == :png
+
+  # Check image file size
+  img_size = File.size(img)
+  error("#{img} should not be larger than #{@img_max_size} bytes. It is"\
+          " currently #{img_size} bytes.") unless img_size <= @img_max_size
+end
+# rubocop:enable AbcSize,CyclomaticComplexity
 
 begin
 
-  # Send error message
-  def error(msg)
-    @output += 1
-    puts "<------------ ERROR ------------>\n" if @output == 1
-    puts "#{@output}. #{msg}"
-  end
-
-  # Validate an individual YAML tag
-  def check_tag(tag, required, tfa_state, website, only_true = false)
-    if website[tag].nil?
-      if website['tfa'] == tfa_state && required
-        error("#{website['name']}: The required YAML tag \'#{tag}\' tag is not present.")
-      end
-    else
-      if website['tfa'] != tfa_state
-        state = website['tfa'] ? "enabled" : "disabled"
-        error("#{website['name']}: The YAML tag \'#{tag}\' should NOT be present when TFA is #{state}.")
-      end
-      if only_true && website[tag] != true
-        error("#{website['name']}: The YAML tag \'#{tag}\' should either have a value set to \'Yes\' or not be used at all. (Current value: \'#{website[tag]}\')")
-      end
-    end
-  end
-
-  # Validate the YAML tags
-  def validate_tags(website)
-    tfa = website['tfa']
-    if tfa != true && tfa != false
-      error("#{website['name']}: The YAML tag \'#{tag}\' should be either \'Yes\' or \'No\'. (#{tfa})")
-    end
-
-    # Validate tags that are obligatory
-    @obligatory_tags.each do |t|
-      tag = website[t]
-      next unless tag.nil?
-      error("#{website['name']}: The required YAML tag \'#{t}\' tag is not present.")
-    end
-
-    # Validate tags associated with TFA 'YES'
-    @tfa_yes_tags.each do |tfa_form|
-      check_tag(tfa_form, false, true, website)
-    end
-
-    # Validate TFA form tags'
-    @tfa_forms.each do |tfa_form|
-      check_tag(tfa_form, false, true, website, true)
-    end
-
-    # Validate tags associated with TFA 'NO'
-    @tfa_no_tags.each do |tfa_form|
-      check_tag(tfa_form, false, false, website)
-    end
-  end
-
-  def validate_image(image, name, images)
-    if File.exist?(image)
-      if images.index(image) != nil
-        images.delete_at(images.index(image))
-      end
-
-      image_dimensions = [32, 32]
-
-      unless FastImage.size(image) == image_dimensions
-        error("#{image} is not #{image_dimensions.join('x')} pixels.")
-      end
-
-      error("#{image} is not using the #{@image_extension} format.") unless File.extname(image) == @image_extension
-
-      unless @ignore_image_size
-        image_size = File.size(image)
-        error("#{image} should not be larger than #{@image_max_size} bytes. It is currently #{image_size} bytes.") unless image_size <= @image_max_size
-      end
-
-    else
-      error("#{name} image not found.")
-    end
-  end
-
   # Load each section, check for errors such as invalid syntax
   # as well as if an image is missing
-
   sections = YAML.load_file('_data/sections.yml')
   sections.each do |section|
-
     data = YAML.load_file('_data/' + section['id'] + '.yml')
-    
-    if data['websites'] != data['websites'].sort_by { |h| h['name'].downcase }
-      error("_data/#{section['id']}.yml is not alphabetized by name")
+    websites = data['websites']
+
+    # Check section alphabetization
+    error("_data/#{section['id']}.yml is not alphabetized by name") \
+      if websites != websites.sort_by { |website| website['name'].downcase }
+
+    # Collect list of all images for section
+    imgs = Dir["img/#{section['id']}/*"]
+
+    websites.each do |website|
+      test_tags(website)
+      test_img("img/#{section['id']}/#{website['img']}", website['name'],
+               imgs)
     end
 
-    images = Dir["img/#{section['id']}/*"]
-
-    data['websites'].each do |website|
-
-      validate_tags(website)
-      validate_image("img/#{section['id']}/#{website['img']}", website['name'], images)
-
-    end
-
-    if not images.empty?
-      images.each do |image|
-        error("#{image} is an unused file")
-      end
-    end
-
+    # After removing images associated with entries in test_img, alert
+    # for unused or orphaned images
+    imgs.each { |img| next unless img.nil? error("#{img} is not used") }
   end
 
   exit 1 if @output > 0


### PR DESCRIPTION
This is an idea.

I enabled rubocop, which is an **aggressive** ruby linting tool. you can see that i disable a few of the check for the of the more complex functions, but this does force uniformity in the ruby code.

adding a .rubocop.yml is also an option (instead of the inline `# rubocop:disable` comments)

general comments or hatred welcome

next goal is to get/make a linting tool that tools at the editorconfig for all files
