### PR TITLE
Update INWX entry in Domains

### DIFF
--- a/_data/domains.yml
+++ b/_data/domains.yml
@@ -255,12 +255,12 @@ websites:
       software: Yes
       doc: /notes/internetbs/
 
-    - name: InterNetworX (INWX)
-      url: https://www.inwx.de/en/
+    - name: INWX
+      url: https://www.inwx.com/en/
       img: internetworx.png
       tfa: Yes
       software: Yes
-      doc: https://www.inwx.de/en/offer/mobiletan
+      doc: https://www.inwx.com/en/offer/mobiletan
 
     - name: iWantMyName
       url: https://iwantmyname.com/


### PR DESCRIPTION
Changed InterNetworX to INWX. 

See also [blogpost](https://www.inwx.com/en/news/364/internetworx-becomes-inwx-nothing-else-changes) about the namechange.