### PR TITLE
Add a notice about Launchpad being still in beta.

### DIFF
--- a/_data/developer.yml
+++ b/_data/developer.yml
@@ -209,6 +209,8 @@ websites:
       hardware: Yes
       software: Yes
       doc: https://help.ubuntu.com/community/SSO/FAQs/2FA
+      exceptions:
+          text: "TFA available only after joining beta testers group"
 
     - name: Looker
       url: https://looker.com/


### PR DESCRIPTION
Even three years later it appears you need to join the beta testers group to be able to use 2FA on Launchpad.