### PR TITLE
Update Barclays UK doc URL

### DIFF
--- a/_data/banking.yml
+++ b/_data/banking.yml
@@ -102,7 +102,7 @@ websites:
       tfa: Yes
       hardware: Yes
       software: Yes
-      doc: https://ask.barclays.co.uk/help/security/protection
+      doc: https://www.barclays.co.uk/Helpsupport/UpgradetoPINsentry/P1242559314766
 
     - name: Barclays US
       url: https://www.banking.barclaysus.com/index.html


### PR DESCRIPTION
The old Barclays UK doc page redirects to a general security FAQ with no mention of 2FA.

I'm not entirely sure if Barclays UK still supports 2FA. Can someone with an account confirm?