### PR TITLE
Update Samsung

### DIFF
--- a/_data/retail.yml
+++ b/_data/retail.yml
@@ -264,7 +264,6 @@ websites:
 
     - name: Samsung
       url: http://www.samsung.com/
-      twitter: SamsungMobile
       img: samsung.png
       tfa: Yes
       sms: Yes

--- a/_data/retail.yml
+++ b/_data/retail.yml
@@ -266,7 +266,8 @@ websites:
       url: http://www.samsung.com/
       twitter: SamsungMobile
       img: samsung.png
-      tfa: No
+      tfa: Yes
+      sms: Yes
 
     - name: Sierra Trading Post
       url: http://www.sierratradingpost.com

--- a/_data/retail.yml
+++ b/_data/retail.yml
@@ -267,6 +267,7 @@ websites:
       img: samsung.png
       tfa: Yes
       sms: Yes
+      doc: https://help.content.samsung.com/csweb/faq/searchFaq.do?category1_id=sacb-01-003&serviceCd=saccount
 
     - name: Sierra Trading Post
       url: http://www.sierratradingpost.com


### PR DESCRIPTION
#### Changes: 
- Updated: Samsung under retail. 

  - Samsung supports SMS two factor authentication (referred to as "2-step verification" on the webpage.) I briefly searched for a doc link, but could not find one. 

#### Steps to turn on 2-step verification: 

1. Go to [Samsung account](https://account.samsung.com/). 
2. Click _Sign in_. 
3. Enter login details. 
4. Click _Security_. 
5. Verify password. 
6. On _Enable 2-step verification_ click _Turn On_. 
7. Enter phone number and confirm. 
8. _???_ 
9. Security!
