### PR TITLE
Update Pogoplug

### DIFF
--- a/_data/backup.yml
+++ b/_data/backup.yml
@@ -133,7 +133,6 @@ websites:
     twitter: pogoplug
     img: pogoplug.png
     tfa: No
-    status: https://twitter.com/pogoplug/status/486192568745476096
 
   - name: QNAP
     url: https://www.qnap.com


### PR DESCRIPTION
As per issue #1508, the last update on 2FA from Pogoplug was from 2014.