### PR TITLE
Remove version hold on ghpages gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 # Dependencies are bundled with the github-pages gem
-gem 'github-pages', '140', group: :jekyll_plugins
+gem 'github-pages', group: :jekyll_plugins
 
 group :test do
   gem 'fastimage'


### PR DESCRIPTION
It's already bumped another version from #2616, I think we can trust that github will be using the latest version