### PR TITLE
Update Robinhood

### DIFF
--- a/_data/investing.yml
+++ b/_data/investing.yml
@@ -116,8 +116,9 @@ websites:
     - name: Robinhood
       url: https://www.robinhood.com/
       img: robinhood.png
-      tfa: No
-      twitter: RobinhoodApp
+      tfa: Yes
+      sms: Yes
+      doc: https://support.robinhood.com/hc/en-us/articles/211546986-Two-Factor-Authentication
 
     - name: Scottrade
       url: https://www.scottrade.com/


### PR DESCRIPTION
Robinhood supports SMS 2FA as of Sept. 7, 2016
http://blog.robinhood.com/news/2016/9/7/two-factor-authentication
