### PR TITLE
Update Aol Mail exception

### DIFF
--- a/_data/email.yml
+++ b/_data/email.yml
@@ -5,8 +5,6 @@ websites:
       tfa: Yes
       sms: Yes
       phone: Yes
-      exceptions:
-        text: "Currently U.S. only. International support coming soon."
       doc: https://help.aol.com/articles/2-factor-authentication-stronger-than-your-password-alone
 
     - name: FastMail


### PR DESCRIPTION
AOL Mail 2FA does support international users.  Updated to reflect this.
