### PR TITLE
Adds more accurate pattern validations

### DIFF
--- a/websites_schema.yml
+++ b/websites_schema.yml
@@ -18,24 +18,26 @@ mapping:
           "img":
             type: str
             required: yes
+            pattern: /\.png$/i
           "tfa":
             type: bool
             required: yes
+            pattern: /(true|false)/
           "software":
             type: bool
-            pattern: /true/
+            pattern: /(true|false)/
           "hardware":
             type: bool
-            pattern: /true/
+            pattern: /(true|false)/
           "sms":
             type: bool
-            pattern: /true/
+            pattern: /(true|false)/
           "phone":
             type: bool
-            pattern: /true/
+            pattern: /(true|false)/
           "email":
             type: bool
-            pattern: /true/
+            pattern: /(true|false)/
           "exceptions":
             type: map
             mapping:


### PR DESCRIPTION
I've used these for the [acceptbitcoincash/acceptbitcoincash](https://github.com/acceptbitcoincash/acceptbitcoincash) fork to be more precise when validating using the verify.rb script.

Since your verify.rb script validates the img tag uses only .png files, why not just add the pattern here instead of having it in the verify.rb only?