### PR TITLE
Fix quoting for Watchman Monitoring

### DIFF
--- a/_data/other.yml
+++ b/_data/other.yml
@@ -408,7 +408,7 @@ websites:
       software: Yes
       doc: https://www.watchmanmonitoring.com/two-factor-authentication
       exceptions:
-          text: 'Two factor authentication unavailable for "End User" access, which is read-only.'
+          text: "Two factor authentication unavailable for 'End User' access, which is read-only."
 
     - name: Webmin
       url: http://www.webmin.com/


### PR DESCRIPTION
Double quotes used inside the string cause the layout to break as the generated HTML is invalid.

```html
<span class="popup exception"
    data-position="bottom center"
    data-html="<div class='header'>    Exceptions &amp; Restrictions</div><div class='content'>            Two factor authentication unavailable for "End User" access, which is read-only.    </div>">
    <i class="warning sign red link icon"></i>
</span>
```