### PR TITLE
Update Aol Mail

### DIFF
--- a/_data/email.yml
+++ b/_data/email.yml
@@ -5,7 +5,8 @@ websites:
       tfa: Yes
       sms: Yes
       phone: Yes
-      doc: https://help.aol.com/articles/2-factor-authentication-stronger-than-your-password-alone
+      software: Yes
+      doc: https://help.aol.com/articles/2-step-verification-stronger-than-your-password-alone
 
     - name: FastMail
       url: https://www.fastmail.com/


### PR DESCRIPTION
AOL released support for software tokens on 11/2.  Also the name has been updated to 2 Step Verification, so the help articles have been updated both for that and this new feature.  (updated the URL for help)