### PR TITLE
Update Sendloop doc link

### DIFF
--- a/_data/communication.yml
+++ b/_data/communication.yml
@@ -156,7 +156,7 @@ websites:
       img: sendloop.png
       tfa: Yes
       software: Yes
-      doc: https://sendloop.com/help/account-settings/how-can-i-make-my-account-more-secure/
+      doc: https://help.sendloop.com/docs/securing-your-account
 
     - name: Skype (via Microsoft Account)
       url: https://www.skype.com


### PR DESCRIPTION
The doc link for Sendloop which is currently listed redirects to the one I have updated it to. No changes to their 2FA process seem to have been made.