### PR TITLE
Corrected Loopia exception.

### DIFF
--- a/_data/domains.yml
+++ b/_data/domains.yml
@@ -284,7 +284,7 @@ websites:
       software: Yes
       doc: https://blogg.loopia.se/2015/03/16/nu-kan-du-logga-in-med-tvafaktorsautentiering-hos-loopia-genom-bankid/
       exceptions:
-          text: "TFA only available for Swedish citizens"
+          text: "TFA only available for Swedish residents with BankID."
 
     - name: MarkMonitor
       url: https://www.markmonitor.com


### PR DESCRIPTION
Citizenship is not required - a permanent residence with a Swedish personal number from the Swedish tax authorities is enough.