### PR TITLE
Add 1984 hosting

### DIFF
--- a/_data/domains.yml
+++ b/_data/domains.yml
@@ -28,6 +28,12 @@ websites:
       twitter: 123reg
       facebook: 123regfans
 
+    - name: 1984 Hosting
+      url: https://www.1984hosting.com/
+      twitter: 1984HostingCo
+      facebook: 1984Hosting
+      tfa: No
+      
     - name: 1and1
       url: https://www.1and1.com/
       img: 1and1.png


### PR DESCRIPTION
1984 hosting doesn't have a favicon. Their only logo is a stylized 1984 with a 4:1 aspect ratio, so I'm not really sure what to do for an icon...