### PR TITLE
Remove EVE Online exception

### DIFF
--- a/_data/gaming.yml
+++ b/_data/gaming.yml
@@ -67,7 +67,7 @@ websites:
       tfa: Yes
       email: Yes
       software: Yes
-      doc: https://community.eveonline.com/news/dev-blogs/two-factor-authentication/
+      doc: https://support.eveonline.com/hc/en-us/articles/203465601-Two-Factor-Authentication-and-Authenticator
 
     - name: GameFly
       url: https://www.gamefly.com/

--- a/_data/gaming.yml
+++ b/_data/gaming.yml
@@ -68,8 +68,6 @@ websites:
       email: Yes
       software: Yes
       doc: https://community.eveonline.com/news/dev-blogs/two-factor-authentication/
-      exceptions:
-          text: "This does not prevent people from logging into the game client by circumventing the launcher. That is a legacy issue that the developers have acknowledged."
 
     - name: GameFly
       url: https://www.gamefly.com/


### PR DESCRIPTION
The client login circumvention has fixed according to [this blog post](https://community.eveonline.com/news/news-channels/eve-online-news/exefile-login-to-be-discontinued-on-september-20th/)