### PR TITLE
Typo: itch.io is not capitalized

### DIFF
--- a/_data/gaming.yml
+++ b/_data/gaming.yml
@@ -124,7 +124,7 @@ websites:
       software: Yes
       doc: https://support.humblebundle.com/hc/en-us/articles/202421374
 
-    - name: Itch.io
+    - name: itch.io
       url: https://itch.io/
       img: itchio.png
       tfa: Yes


### PR DESCRIPTION
**itch.io** (with a lower case initial _i_) is how it is written in all documentation, including the Terms of Service.