### PR TITLE
Add no results message and fix location hash

### DIFF
--- a/css/base.scss
+++ b/css/base.scss
@@ -122,6 +122,12 @@ input[type=search] {
   }
 }
 
+#no-results {
+  display: none;
+  padding-bottom: 40px;
+  text-align: center;
+}
+
 .active-icon {
   background-color: $primary-color;
   color: white;

--- a/index.html
+++ b/index.html
@@ -95,3 +95,7 @@ hash: SupportTwoFactorAuth
     {% endif %}
     {% endfor %}
   </div>
+
+  <div id="no-results">
+    <h2>No results found</h2>
+  </div>

--- a/js/app.js
+++ b/js/app.js
@@ -7,6 +7,12 @@ $(document).ready(function () {
 
   // Unveil images 50px before they appear
   $('img').unveil(50);
+
+  // Show exception warnings upon hover
+  $('span.popup.exception').popup({
+    hoverable: true
+  });
+  $('a.popup.exception').popup();
 });
 
 /**
@@ -22,47 +28,50 @@ $(window).resize(function () {
   }, 500);
 });
 
-// Show exception warnings upon hover
-(function (root, $) {
-  $('span.popup.exception').popup({
-    hoverable: true
-  });
-  $('a.popup.exception').popup();
-}(window, jQuery));
-
 var isSearching = false;
 var jets = new Jets({
   searchTag: '#jets-search',
   contentTag: '.jets-content',
   didSearch: function (searchPhrase) {
+    document.location.hash = '';
+    $('#no-results').css('display', 'none');
     $('.category h5 i').removeClass('active-icon');
+    // Two separate table layouts are used for desktop/mobile
     var platform = ($(window).width() > 768) ? 'desktop' : 'mobile';
     var content = $('.' + platform + '-table .jets-content');
     var table = $('.' + platform + '-table');
 
     // Non-strict comparison operator is used to allow for null
     if (searchPhrase == '') {
+      // Show all categories when no search term is entered
       $('.website-table').css('display', 'none');
       $('.website-table .label').css('display', 'none');
       $('.category').show();
       $('table').show();
       isSearching = false;
     } else {
+      // Hide irrelevant categories
       $('.website-table').css('display', 'none');
       $('.website-table .label').css('display', 'block');
       $('.category').hide();
       table.css('display', 'block');
       content.parent().show();
       content.each(function () {
-        // Hide table when all rows are hidden by Jets
+        // Hide table when all rows within are hidden by Jets
         if ($(this).children(':hidden').length === $(this).children().length) {
           if (platform == 'mobile') $(this).parent().hide();
           else $(this).parent().parent().hide();
         }
       });
+
+      if (table.children().length == table.children(':hidden').length) {
+          $('#no-results').css('display', 'block');
+      }
+
       isSearching = true;
     }
   },
+  // Process searchable elements manually
   manualContentHandling: function(tag) {
     return $(tag).find('.title > a.name').text();
   }
@@ -127,4 +136,5 @@ function openCategory(category) {
 function closeCategory(category) {
   $('#' + category + ' h5 i').removeClass('active-icon');
   $('.' + category + '-table').css('display', 'none');
+  document.location.hash = '';
 }


### PR DESCRIPTION
Hello!

This pull request adds a "No Results" message when no search results can be found. The window location hash (for example `https://twofactorauth.com/#cloud`) is also removed when a particular category is closed.

<img width="1618" alt="screen shot 2017-07-04 at 14 11 25" src="https://user-images.githubusercontent.com/3946887/27814835-c6b973dc-60c2-11e7-9961-49b46b227a1b.png">

Thanks,
psgs 🌴 