### PR TITLE
Output the proper order of the sites when not alphabetical

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source 'https://rubygems.org'
 gem 'github-pages', group: :jekyll_plugins
 
 group :test do
+  gem 'diffy'
   gem 'fastimage'
   gem 'html-proofer'
   gem 'kwalify'

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem 'github-pages', group: :jekyll_plugins
 
 group :test do
   gem 'diffy'
+  gem 'diff-lcs', :platforms => mswin
   gem 'fastimage'
   gem 'html-proofer'
   gem 'kwalify'

--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,8 @@ source 'https://rubygems.org'
 gem 'github-pages', group: :jekyll_plugins
 
 group :test do
+  gem 'diff-lcs', platforms: :mswin
   gem 'diffy'
-  gem 'diff-lcs', :platforms => :mswin
   gem 'fastimage'
   gem 'html-proofer'
   gem 'kwalify'

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'github-pages', group: :jekyll_plugins
 
 group :test do
   gem 'diffy'
-  gem 'diff-lcs', :platforms => mswin
+  gem 'diff-lcs', :platforms => :mswin
   gem 'fastimage'
   gem 'html-proofer'
   gem 'kwalify'

--- a/verify.rb
+++ b/verify.rb
@@ -50,6 +50,12 @@ def test_img(img, name, imgs)
 end
 # rubocop:enable AbcSize,CyclomaticComplexity
 
+def outputOrdered(websites)
+  websites.each do |site|
+    puts "    #{site['name']}\n"
+  end
+end
+      
 # Load each section, check for errors such as invalid syntax
 # as well as if an image is missing
 begin
@@ -70,6 +76,9 @@ begin
 
     # Check section alphabetization
     error("_data/#{section['id']}.yml is not alphabetized by name") \
+      if websites != (websites.sort_by { |website| website['name'].downcase })
+        
+	  outputOrdered(websites.sort_by { |website| website['name'].downcase }) \
       if websites != (websites.sort_by { |website| website['name'].downcase })
 
     # Collect list of all images for section

--- a/verify.rb
+++ b/verify.rb
@@ -50,12 +50,6 @@ def test_img(img, name, imgs)
 end
 # rubocop:enable AbcSize,CyclomaticComplexity
 
-def output_ordered(websites)
-  websites.each do |site|
-    puts "  #{site['name']}\n"
-  end
-end
-
 # Load each section, check for errors such as invalid syntax
 # as well as if an image is missing
 begin
@@ -75,11 +69,10 @@ begin
     end
 
     # Check section alphabetization
-    error("_data/#{section['id']}.yml is not alphabetized by name") \
-      if websites != (websites.sort_by { |website| website['name'].downcase })
-
-    output_ordered(websites.sort_by { |website| website['name'].downcase }) \
-      if websites != (websites.sort_by { |website| website['name'].downcase })
+    if websites != (sites_ordered = websites.sort_by { |s| s['name'].downcase })
+      error("_data/#{section['id']}.yml not ordered by name. Correct order:")
+      sites_ordered.each { |site| error("  #{site['name']}\n") }
+    end
 
     # Collect list of all images for section
     imgs = Dir["img/#{section['id']}/*"]
@@ -104,11 +97,9 @@ rescue Psych::SyntaxError => e
   puts "<------------ ERROR in a YAML file ------------>\n"
   puts e
   exit 1
-# rubocop:disable Style/RescueStandardError
-rescue => e
+rescue StandardError => e
   puts e
   exit 1
-# rubocop:enable Style/RescueStandardError
 else
   puts "<------------ No errors. You\'re good to go! ------------>\n"
 end

--- a/verify.rb
+++ b/verify.rb
@@ -1,6 +1,7 @@
 require 'yaml'
 require 'fastimage'
 require 'kwalify'
+require 'diffy'
 @output = 0
 
 # YAML tags related to TFA
@@ -69,9 +70,10 @@ begin
     end
 
     # Check section alphabetization
-    if websites != (sites_ordered = websites.sort_by { |s| s['name'].downcase })
-      error("_data/#{section['id']}.yml not ordered by name. Correct order:")
-      sites_ordered.each { |site| error("  #{site['name']}\n") }
+    if websites != (sites_sort = websites.sort_by { |s| s['name'].downcase })
+      error("_data/#{section['id']}.yml not ordered by name. Correct order:" \
+        "\n" + Diffy::Diff.new(websites.to_yaml, sites_sort.to_yaml, \
+                               context: 10).to_s(:color))
     end
 
     # Collect list of all images for section

--- a/verify.rb
+++ b/verify.rb
@@ -52,7 +52,7 @@ end
 
 def outputOrdered(websites)
   websites.each do |site|
-    puts "    #{site['name']}\n"
+    puts "  #{site['name']}\n"
   end
 end
       

--- a/verify.rb
+++ b/verify.rb
@@ -50,12 +50,12 @@ def test_img(img, name, imgs)
 end
 # rubocop:enable AbcSize,CyclomaticComplexity
 
-def outputOrdered(websites)
+def output_ordered(websites)
   websites.each do |site|
     puts "  #{site['name']}\n"
   end
 end
-      
+ 
 # Load each section, check for errors such as invalid syntax
 # as well as if an image is missing
 begin
@@ -77,8 +77,8 @@ begin
     # Check section alphabetization
     error("_data/#{section['id']}.yml is not alphabetized by name") \
       if websites != (websites.sort_by { |website| website['name'].downcase })
-        
-	  outputOrdered(websites.sort_by { |website| website['name'].downcase }) \
+
+    output_ordered(websites.sort_by { |website| website['name'].downcase }) \
       if websites != (websites.sort_by { |website| website['name'].downcase })
 
     # Collect list of all images for section

--- a/verify.rb
+++ b/verify.rb
@@ -55,7 +55,7 @@ def output_ordered(websites)
     puts "  #{site['name']}\n"
   end
 end
- 
+
 # Load each section, check for errors such as invalid syntax
 # as well as if an image is missing
 begin


### PR DESCRIPTION
Might be able to batch it within the test two lines above, but this checks the alphabetical-truthiness of the current section and outputs the order they should be in so its easier to fix.

Just something I found very useful for maintaining [acceptbitcoincash/acceptbitcoincash](https://github.com/acceptbitcoincash/acceptbitcoincash)