### PR TITLE
Update Gems and documentation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,7 @@
 source 'https://rubygems.org'
 
-# Freeze to GitHub Pages versions:
-# https://pages.github.com/versions/
-gem 'github-pages', '~> 75'
-gem 'jekyll', '~> 3.0.4'
-gem 'kramdown', '~> 1.10.0'
+# Dependencies are bundled with the github-pages gem
+gem 'github-pages', '112', group: :jekyll_plugins
 
 group :test do
   gem 'fastimage'

--- a/README.md
+++ b/README.md
@@ -23,16 +23,19 @@ If you'd like to contribute, read the entire guidelines here in
 
 ## Running Locally
 
-TwoFactorAuth.org is built on [Jekyll](https://jekyllrb.com/). In order to run Jekyll, it is necessary to install Ruby with RubyGems.
+TwoFactorAuth.org is built upon [Jekyll](https://jekyllrb.com/), using the [github-pages](https://github.com/github/pages-gem) gem.
+In order to run the site locally, it is necessary to install bundler, install all dependencies, and then use Jekyll to serve
+the site. If the `gem` command is not available to you, it is necessary to install Ruby with RubyGems.
 Once Ruby and RubyGems are installed and available from the command line, TwoFactorAuth can be setup using the following commands.
 
 ```
-gem install jekyll
+gem install bundler
 cd ~/twofactorauth
+bundle install
 jekyll serve
 ```
 
-The TwoFactorAuth website should then be running on `http://localhost:4000`.
+The TwoFactorAuth website should then be accessible from `http://localhost:4000`.
 
 ## License
 


### PR DESCRIPTION
Hello!

This pull request updates twofactorauth.org's dependencies (they were last updated in commit cb5b295ecf30ba4850ec2aba2f52c33dcb644b44). Due to restructuring of the `github-pages` gem, it is no longer necessary to freeze dependency versions individually in the Gemfile.
According instructions have also been updated in README.md.

Thanks,
psgs 🌴 