### PR TITLE
Update Wealthsimple 2FA details

### DIFF
--- a/_data/investing.yml
+++ b/_data/investing.yml
@@ -202,7 +202,9 @@ websites:
     - name: Wealthsimple
       url: https://www.wealthsimple.com
       img: wealthsimple.png
-      tfa: No
+      tfa: Yes
+      sms: Yes
+      software: Yes
       twitter: Wealthsimple
       facebook: wealthsimple
 

--- a/_data/investing.yml
+++ b/_data/investing.yml
@@ -205,8 +205,6 @@ websites:
       tfa: Yes
       sms: Yes
       software: Yes
-      twitter: Wealthsimple
-      facebook: wealthsimple
 
     - name: WiseBanyan
       url: https://www.wisebanyan.com/


### PR DESCRIPTION
Wealthsimple will shortly be launching 2FA, supporting both TOTP software and SMS as authentication methods.

I wanted to submit a PR now so that we can keep you up to date with the change.