### PR TITLE
Change eBay Software status to No

### DIFF
--- a/_data/retail.yml
+++ b/_data/retail.yml
@@ -81,7 +81,7 @@ websites:
       img: ebay.png
       tfa: Yes
       hardware: Yes
-      software: Yes
+      software: No
       exceptions:
           text: "eBay only supports 2FA in some countries."
       doc: http://pages.ebay.com/securitykey/faq.html


### PR DESCRIPTION
I cannot find any evidence that eBay supports Software 2FA. The linked URL references a hardware token that is available. There is no information about using software tokens.