### PR TITLE
Vanguard u2f/alternate method update

### DIFF
--- a/_data/investing.yml
+++ b/_data/investing.yml
@@ -177,7 +177,9 @@ websites:
       img: vanguard.png
       tfa: Yes
       sms: Yes
-      doc: https://personal.vanguard.com/us/insights/article/Account-security-092015
+      phone: Yes
+      hardware: Yes
+      doc: https://personal.vanguard.com/us/insights/article/security-codes-112015
       exceptions:
           text: "TFA is only available for Personal Investor accounts"
 


### PR DESCRIPTION
While only available to logged-in users, Vanguard's u2f documentation is available here: https://personal.vanguard.com/us/U2FKeyEnrollment.

I assume it has the same restriction to personal investing accounts only, so the exception still stands.

I also added a link to the blog post which outlines that both SMS and voice call 2fa are available.