### PR TITLE
Fix value for link to YAML file in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,14 +82,13 @@ View the complete list in the [EXCLUSION.md file][exclude].
 
 ## New Sections
 
-To add a new section, modify the `sections` value in [main.yml](_data/main.yml)
+To add a new section, modify the `sections` value in [sections.yml](_data/sections.yml)
 and follow the template below:
 
 ```yml
-sections:
-  - id: category-id
-    title: Category Name
-    icon: icon-class
+- id: category-id
+  title: Category Name
+  icon: icon-class
 ```
 
 Then create a new file in the `_data` directory with the same name as your section's


### PR DESCRIPTION
The instructions for adding a new section are out of date, as `main.yml` doesn't exist. I changed this value to `sections.yml` and made small adjustments to the instructions for the time being.