### PR TITLE
Added exception to Humble Bundle in gaming.yaml

### DIFF
--- a/_data/gaming.yml
+++ b/_data/gaming.yml
@@ -114,6 +114,8 @@ websites:
       tfa: Yes
       sms: Yes
       software: Yes
+      exceptions:
+          text: "Software implementation requires use of the Authy service."
       doc: https://support.humblebundle.com/hc/en-us/articles/202421374
 
     - name: Itch.io


### PR DESCRIPTION
For software tokens, Humble Bundle requires that you use the Authy service
