### PR TITLE
Add an exception to Vanguard

### DIFF
--- a/_data/investing.yml
+++ b/_data/investing.yml
@@ -174,6 +174,8 @@ websites:
       tfa: Yes
       sms: Yes
       doc: https://personal.vanguard.com/us/insights/article/Account-security-092015
+      exceptions:
+          text: "TFA is only available for Personal Investor accounts"
 
     - name: Wealthfront
       url: https://www.wealthfront.com/


### PR DESCRIPTION
Hello,

This pull request makes it clear that Vanguard does not support two factor authentication across all of its plans. The pull request also fixes #2096.
