### PR TITLE
Update Square

### DIFF
--- a/_data/payments.yml
+++ b/_data/payments.yml
@@ -125,8 +125,9 @@ websites:
       img: squareup.png
       tfa: Yes
       sms: Yes
+      software: Yes
       exceptions:
-        text: "Currently only US merchants, protects only Dashboard access"
+        text: "SMS only supported in US and Canada"
       doc: https://squareup.com/help/us/en/article/5593-2-step-verification
 
     - name: Square Cash


### PR DESCRIPTION
Google Authenticator (or any other software/hardware that supports RFC6238 TOTP)
is now supported everywhere, while SMS 2FA is only supported in US/CA.  I didn't
list it as supporting hardware tokens despite some hardware supporting TOTP
since otherwise there would be no point of having a hardware entry separate from
software.