### PR TITLE
Halebop supports 2FA using BankID

### DIFF
--- a/_data/utilities.yml
+++ b/_data/utilities.yml
@@ -143,6 +143,7 @@ websites:
       lang: sv
       exceptions:
           text: "2FA is only available for Swedish citizens with BankID."
+      doc: https://github.com/2factorauth/twofactorauth/pull/2304#issue-200730083
 
     - name: Optus
       url: http://www.optus.com.au/

--- a/_data/utilities.yml
+++ b/_data/utilities.yml
@@ -140,7 +140,6 @@ websites:
       img: halebop.png
       tfa: Yes
       software: Yes
-      lang: sv
       exceptions:
           text: "2FA is only available for Swedish citizens with BankID."
       doc: https://github.com/2factorauth/twofactorauth/pull/2304#issue-200730083

--- a/_data/utilities.yml
+++ b/_data/utilities.yml
@@ -137,11 +137,12 @@ websites:
 
     - name: Halebop
       url: https://www.halebop.se/
-      twitter: halebop_sverige
-      facebook: halebop
       img: halebop.png
-      tfa: No
+      tfa: Yes
+      software: Yes
       lang: sv
+      exceptions:
+          text: "2FA is only available for Swedish citizens with BankID."
 
     - name: Optus
       url: http://www.optus.com.au/


### PR DESCRIPTION
Halebop supports 2FA using BankID. I can't find any documentation but BankID is well used in Sweden. It's the same solution as for example Klarna and Loopia.
![halebop](https://cloud.githubusercontent.com/assets/9416498/21945514/f0fe0982-d9db-11e6-9efa-dacb24811c4d.png)
