### PR TITLE
Autofocus search box

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,7 +58,7 @@ hash: SupportTwoFactorAuth
       <i class="search icon"></i>
     </label>
     <input type="search" id="jets-search" placeholder="Search websites" autocomplete="off" spellcheck="false"
-           tabindex="0">
+           tabindex="0" autofocus>
   </div>
 </div>
 


### PR DESCRIPTION
I assume most visitors to https://twofactorauth.org/ immediately use the search box, so automatically focus the search box.