### PR TITLE
Add Bitwarden exception

### DIFF
--- a/_data/identity.yml
+++ b/_data/identity.yml
@@ -25,6 +25,8 @@ websites:
       phone: Yes
       software: Yes
       hardware: Yes
+      exceptions:
+        text: "Premium account required for hardware 2FA."
       doc: https://help.bitwarden.com/article/setup-two-step-login/
 
     - name: Centrify

--- a/_data/identity.yml
+++ b/_data/identity.yml
@@ -26,7 +26,7 @@ websites:
       software: Yes
       hardware: Yes
       exceptions:
-        text: "Premium account required for hardware 2FA."
+        text: "Premium account required for Duo, YubiKey and FIDO U2F."
       doc: https://help.bitwarden.com/article/setup-two-step-login/
 
     - name: Centrify


### PR DESCRIPTION
Bitwarden requires you to have a [premium](https://help.bitwarden.com/article/setup-two-step-login/) account to use hardware 2FA. I think it would be good to have an exception for this.