### PR TITLE
Add U2F (hardware) to gandi.net

### DIFF
--- a/_data/domains.yml
+++ b/_data/domains.yml
@@ -193,6 +193,7 @@ websites:
       img: gandi.png
       tfa: Yes
       software: Yes
+      hardware: Yes
       doc: https://wiki.gandi.net/en/contacts/login/2-factor-activation
 
     - name: GoDaddy


### PR DESCRIPTION
As of today Gandi's new website supports U2F authentication
