### PR TITLE
Add Software Token 2FA to Namecheap

### DIFF
--- a/_data/domains.yml
+++ b/_data/domains.yml
@@ -329,6 +329,7 @@ websites:
       tfa: Yes
       sms: Yes
       phone: Yes
+      software: Yes
       doc: https://www.namecheap.com/support/knowledgebase/article.aspx/9253/45/how-to-two-factor-authentication
 
     - name: NameSilo.com


### PR DESCRIPTION
Namecheap recently added the option to use its own mobile app as an extra way of two factor authentication, called [OneTouch](https://www.namecheap.com/support/knowledgebase/article.aspx/9905/45/how-can-i-use-onetouch-method-for-twofactor-authentication).

Therefore I added the "software token" flag to the already present entry for Namecheap.