### PR TITLE
Update Zalando - twitter, facebook, and email_address

### DIFF
--- a/_data/retail.yml
+++ b/_data/retail.yml
@@ -335,7 +335,9 @@ websites:
       url: https://www.zalando.co.uk/
       img: zalando.png
       tfa: No
-      twitter: Zalando_uk
+      twitter: zalando_uk
+      facebook: Zalando.co.uk
+      email_address: service@zalando.co.uk
 
     - name: Zappos
       url: http://www.zappos.com/


### PR DESCRIPTION
Match the case for the Twitter handle. 

Added [Zalando](https://www.zalando.co.uk/)'s [Facebook page](https://www.facebook.com/Zalando.co.uk/). 

Added Zalando's [service email address](https://www.zalando.co.uk/contact/). 
