### PR TITLE
Contributing: Adding a site that does not support TFA: Email Address

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,6 +160,7 @@ The following is an example of a website that *does not* support TFA:
       url: https://www.netflix.com/us/
       twitter: Netflixhelps
       facebook: netflix
+      email_address: example@netflix.com (Only if available and monitored)
       img: netflix.png
       tfa: No
       lang: <ISO 639-1 language code> (Only for non-English websites)


### PR DESCRIPTION
The [example](https://github.com/2factorauth/twofactorauth/blob/5d47853db54c5c22f0e14e9f41b0d0c9894dec3e/CONTRIBUTING.md#adding-a-site-that-does-not-support-tfa) is now more consistent with [wiki/FAQ-New-Site](https://github.com/2factorauth/twofactorauth/wiki/FAQ-New-Site/0cf58c0552a696e36616ae1f75514e2a176db12f#i-want-to-add-a-site-thats-not-currently-using-two-factor-authentication-to-the-list). 
