### PR TITLE
Fix Travis Error: Facebook → facebook

### DIFF
--- a/_data/retail.yml
+++ b/_data/retail.yml
@@ -97,7 +97,7 @@ websites:
       img: eprice.png
       tfa: No
       twitter: EPRICEIT
-      Facebook: ePRICE.it
+      facebook: ePRICE.it
       lang: it
 
     - name: Etsy


### PR DESCRIPTION
[Resolves](https://travis-ci.org/2factorauth/twofactorauth/jobs/280132399): `1. ePRICE: key 'Facebook:' is undefined.` 
