### PR TITLE
Set Capital One tfa: to No

### DIFF
--- a/_data/banking.yml
+++ b/_data/banking.yml
@@ -166,11 +166,7 @@ websites:
     - name: Capital One
       url: https://www.capitalone.com/
       img: capitalone.png
-      tfa: Yes
-      sms: Yes
-      email: Yes
-      software: Yes
-      doc: https://www.capitalone.com/identity-protection/swiftid/
+      tfa: No
 
     - name: CDC Federal Credit Union
       url: https://www.cdcfcu.com


### PR DESCRIPTION
As best I can tell, Capital One has backslid on their two-factor. I attempted to follow the instructions on the linked website (describing the process for "SwiftID"), but found that the settings they mention no longer appear in their mobile app (https://play.google.com/store/apps/details?id=com.konylabs.capitalone).