### PR TITLE
HostHatch: Now supports 2fa

### DIFF
--- a/_data/hosting.yml
+++ b/_data/hosting.yml
@@ -129,9 +129,8 @@ websites:
     - name: HostHatch
       url: https://hosthatch.com/
       img: hosthatch.png
-      tfa: No
-      twitter: HostHatch
-      facebook: hosthatch
+      tfa: Yes
+      software: Yes
 
     - name: ICUK
       url: https://icuk.net


### PR DESCRIPTION
HostHatch now supports 2fa using software. No link to documentation but looks like this:
![hosthatch](https://user-images.githubusercontent.com/9416498/29997425-1b4c90da-9013-11e7-8e97-943b1935287a.jpg)
