### PR TITLE
Vanguard supports TFA not just for personal accounts

### DIFF
--- a/_data/investing.yml
+++ b/_data/investing.yml
@@ -189,8 +189,6 @@ websites:
       phone: Yes
       hardware: Yes
       doc: https://personal.vanguard.com/us/insights/article/security-codes-112015
-      exceptions:
-          text: "TFA is only available for Personal Investor accounts"
 
     - name: Wealthfront
       url: https://www.wealthfront.com/


### PR DESCRIPTION
I have an employer sponsored retirement account and am able to set up hardware token on my account.

U2F announcement [here](http://www.cybersecuritytrend.com/news/2017/01/17/8480728.htm) though it doesn't state account type restrictions.