### PR TITLE
Paycor supports software 2fa now

### DIFF
--- a/_data/finance.yml
+++ b/_data/finance.yml
@@ -189,6 +189,7 @@ websites:
       sms: Yes
       email: Yes
       phone: Yes
+      software: Yes
       doc: https://www.paycor.com/security/how-to-keep-your-account-safe
 
     - name: Paytrust


### PR DESCRIPTION
They don't mention it on their doc page, but in the user settings there's an option to use Google Authenticator. This displays a regular QR code that works in any TOTP app.