### PR TITLE
ProtonMail (v3.6) now supports 2fa with a software token. (not duplicate)

### DIFF
--- a/_data/email.yml
+++ b/_data/email.yml
@@ -109,10 +109,10 @@ websites:
 
     - name: ProtonMail
       url: https://protonmail.com/
-      twitter: ProtonMail
-      facebook: protonmail
       img: protonmail.png
-      tfa: No
+      tfa: Yes
+      software: Yes
+      doc: https://protonmail.com/support/knowledge-base/two-factor-authentication/
 
     - name: Riseup Mail
       url: https://mail.riseup.net


### PR DESCRIPTION
Support status updated. Documentation link added. Contact info removed.
Ref: https://protonmail.com/blog/protonmail-v3-6-release-notes/

Please do not mark this PR as a duplicate:

These changes were originally submitted 15 days ago as PR #2207. My changes passed jekyll locally just fine. It was approved and merged. Unfortunately, the build machine had an outdated module installed that was incompatible with the current version of Travis. During the lint check, Travis exited with an error due to this build machine issue. @stephengroat fixed the Travis problem on the build machine and thought the PR #2208 merge would pull in the changes from PR #2207. But, the build system discarded the PR #2207 changes due to the build check failure before the PR #2208 merge was done. I am submitting this new PR so that the changes can easily be merged. I noticed some other people submitted ProtonMail updates that were marked duplicated in the last couple weeks. If it's easier for your guys to merge one of those I don't mind at all.

Thanks for all your work on the site. It's a great resource. It was very helpful in my efforts to raise the priority of 2fa support at ProtonMail internally.