### PR TITLE
Add more regex patterns

### DIFF
--- a/websites_schema.yml
+++ b/websites_schema.yml
@@ -12,6 +12,7 @@ mapping:
             unique: yes
           "url":
             type: str
+            pattern: /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/
             required: yes
             unique: yes
           "img":
@@ -21,16 +22,16 @@ mapping:
             type: bool
             required: yes
           "software":
-            type: bool 
+            type: bool
             pattern: /true/
           "hardware":
-            type: bool 
+            type: bool
             pattern: /true/
           "sms":
-            type: bool 
+            type: bool
             pattern: /true/
           "phone":
-            type: bool 
+            type: bool
             pattern: /true/
           "email":
             type: bool
@@ -45,12 +46,15 @@ mapping:
             type: str
           "twitter":
             type: str
+            pattern: /(\w){1,15}$/
           "facebook":
             type: str
+            pattern: /(\w){1,50}$/
           "email_address":
             type: str
             pattern: /\A([\w+\-].?)+@[a-z\d\-]+(\.[a-z]+)*\.[a-z]+\z/i
           "status":
             type: str
+            pattern: /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/
           "lang":
             type: str


### PR DESCRIPTION
Hello,
I decided to go over the websites_schema.yml and found that there was room for improving the regex pattern checks. I've added some patterns such as a URL pattern for the `url` tag, twitter handle pattern for the `twitter` tag and a facebook page pattern.

For the twitter handle there seems to be a 16 character limit including the `@` and since we don't display the `@` the pattern is set to have a maximum char limit of 15.

For the facebook handle I looked at facebook's own documentation [\[i\]](https://www.facebook.com/help/105399436216001) which states that pages must have a name of at least 5 characters and a maximum of 50. This however seems to be inaccurate as several the sites we list here use fewer characters. Maybe it's a legacy thing?
Therefore I decided to stick with the 50 char maximum limit and set a 1 char minimum limit.


For the URL checking I've used http://stackoverflow.com/a/3809435.
This pattern checks for HTTP/HTTPS and a valid url.


_//Carl <img src="https://emoji.slack-edge.com/T09K5E2M8/tay/f281b204bc62cd07.png" alt=":tay:" height="32" width="32"/>_