### PR TITLE
Update Viber - twitter and email_address

### DIFF
--- a/_data/communication.yml
+++ b/_data/communication.yml
@@ -98,7 +98,6 @@ websites:
       facebook: irccloud
       tfa: No
 
-
     - name: Kik
       url: https://www.kik.com/
       img: kik.png
@@ -238,8 +237,9 @@ websites:
       url: https://www.viber.com
       img: viber.png
       tfa: No
-      twitter: viber
+      twitter: ViberHelp
       facebook: viber
+      email_address: support@viber.com
 
     - name: WhatsApp
       url: https://www.whatsapp.com/


### PR DESCRIPTION
Removed extra line. 

Changed `twitter` to [Viber](https://www.viber.com/)'s tech support and assistance [handle](https://twitter.com/ViberHelp). 

Added Viber's [support email address](https://support.viber.com/customer/portal/emails/new). 
