### PR TITLE
Cryptocurrencies: Update: URL and Doc

### DIFF
--- a/_data/cryptocurrencies.yml
+++ b/_data/cryptocurrencies.yml
@@ -150,7 +150,7 @@ websites:
       sms: Yes
       software: Yes
       phone: Yes
-      doc: 
+      doc: https://support.coinbase.com/customer/en/portal/articles/1658338-how-do-i-set-up-2-factor-authentication-with-authy-
 
     - name: Coinfloor
       url: https://www.coinfloor.co.uk/

--- a/_data/cryptocurrencies.yml
+++ b/_data/cryptocurrencies.yml
@@ -1,6 +1,6 @@
 websites:
     - name: BitBay
-      url: http://bitbay.net
+      url: https://bitbay.net/
       img: bitbay.png
       tfa: Yes
       sms: Yes
@@ -85,7 +85,7 @@ websites:
       doc: https://support.btc-e.com/index.php?/Knowledgebase/Article/View/97/25/how-do-i-set-2-factor-authentication-to-my-btc-e-account
 
     - name: BTCJam
-      url: https://www.btcjam.com
+      url: https://btcjam.com/
       img: btcjam.png
       tfa: Yes
       software: Yes
@@ -134,7 +134,7 @@ websites:
       tfa: Yes
       software: Yes
       email: Yes
-      doc: http://blog.coincafe.com/2016/01/08/2fa/
+      doc: https://blog.coincafe.com/2016/01/08/2fa/
 
     - name: Coinapult
       url: https://coinapult.com
@@ -144,13 +144,13 @@ websites:
       doc: https://coinapult.com/faq
 
     - name: Coinbase
-      url: https://coinbase.com/
+      url: https://www.coinbase.com/
       img: coinbase.png
       tfa: Yes
       sms: Yes
       software: Yes
       phone: Yes
-      doc: http://blog.coinbase.com/post/25677574019/coinbase-now-offers-two-factor-authentication
+      doc: 
 
     - name: Coinfloor
       url: https://www.coinfloor.co.uk/
@@ -235,7 +235,7 @@ websites:
       img: localbitcoins.png
       tfa: Yes
       software: Yes
-      doc: http://localbitcoins.blogspot.fi/2013/05/using-two-factor-authentication-on.html
+      doc: https://localbitcoins.blogspot.com.au/2013/05/using-two-factor-authentication-on.html
 
     - name: Uphold
       url: https://uphold.com/


### PR DESCRIPTION
#### Changes:
- Updated: `url` and `doc` links. 
- Removed: Coinbase `doc` as it 404s and I couldn't find any documentation. 
