### PR TITLE
BitGo has removed SMS 2FA support and add hardware tag

### DIFF
--- a/_data/cryptocurrencies.yml
+++ b/_data/cryptocurrencies.yml
@@ -33,8 +33,8 @@ websites:
       url: https://www.bitgo.com
       img: bitgo.png
       tfa: Yes
-      sms: Yes
       software: Yes
+      hardware: Yes
       doc: https://bitgo.zendesk.com/hc/en-us/sections/201009049-Two-Factor-Authentication-Help-Page
 
     - name: Bitlish


### PR DESCRIPTION
We have removed SMS 2FA due to the rise in phone porting attacks https://blog.bitgo.com/bitgo-phasing-out-sms-based-2-factor-authentication-96db16fdd63a