### PR TITLE
Remove exception from DigitalOcean

### DIFF
--- a/_data/cloud.yml
+++ b/_data/cloud.yml
@@ -48,8 +48,6 @@ websites:
       img: digitalocean.png
       tfa: Yes
       software: Yes
-      exceptions:
-          text: "SMS-capable phone required."
       doc: https://www.digitalocean.com/company/blog/introducing-two-factor-authentication/
 
     - name: EngineYard


### PR DESCRIPTION
See https://www.digitalocean.com/company/blog/updates-to-digitalocean-two-factor-authentication/

> Our new two-factor authentication features allow developers to choose between an authenticator app or SMS as a primary method, and between downloadable codes, authenticator app, or SMS as backup methods. This way SMS stays an option, but isn't a necessary part of securing access to your DigitalOcean account.