### PR TITLE
Exclude websites_schema.yml from live site

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,3 +20,4 @@ exclude:
     - Rakefile
     - verify.rb
     - vendor
+    - websites_schema.yml


### PR DESCRIPTION
Nothing uses the websites_schema.yml besides the verify.rb script so you might as well exclude it from being copied over to your generated site.