### PR TITLE
ProtonMail (v3.6) now supports 2fa with a software token.

### DIFF
--- a/_data/email.yml
+++ b/_data/email.yml
@@ -105,7 +105,9 @@ websites:
       twitter: ProtonMail
       facebook: protonmail
       img: protonmail.png
-      tfa: No
+      tfa: Yes
+      software: Yes
+      doc: https://protonmail.com/support/knowledge-base/two-factor-authentication/
 
     - name: Riseup Mail
       url: https://mail.riseup.net

--- a/_data/email.yml
+++ b/_data/email.yml
@@ -102,8 +102,6 @@ websites:
 
     - name: ProtonMail
       url: https://protonmail.com/
-      twitter: ProtonMail
-      facebook: protonmail
       img: protonmail.png
       tfa: Yes
       software: Yes


### PR DESCRIPTION
Support status updated. Documentation link added.

Ref: https://protonmail.com/blog/protonmail-v3-6-release-notes/