### PR TITLE
Added exception to Blizzard in gaming.yaml

### DIFF
--- a/_data/gaming.yml
+++ b/_data/gaming.yml
@@ -27,6 +27,8 @@ websites:
       sms: Yes
       software: Yes
       hardware: Yes
+      exceptions:
+          text: "Software implementation requires use of the Battle.net Authenticator mobile app. It does not support multiple accounts on the same device."
       doc: http://us.battle.net/en/security/
 
     - name: Curse


### PR DESCRIPTION
For software tokens, Blizzard requires that you use their own Battle.net Authenticator mobile app
