### PR TITLE
Add code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,6 @@
 # Below is a list of files/directories along with their owner.
-# Owners are responsible for their files and owner approval is needed before any changes to said files can be done.
-# This is managed by GitHub's "code owners" https://github.com/blog/2392-introducing-code-owners
+# Owners are responsible for their files and owner approval is needed before any changes to said files can occur.
+# This is managed by GitHub's "code owners" feature https://github.com/blog/2392-introducing-code-owners
 
 # Jekyll and website design
 js/*		@psgs

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,19 @@
+# Below is a list of files/directories along with their owner.
+# Owners are responsible for their files and owner approval is needed before any changes to said files can be done.
+# This is managed by GitHub's "code owners" https://github.com/blog/2392-introducing-code-owners
+
+# Jekyll and website design
+js/*		@psgs
+css/*		@psgs
+lib/*		@psgs
+_layouts/*	@psgs
+_includes/*	@psgs
+_sass/*		@psgs
+_config.yml	@psgs
+
+# Core files
+CNAME		@2factorauth/core
+LICENSE		@2factorauth/core
+
+# Miscellaneous files
+data.json       @carlgo11

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -16,4 +16,6 @@ CNAME		@2factorauth/core
 LICENSE		@2factorauth/core
 
 # Miscellaneous files
-data.json       @carlgo11
+data.json	@carlgo11
+verify.rb	@stephengroat
+Rakefile	@stephengroat


### PR DESCRIPTION
GitHub recently added [code owners](https://github.com/blog/2392-introducing-code-owners).
This is something that have been on their to do list for a long while. Last year at GitHub Universe, when they added 'reviewers', they told the audience that code owners was on their road map. Finally it's here! 🍰

I added a little note at the top of the document, describing what the files does.
Is the language okay?

Also, am I missing some essential file?

_//Carl <img src="https://emoji.slack-edge.com/T09K5E2M8/tay/f281b204bc62cd07.png" alt=":tay:" height="32" width="32"/>_