### PR TITLE
Update Trello

### DIFF
--- a/_data/task.yml
+++ b/_data/task.yml
@@ -48,6 +48,7 @@ websites:
       img: trello.png
       tfa: Yes
       sms: Yes
+      software: Yes
       doc: http://help.trello.com/article/993-enabling-two-factor-authentication-for-your-trello-account
 
     - name: Wunderlist


### PR DESCRIPTION
Trello now supports software authenticator apps. Partially solves #2703.
The option is on their existing 2FA settings page:
![2FA software config page](https://user-images.githubusercontent.com/1897053/30437369-a924c550-992b-11e7-9bbc-814442db0699.png)
They've also added a small note to the existing documentation.:
![2FA documentation with software note highlighted](https://user-images.githubusercontent.com/1897053/30437446-dbfef590-992b-11e7-882e-7fb93fe051f7.png)
