### PR TITLE
Avoid noscript content in data-jets attribute

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -63,7 +63,9 @@ var jets = new Jets({
       isSearching = true;
     }
   },
-  columns: [0] // Search by first column only
+  manualContentHandling: function(tr) {
+    return $(tr).find('td:first a').text();
+  }
 });
 
 /**


### PR DESCRIPTION
How it was [before](http://codepen.io/NeXTs/pen/bgRemv?editors=1010)
<img width="788" alt="screen shot 2017-01-23 at 6 55 23 pm" src="https://cloud.githubusercontent.com/assets/1753208/22213642/a3f8e91c-e19d-11e6-84de-072963e5a451.png">

How it is [now](http://codepen.io/NeXTs/pen/ygXJaj?editors=1010)
<img width="729" alt="screen shot 2017-01-23 at 6 55 51 pm" src="https://cloud.githubusercontent.com/assets/1753208/22213647/a9b44220-e19d-11e6-8cca-b48c4fe63d66.png">


See diff in row's data-jets attribute