### PR TITLE
Investing - Vanguard poor use of Yubikey (FIDO) noted

### DIFF
--- a/_data/banking.yml
+++ b/_data/banking.yml
@@ -94,7 +94,7 @@ websites:
       tfa: Yes
       sms: Yes
       email: Yes
-      hardware: No
+      hardware: Yes
       doc: https://www.bankofamerica.com/privacy/online-mobile-banking-privacy/safepass.go
 
     - name: Bank of China (Hong Kong)

--- a/_data/banking.yml
+++ b/_data/banking.yml
@@ -94,7 +94,7 @@ websites:
       tfa: Yes
       sms: Yes
       email: Yes
-      hardware: Yes
+      hardware: No
       doc: https://www.bankofamerica.com/privacy/online-mobile-banking-privacy/safepass.go
 
     - name: Bank of China (Hong Kong)

--- a/_data/investing.yml
+++ b/_data/investing.yml
@@ -208,7 +208,7 @@ websites:
       phone: Yes
       hardware: Yes
       exceptions:
-            text: SMS option is required, U2F/FIDO (Yubikey) cannot be used without an option to login with SMS
+            text: SMS/Phone Call option is required for 2FA.
       doc: https://personal.vanguard.com/us/insights/article/security-codes-112015
 
     - name: Wealthfront

--- a/_data/investing.yml
+++ b/_data/investing.yml
@@ -207,6 +207,8 @@ websites:
       sms: Yes
       phone: Yes
       hardware: Yes
+      exceptions:
+            text: Yubikey (FIDO) is trivially bypassed by checking "I forgot my device, use SMS instead"
       doc: https://personal.vanguard.com/us/insights/article/security-codes-112015
 
     - name: Wealthfront

--- a/_data/investing.yml
+++ b/_data/investing.yml
@@ -208,7 +208,7 @@ websites:
       phone: Yes
       hardware: Yes
       exceptions:
-            text: Yubikey (FIDO) is trivially bypassed by checking "I forgot my device, use SMS instead"
+            text: SMS option is required, U2F/FIDO (Yubikey) cannot be used without an option to login with SMS
       doc: https://personal.vanguard.com/us/insights/article/security-codes-112015
 
     - name: Wealthfront


### PR DESCRIPTION
Updated Vanguard entry to note that use of FIDO device like Yubikey is trivially bypassed by simply checking a box for "I forgot my device please use SMS instead". SMS cannot be disabled, thus the security of Yubikey is not actually enforced. Tested as of Jan 2018.