### PR TITLE
Contributing: Add "lang" field to example (#2357)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,9 +120,11 @@ websites:
     software: Yes
     hardware: Yes
     doc: <link to site TFA documentation>
+    lang: <ISO 639-1 language code>
 ```
 
 The fields `name:`, `url:`, `img:`, `tfa:` are required for all entries.
+The field `lang:` is only used for non-English websites. The language codes should be lowercase [ISO 639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) codes.
 
 #### Adding a site that *supports* TFA
 


### PR DESCRIPTION
* Contributing: Explain usage of `lang` field

Added 'lang' tag to the website template and explained its usage.

* Contributing: Specify lang code uses ISO 639-1

* Add wiki link for the lang codes