### PR TITLE
Update Gandi

### DIFF
--- a/_data/domains.yml
+++ b/_data/domains.yml
@@ -201,7 +201,7 @@ websites:
       tfa: Yes
       software: Yes
       hardware: Yes
-      doc: https://wiki.gandi.net/en/contacts/login/2-factor-activation
+      doc: https://doc.gandi.net/en/organization/users/security
 
     - name: GoDaddy
       img: godaddy.png


### PR DESCRIPTION
Use [newer documentation](https://doc.gandi.net/en/organization/users/security) that includes instructions for enabling universal second factor (U2F) hardware tokens. 