### PR TITLE
Fix html validator errors

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -24,7 +24,6 @@
   <meta charset="UTF-8">
   <meta name="description" content="{{ site.description }}">
   <meta name="author" content="{{ site.author }}">
-  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/png" href="/img/logo.png"/>
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,26 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta http-equiv='Content-Security-Policy' content="
-    script-src
-      'self'
-      https://ajax.cloudflare.com
-      https://code.jquery.com
-      https://cdnjs.cloudflare.com;
-    style-src
-      'self'
-      'unsafe-inline'
-      data:
-      https://fonts.googleapis.com
-      https://cdnjs.cloudflare.com;
-    font-src
-      'self'
-      data:
-      https://fonts.gstatic.com
-      https://cdnjs.cloudflare.com;
-    img-src
-      'self';
-  ">
+  <meta http-equiv='Content-Security-Policy' content="script-src 'self' https://ajax.cloudflare.com https://code.jquery.com https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' data: https://fonts.googleapis.com https://cdnjs.cloudflare.com; font-src 'self' data: https://fonts.gstatic.com https://cdnjs.cloudflare.com; img-src 'self';">
   <meta charset="UTF-8">
   <meta name="description" content="{{ site.description }}">
   <meta name="author" content="{{ site.author }}">

--- a/_layouts/secondary.html
+++ b/_layouts/secondary.html
@@ -1,25 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta http-equiv='Content-Security-Policy' content="
-    script-src
-      'self'
-      https://ajax.cloudflare.com
-      https://code.jquery.com
-      https://cdnjs.cloudflare.com;
-    style-src
-      'self'
-      'unsafe-inline'
-      https://fonts.googleapis.com
-      https://cdnjs.cloudflare.com;
-    font-src
-      'self'
-      data:
-      https://fonts.gstatic.com
-      https://cdnjs.cloudflare.com;
-    img-src
-      'self';
-  ">
+  <meta http-equiv='Content-Security-Policy' content="script-src 'self' https://ajax.cloudflare.com https://code.jquery.com https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdnjs.cloudflare.com; font-src 'self' data: https://fonts.gstatic.com https://cdnjs.cloudflare.com; img-src 'self';">
   <meta charset="UTF-8">
   <meta name="description" content="{{ site.description }}">
   <meta name="author" content="{{ site.author }}">

--- a/_layouts/secondary.html
+++ b/_layouts/secondary.html
@@ -23,7 +23,6 @@
   <meta charset="UTF-8">
   <meta name="description" content="{{ site.description }}">
   <meta name="author" content="{{ site.author }}">
-  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/png" href="/img/logo.png"/>
 


### PR DESCRIPTION
This PR addresses 2 issues reported by [validator.w3.org](https://validator.w3.org/nu/?doc=https%3A%2F%2Ftwofactorauth.org%2F):

According to https://w3c.github.io/html/single-page.html#statedef-http-equiv-content-type
>A document must not contain both a `<meta>` element with an `http-equiv` attribute in the encoding declaration state and a `<meta>` element with the `charset` attribute present.

As such, I deleted the longer one.

Additionally, it complains:
>Error: Bad value for attribute `content` on element `meta`: Expecting directive-name but found "↩".

As such, I removed line breaks.