### PR TITLE
Update investing - Vanguard's claim to support Yubikey is false

### DIFF
--- a/_data/investing.yml
+++ b/_data/investing.yml
@@ -206,7 +206,7 @@ websites:
       tfa: Yes
       sms: Yes
       phone: Yes
-      hardware: Yes
+      hardware: No
       doc: https://personal.vanguard.com/us/insights/article/security-codes-112015
 
     - name: Wealthfront


### PR DESCRIPTION
Yubikey support is easily bypassed with a simple checkbox

Vanguard allows the user to check a box '[] I forgot my Yubikey device, allow me in without it'
thus rendering hardware 2FA support completely useless. I spoke with Vanguard support to confirm this. I tested this myself.