### PR TITLE
Update Discord

### DIFF
--- a/_data/communication.yml
+++ b/_data/communication.yml
@@ -45,6 +45,7 @@ websites:
       url: https://discordapp.com/
       img: discord.png
       tfa: Yes
+      sms: Yes
       email: Yes
       software: Yes
       doc: https://support.discordapp.com/hc/en-us/articles/219576828


### PR DESCRIPTION
[Discord](https://discordapp.com) allows a user to add their phone number as a backup 2FA method in case they lose their authentication app or backup codes. 

Their documentation does not (yet) mention SMS 2FA. 