### PR TITLE
added additional methods now available in bitwarden

### DIFF
--- a/_data/identity.yml
+++ b/_data/identity.yml
@@ -20,7 +20,11 @@ websites:
       url: https://bitwarden.com
       img: bitwarden.png
       tfa: Yes
+      sms: Yes
+      email: Yes
+      phone: Yes
       software: Yes
+      hardware: Yes
       doc: https://help.bitwarden.com/article/setup-two-step-login/
 
     - name: Centrify


### PR DESCRIPTION
bitwarden recently released additional 2FA support for email, YubiKeys, FIDO U2F, and Duo (which supports push, sms and phone calls). see https://help.bitwarden.com/article/setup-two-step-login/ for all details