### PR TITLE
Mint does not support 2FA

### DIFF
--- a/_data/finance.yml
+++ b/_data/finance.yml
@@ -123,10 +123,10 @@ websites:
     - name: Mint
       url: https://www.mint.com
       img: mint.png
-      tfa: Yes
-      sms: Yes
-      email: Yes
-      software: Yes
+      tfa: No
+      sms: No
+      email: No
+      software: No
 
     - name: Mint Bills (formerly Check)
       url: https://bills.mint.com


### PR DESCRIPTION
Mint has no support for hardware or software 2FA. If you're signing in from a new device they will email an OTP, but I wouldn't consider that 2FA since it doesn't occur for every login nor is it configurable.