### PR TITLE
Fix Betterment 2FA FAQ link

### DIFF
--- a/_data/investing.yml
+++ b/_data/investing.yml
@@ -11,7 +11,7 @@ websites:
       tfa: Yes
       software: Yes
       sms: Yes
-      doc: https://support.betterment.com/customer/en/portal/topics/1023745-two-factor-authentication-2fa-?b_id=9042
+      doc: https://support.betterment.com/customer/en/portal/topics/1026376-two-factor-authentication-2fa-?b_id=9042
 
     - name: Charles Schwab
       url: https://www.schwab.com/


### PR DESCRIPTION
The URL for our 2FA support page changed.