### PR TITLE
Remove hardware support for Name.com

### DIFF
--- a/_data/domains.yml
+++ b/_data/domains.yml
@@ -312,7 +312,6 @@ websites:
       img: namecom.png
       tfa: Yes
       software: Yes
-      hardware: Yes
       doc: https://www.name.com/services/two-step-verification
 
     - name: Namecheap


### PR DESCRIPTION
I am not sure if support for hardware tokens existed previously, but currently, as far as Name.com docs and account settings show, there is no support for hardware tokens. Only TOTP using Google Authenticator is supported.