### PR TITLE
Fix mobile search and icon style

### DIFF
--- a/css/base.scss
+++ b/css/base.scss
@@ -184,12 +184,6 @@ input[type=search] {
     }
 
     .main {
-      display: -ms-flexbox;
-      display: -webkit-flex;
-      display: flex;
-      -ms-flex-direction: column;
-      flex-direction: column;
-
       .title {
         display: -ms-flexbox;
         display: -webkit-flex;
@@ -254,6 +248,7 @@ td img.icon,
   float: left;
   padding: 4px 4px;
   height: 2em;
+  width: 2em;
   line-height: 1;
   margin-right: 0.8em;
 }

--- a/js/app.js
+++ b/js/app.js
@@ -36,8 +36,7 @@ var jets = new Jets({
   contentTag: '.jets-content',
   didSearch: function (searchPhrase) {
     $('.category h5 i').removeClass('active-icon');
-    var platform;
-    $(window).width() > 768 ? platform = 'desktop' : platform = 'mobile';
+    var platform = ($(window).width() > 768) ? 'desktop' : 'mobile';
     var content = $('.' + platform + '-table .jets-content');
     var table = $('.' + platform + '-table');
 


### PR DESCRIPTION
My last PR(s) broke search on mobile. It was because flexbox was conflicting with Jets. Removing it from `.main` doesn't affect the table styling, and allow search to work again!

Also fixed the icon width that wasn't set properly.