### PR TITLE
Update Paysafecard

### DIFF
--- a/_data/payments.yml
+++ b/_data/payments.yml
@@ -96,6 +96,7 @@ websites:
       img: paysafecard.png
       tfa: Yes
       software: Yes
+      doc: https://www.paysafecard.com/en-au/lp-products/2-step-login/
 
     - name: Privacy
       url: https://privacy.com/

--- a/_data/payments.yml
+++ b/_data/payments.yml
@@ -94,8 +94,8 @@ websites:
     - name: Paysafecard
       url: https://www.paysafecard.com/
       img: paysafecard.png
-      tfa: No
-      twitter: paysafecard
+      tfa: Yes
+      software: Yes
 
     - name: Privacy
       url: https://privacy.com/


### PR DESCRIPTION
@olback informed me that Paysafecard offers 2FA in the form of TOTP tokens.
SMS and Email is asked for upon registration but not used on every login.

Couldn't find a doc page but I do have a screenshot of the settings page to confirm.
_Please note that the settings page is in Swedish as they apparently change language per geo-ip location._ ☹️
![screenshot](https://puu.sh/so0ic/3fba935888.png)