### PR TITLE
Partialized the row title div section

### DIFF
--- a/_includes/desktop-table.html
+++ b/_includes/desktop-table.html
@@ -27,7 +27,7 @@
       {% if website.status %}
         <td class="main progress">
           <div class="title">
-	        {% include row-logo.html section=section_id img=website.img site=website.name %}
+            {% include row-logo.html section=section_id img=website.img site=website.name %}
             <a class="name" href="{{ website.url }}">{{ website.name }}</a>
             {% include exception.html website=website %}
           </div>
@@ -45,7 +45,7 @@
       {% elsif website.tfa %}
         <td class="main positive">
           <div class="title">
-	        {% include row-logo.html section=section_id img=website.img site=website.name %}
+            {% include row-logo.html section=section_id img=website.img site=website.name %}
             <a class="name" href="{{ website.url }}">{{ website.name }}</a>
             {% include exception.html website=website %}
           </div>
@@ -89,7 +89,7 @@
       {% else %}
         <td class="main negative">
           <div class="title">
-	        {% include row-logo.html section=section_id img=website.img site=website.name %}
+            {% include row-logo.html section=section_id img=website.img site=website.name %}
             <a class="name" href="{{ website.url }}">{{ website.name }}</a>
             {% include exception.html website=website %}
           </div>

--- a/_includes/desktop-table.html
+++ b/_includes/desktop-table.html
@@ -26,11 +26,7 @@
     <tr class="desktop-tr">
       {% if website.status %}
         <td class="main progress">
-          <div class="title">
-            {% include row-logo.html section=section_id img=website.img site=website.name %}
-            <a class="name" href="{{ website.url }}">{{ website.name }}</a>
-            {% include exception.html website=website %}
-          </div>
+          {% include row-title.html section=section_id website=website type='desktop' %}
           <div class="progress-info">
             <a class="ui mini orange button" href="{{website.status}}" target="_blank">
               <i class="star icon"></i> In Progress!
@@ -44,11 +40,7 @@
         </td>
       {% elsif website.tfa %}
         <td class="main positive">
-          <div class="title">
-            {% include row-logo.html section=section_id img=website.img site=website.name %}
-            <a class="name" href="{{ website.url }}">{{ website.name }}</a>
-            {% include exception.html website=website %}
-          </div>
+          {% include row-title.html section=section_id website=website type='desktop' %}
         </td>
 
         <td class="positive icon">
@@ -88,11 +80,7 @@
         </td>
       {% else %}
         <td class="main negative">
-          <div class="title">
-            {% include row-logo.html section=section_id img=website.img site=website.name %}
-            <a class="name" href="{{ website.url }}">{{ website.name }}</a>
-            {% include exception.html website=website %}
-          </div>
+          {% include row-title.html section=section_id website=website type='desktop' %}
         </td>
         <td class="twitter negative" colspan="6">
         {% if website.twitter %} <a class="ui twitter mini button" href="https://twitter.com/share?url={{site.url|cgi_escape}}&amp;text={{workonit_tweet|replace:'TWITTERHANDLE',website.twitter|cgi_escape}}&amp;hashtags={{page.hash|cgi_escape}}" target="_blank"><i class="twitter icon"></i> {{page.link}} on Twitter</a>{% endif %}

--- a/_includes/desktop-table.html
+++ b/_includes/desktop-table.html
@@ -27,9 +27,7 @@
       {% if website.status %}
         <td class="main progress">
           <div class="title">
-            <noscript><img src="/img/{{ section_id }}/{{ website.img }}" class="icon" alt="{{ website.name }}"></noscript>
-            <img src="/img/placeholder.png" data-src="/img/{{ section_id }}/{{ website.img }}" class="icon"
-                 alt="{{ website.name }}">
+	        {% include row-logo.html section=section_id img=website.img site=website.name %}
             <a class="name" href="{{ website.url }}">{{ website.name }}</a>
             {% include exception.html website=website %}
           </div>
@@ -47,9 +45,7 @@
       {% elsif website.tfa %}
         <td class="main positive">
           <div class="title">
-            <noscript><img src="/img/{{ section_id }}/{{ website.img }}" class="icon" alt="{{ website.name }}"></noscript>
-            <img src="/img/placeholder.png" data-src="/img/{{ section_id }}/{{ website.img }}" class="icon"
-                 alt="{{ website.name }}">
+	        {% include row-logo.html section=section_id img=website.img site=website.name %}
             <a class="name" href="{{ website.url }}">{{ website.name }}</a>
             {% include exception.html website=website %}
           </div>
@@ -93,9 +89,7 @@
       {% else %}
         <td class="main negative">
           <div class="title">
-            <noscript><img src="/img/{{ section_id }}/{{ website.img }}" class="icon" alt="{{ website.name }}"></noscript>
-            <img src="/img/placeholder.png" data-src="/img/{{ section_id }}/{{ website.img }}" class="icon"
-                 alt="{{ website.name }}">
+	        {% include row-logo.html section=section_id img=website.img site=website.name %}
             <a class="name" href="{{ website.url }}">{{ website.name }}</a>
             {% include exception.html website=website %}
           </div>

--- a/_includes/desktop-table.html
+++ b/_includes/desktop-table.html
@@ -27,11 +27,9 @@
       {% if website.status %}
         <td class="main progress">
           <div class="title">
-            {% if website.img %}
-              <noscript><img src="/img/{{ section_id }}/{{ website.img }}" class="icon" alt="{{ website.name }}"></noscript>
-              <img src="/img/placeholder.png" data-src="/img/{{ section_id }}/{{ website.img }}" class="icon"
-                   alt="{{ website.name }}">
-            {% endif %}
+            <noscript><img src="/img/{{ section_id }}/{{ website.img }}" class="icon" alt="{{ website.name }}"></noscript>
+            <img src="/img/placeholder.png" data-src="/img/{{ section_id }}/{{ website.img }}" class="icon"
+                 alt="{{ website.name }}">
             <a class="name" href="{{ website.url }}">{{ website.name }}</a>
             {% include exception.html website=website %}
           </div>
@@ -49,11 +47,9 @@
       {% elsif website.tfa %}
         <td class="main positive">
           <div class="title">
-            {% if website.img %}
-              <noscript><img src="/img/{{ section_id }}/{{ website.img }}" class="icon" alt="{{ website.name }}"></noscript>
-              <img src="/img/placeholder.png" data-src="/img/{{ section_id }}/{{ website.img }}" class="icon"
-                   alt="{{ website.name }}">
-            {% endif %}
+            <noscript><img src="/img/{{ section_id }}/{{ website.img }}" class="icon" alt="{{ website.name }}"></noscript>
+            <img src="/img/placeholder.png" data-src="/img/{{ section_id }}/{{ website.img }}" class="icon"
+                 alt="{{ website.name }}">
             <a class="name" href="{{ website.url }}">{{ website.name }}</a>
             {% include exception.html website=website %}
           </div>
@@ -97,11 +93,9 @@
       {% else %}
         <td class="main negative">
           <div class="title">
-            {% if website.img %}
-              <noscript><img src="/img/{{ section_id }}/{{ website.img }}" class="icon" alt="{{ website.name }}"></noscript>
-              <img src="/img/placeholder.png" data-src="/img/{{ section_id }}/{{ website.img }}" class="icon"
-                   alt="{{ website.name }}">
-            {% endif %}
+            <noscript><img src="/img/{{ section_id }}/{{ website.img }}" class="icon" alt="{{ website.name }}"></noscript>
+            <img src="/img/placeholder.png" data-src="/img/{{ section_id }}/{{ website.img }}" class="icon"
+                 alt="{{ website.name }}">
             <a class="name" href="{{ website.url }}">{{ website.name }}</a>
             {% include exception.html website=website %}
           </div>

--- a/_includes/mobile-table.html
+++ b/_includes/mobile-table.html
@@ -17,7 +17,7 @@
     {% if website.status %}
     <div class="main progress">
       <div class="title">
-	    {% include row-logo.html section=section_id img=website.img site=website.name %}
+        {% include row-logo.html section=section_id img=website.img site=website.name %}
         <a href="{{ website.url }}" class="name">{{ website.name }}</a>
         {% include exception.html website=website %}
 
@@ -37,7 +37,7 @@
     {% elsif website.tfa %}
     <div class="main positive">
       <div class="title">
-	    {% include row-logo.html section=section_id img=website.img site=website.name %}
+        {% include row-logo.html section=section_id img=website.img site=website.name %}
         <a href="{{ website.url }}" class="name">{{ website.name }}</a>
         {% include exception.html website=website %}
       </div>
@@ -58,7 +58,7 @@
     {% else %}
     <div class="main negative">
       <div class="title">
-	    {% include row-logo.html section=section_id img=website.img site=website.name %}
+        {% include row-logo.html section=section_id img=website.img site=website.name %}
         <a href="{{ website.url }}" class="name">{{ website.name }}</a>
         {% include exception.html website=website %}
       </div>

--- a/_includes/mobile-table.html
+++ b/_includes/mobile-table.html
@@ -17,11 +17,7 @@
     {% if website.status %}
     <div class="main progress">
       <div class="title">
-        {% if website.img %}
-        <noscript><img src="/img/{{ section_id }}/{{ website.img }}" class="icon" alt="{{ website.name }}"></noscript>
-        <img src="/img/placeholder.png" data-src="/img/{{ section_id }}/{{ website.img }}" class="icon"
-             alt="{{ website.name }}">
-        {% endif %}
+	    {% include row-logo.html section=section_id img=website.img site=website.name %}
         <a href="{{ website.url }}" class="name">{{ website.name }}</a>
         {% include exception.html website=website %}
 
@@ -41,11 +37,7 @@
     {% elsif website.tfa %}
     <div class="main positive">
       <div class="title">
-        {% if website.img %}
-        <noscript><img src="/img/{{ section_id }}/{{ website.img }}" class="icon" alt="{{ website.name }}"></noscript>
-        <img src="/img/placeholder.png" data-src="/img/{{ section_id }}/{{ website.img }}" class="icon"
-             alt="{{ website.name }}">
-        {% endif %}
+	    {% include row-logo.html section=section_id img=website.img site=website.name %}
         <a href="{{ website.url }}" class="name">{{ website.name }}</a>
         {% include exception.html website=website %}
       </div>
@@ -66,11 +58,7 @@
     {% else %}
     <div class="main negative">
       <div class="title">
-        {% if website.img %}
-        <noscript><img src="/img/{{ section_id }}/{{ website.img }}" class="icon" alt="{{ website.name }}"></noscript>
-        <img src="/img/placeholder.png" data-src="/img/{{ section_id }}/{{ website.img }}" class="icon"
-             alt="{{ website.name }}">
-        {% endif %}
+	    {% include row-logo.html section=section_id img=website.img site=website.name %}
         <a href="{{ website.url }}" class="name">{{ website.name }}</a>
         {% include exception.html website=website %}
       </div>

--- a/_includes/mobile-table.html
+++ b/_includes/mobile-table.html
@@ -16,16 +16,7 @@
     {% endif %}
     {% if website.status %}
     <div class="main progress">
-      <div class="title">
-        {% include row-logo.html section=section_id img=website.img site=website.name %}
-        <a href="{{ website.url }}" class="name">{{ website.name }}</a>
-        {% include exception.html website=website %}
-
-        <a href="{{ website.status }}" target="_blank">
-          <i class="external url link large icon"></i>
-        </a>
-      </div>
-
+      {% include row-title.html section=section_id website=website type='mobile' %}
       <p>IN PROGRESS!</p>
 
       <div>
@@ -36,11 +27,7 @@
     </div>
     {% elsif website.tfa %}
     <div class="main positive">
-      <div class="title">
-        {% include row-logo.html section=section_id img=website.img site=website.name %}
-        <a href="{{ website.url }}" class="name">{{ website.name }}</a>
-        {% include exception.html website=website %}
-      </div>
+      {% include row-title.html section=section_id website=website type='mobile' %}
       <p>
         Supported:
         {% if website.sms %}SMS{% endif %}
@@ -57,11 +44,7 @@
     </div>
     {% else %}
     <div class="main negative">
-      <div class="title">
-        {% include row-logo.html section=section_id img=website.img site=website.name %}
-        <a href="{{ website.url }}" class="name">{{ website.name }}</a>
-        {% include exception.html website=website %}
-      </div>
+      {% include row-title.html section=section_id website=website type='mobile' %}
       <p>2FA not supported</p>
       <div class="button-group">
         {% if website.twitter %} <a class="ui twitter mini button" href="https://twitter.com/share?url={{site.url|cgi_escape}}&amp;text={{workonit_tweet|replace:'TWITTERHANDLE',website.twitter|cgi_escape}}&amp;hashtags={{page.hash|cgi_escape}}" target="_blank"><i class="twitter icon"></i></a>{% endif %}

--- a/_includes/row-logo.html
+++ b/_includes/row-logo.html
@@ -1,5 +1,0 @@
-{%- assign img_path = include.section | append: '/' | append: include.img -%}
-<noscript>
-  <img src="/img/{{ img_path }}" class="icon" alt="{{ include.site }}">
-</noscript>
-<img src="/img/placeholder.png" data-src="/img/{{ img_path }}" class="icon" alt="{{ include.site }}">

--- a/_includes/row-logo.html
+++ b/_includes/row-logo.html
@@ -1,0 +1,5 @@
+{%- assign img_path = include.section | append: '/' | append: include.img -%}
+<noscript>
+  <img src="/img/{{ img_path }}" class="icon" alt="{{ include.site }}">
+</noscript>
+<img src="/img/placeholder.png" data-src="/img/{{ img_path }}" class="icon" alt="{{ include.site }}">

--- a/_includes/row-title.html
+++ b/_includes/row-title.html
@@ -1,0 +1,15 @@
+{%- assign website = include.website -%}
+{%- assign img_path = include.section | append: '/' | append: website.img -%}
+<div class="title">
+  <noscript>
+    <img src="/img/{{ img_path }}" class="icon" alt="{{ website.name }}">
+  </noscript>
+  <img src="/img/placeholder.png" data-src="/img/{{ img_path }}" class="icon" alt="{{ website.name }}">
+  <a href="{{ website.url }}" class="name">{{ website.name }}</a>
+  {%- include exception.html website=website -%}
+  {%- if website.status and include.type == 'mobile' -%}
+    <a href="{{ website.status }}" target="_blank">
+      <i class="external url link large icon"></i>
+    </a>
+  {%- endif -%}
+</div>

--- a/_includes/row-title.html
+++ b/_includes/row-title.html
@@ -1,10 +1,10 @@
 {%- assign website = include.website -%}
-{%- assign img_path = include.section | append: '/' | append: website.img -%}
+{%- assign img_path = '/img/' | append: include.section | append: '/' | append: website.img -%}
 <div class="title">
   <noscript>
-    <img src="/img/{{ img_path }}" class="icon" alt="{{ website.name }}">
+    <img src="{{ img_path }}" class="icon" alt="{{ website.name }}">
   </noscript>
-  <img src="/img/placeholder.png" data-src="/img/{{ img_path }}" class="icon" alt="{{ website.name }}">
+  <img src="/img/placeholder.png" data-src="{{ img_path }}" class="icon" alt="{{ website.name }}">
   <a href="{{ website.url }}" class="name">{{ website.name }}</a>
   {%- include exception.html website=website -%}
   {%- if website.status and include.type == 'mobile' -%}


### PR DESCRIPTION
This moves the imgs for logos to its own partial to be included from the multiple places it is used. This gives you better revision flexibility in the future.

Also, I removed the If website.img check since img is required. You should never be in a situation where you do not have it.  

However, I could revise it more to the tune of what I did for Accepbitcoincash/acceptbitcoincash here: https://github.com/acceptbitcoincash/acceptbitcoincash/blob/adoption-stats/_includes/segment/row-logo.html

in that version I made placeholder.png our default as we removed the img tag from being required for our site. 