### PR TITLE
Add hardware information from dongleauth.info

### DIFF
--- a/_data/backup.yml
+++ b/_data/backup.yml
@@ -3,6 +3,8 @@ websites:
     url: https://www.aerofs.com/
     tfa: Yes
     software: Yes
+    hardware: Yes
+    otp: Yes
     img: aerofs.png
     doc: https://support.aerofs.com/hc/en-us/articles/202610424-How-Do-I-Set-Up-Two-Factor-Authentication-
 
@@ -60,6 +62,8 @@ websites:
     sms: Yes
     software: Yes
     hardware: Yes
+    otp: Yes
+    u2f: Yes
     doc: https://www.dropbox.com/en/help/363
 
   - name: Evernote
@@ -68,6 +72,8 @@ websites:
     tfa: Yes
     sms: Yes
     software: Yes
+    hardware: Yes
+    otp: Yes
     doc: https://blog.evernote.com/blog/2013/10/04/two-step-verification-available-to-all-users/
 
   - name: FileThis
@@ -85,6 +91,8 @@ websites:
     phone: Yes
     software: Yes
     hardware: Yes
+    otp: Yes
+    u2f: Yes
     doc: https://www.google.com/intl/en-US/landing/2step/features.html
 
   - name: hubiC
@@ -143,6 +151,8 @@ websites:
     tfa: Yes
     sms: Yes
     software: Yes
+    hardware: Yes
+    otp: Yes
     doc: https://support.microsoft.com/en-us/help/12408/microsoft-account-about-two-step-verification
 
   - name: Pogoplug
@@ -158,6 +168,12 @@ websites:
     email: Yes
     software: Yes
     doc: https://www.qnap.com/i/useng/tutorial/con_show.php?op=showone&cid=151
+    
+  - name: Seafile
+    url: https://www.seafile.com/
+    twitter: seafile
+    img: seafile.png
+    tfa: No
 
   - name: SmartBox
     url: https://www.panterranetworks.com/products/smartbox.php
@@ -196,6 +212,8 @@ websites:
     tfa: Yes
     software: Yes
     email: Yes
+    hardware: Yes
+    otp: Yes
     doc: https://originwww.synology.com/en-us/knowledgebase/tutorials/615#t5
 
   - name: ThisData
@@ -214,6 +232,8 @@ websites:
     phone: Yes
     software: Yes
     email: Yes
+    hardware: Yes
+    otp: Yes
     doc: https://support.tresorit.com/entries/104192996-How-to-set-up-two-step-verification
 
   - name: Yandex.Disk
@@ -230,4 +250,6 @@ websites:
     img: zetta.png
     tfa: Yes
     software: Yes
+    hardware: Yes
+    otp: Yes
     doc: https://www.zetta.net/about/blog/how-set-zetta-two-factor-authentication/

--- a/_data/cloud.yml
+++ b/_data/cloud.yml
@@ -6,6 +6,8 @@ websites:
       sms: Yes
       software: Yes
       hardware: Yes
+      otp: Yes
+      u2f: No
       doc: https://aws.amazon.com/iam/details/mfa/
 
     - name: appFog
@@ -27,6 +29,8 @@ websites:
       img: cloud66.png
       tfa: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
       doc: http://blog.cloud66.com/two-factor-authentication-for-your-accounts/
 
     - name: cloud.ca
@@ -48,6 +52,8 @@ websites:
       img: engineyard.png
       tfa: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
       doc: https://blog.engineyard.com/2015/engine-yards-two-factor-authentication
 
     - name: fortrabbit
@@ -65,6 +71,8 @@ websites:
       software: Yes
       phone: Yes
       hardware: Yes
+      otp: Yes
+      u2f: Yes
       doc: https://www.google.com/intl/en-US/landing/2step/features.html
 
     - name: Heroku
@@ -72,6 +80,8 @@ websites:
       img: heroku.png
       tfa: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
       doc: https://devcenter.heroku.com/articles/two-factor-authentication
 
     - name: Hostiso
@@ -101,6 +111,8 @@ websites:
       img: joyent.png
       tfa: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
       doc: https://docs.joyent.com/public-cloud/getting-started/2fa
 
     - name: LeaseWeb
@@ -124,6 +136,8 @@ websites:
       sms: Yes
       phone: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
       doc: https://azure.microsoft.com/en-us/documentation/articles/multi-factor-authentication/
 
     - name: mLab
@@ -183,6 +197,8 @@ websites:
       img: scalr.png
       tfa: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
       doc: https://scalr-wiki.atlassian.net/wiki/display/docs/Two-Factor+Authentication
 
     - name: SingleHop
@@ -190,6 +206,8 @@ websites:
       img: singlehop.png
       tfa: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
       doc: http://library.singlehop.com/assets_project_development/Two_Factor_Instructions.pdf
 
     - name: Tilaa

--- a/_data/communication.yml
+++ b/_data/communication.yml
@@ -11,6 +11,8 @@ websites:
       img: basecamp.png
       tfa: Yes
       sms: Yes
+      hardware: Yes
+      otp: Yes
       doc: https://basecamp.com/help/guides/you/phone-verification
 
     - name: Campfire
@@ -48,6 +50,9 @@ websites:
       sms: Yes
       email: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
+      u2f: No
       doc: https://support.discordapp.com/hc/en-us/articles/219576828
 
     - name: Disqus
@@ -91,6 +96,16 @@ websites:
       sms: Yes
       software: Yes
       doc: https://chatgrape.com/doc/deployment/2fa.html
+      
+    - name: Hangouts
+      url: https://hangouts.google.com/
+      img: hangouts.png
+      tfa: Yes
+      software: Yes
+      hardware: Yes
+      otp: Yes
+      u2f: Yes
+      doc: http://www.google.com/intl/en-US/landing/2step/features.html
 
     - name: HipChat
       url: https://www.hipchat.com
@@ -126,6 +141,9 @@ websites:
       tfa: Yes
       sms: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
+      u2f: No
       doc: http://kb.mailchimp.com/accounts/login/set-up-two-factor-authentication-with-sms
 
     - name: Mailgun
@@ -162,6 +180,8 @@ websites:
       sms: Yes
       software: Yes
       email: Yes
+      hardware: Yes
+      otp: Yes
       doc: https://help.salesforce.com/HTViewHelpDoc?id=security_require_two_factor_authentication.htm
 
     - name: SendGrid
@@ -202,6 +222,9 @@ websites:
       tfa: Yes
       sms: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
+      u2f: No
       doc: https://slack.zendesk.com/hc/en-us/articles/204509068-Enabling-two-factor-authentication
 
     - name: SocketLabs

--- a/_data/cryptocurrencies.yml
+++ b/_data/cryptocurrencies.yml
@@ -35,6 +35,8 @@ websites:
       sms: Yes
       software: Yes
       hardware: Yes
+      otp: Yes
+      u2f: Yes
       doc: https://support.bitfinex.com/hc/en-us/sections/203192029-Security
 
     - name: BitGo
@@ -58,6 +60,8 @@ websites:
       img: bitpay.png
       tfa: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
       doc: https://bitpay.com/two-factor
 
     - name: Bitstamp
@@ -82,6 +86,7 @@ websites:
       email: Yes
       software: Yes
       hardware: Yes
+      otp: Yes
       doc: https://support.blockchain.com/hc/en-us/articles/211164103-Enable-2-Step-Verification-2FA-
 
     - name: BTCJam
@@ -96,6 +101,8 @@ websites:
       img: campbx.png
       tfa: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
       doc: https://campbx.com/faq.php#security-compliance
 
     - name: CEX.IO
@@ -136,6 +143,9 @@ websites:
       sms: Yes
       software: Yes
       phone: Yes
+      hardware: Yes
+      otp: Yes
+      u2f: No
       doc: https://support.coinbase.com/customer/en/portal/articles/1658338-how-do-i-set-up-2-factor-authentication-with-authy-
 
     - name: Coinfloor
@@ -169,6 +179,8 @@ websites:
       tfa: Yes
       software: Yes
       sms: Yes
+      hardware: Yes
+      otp: Yes
       doc: https://support.coinjar.com/kb/using-coinjar/keeping-your-coinjar-secure-with-multi-factor-authentication
 
     - name: Coins.ph
@@ -188,10 +200,11 @@ websites:
     - name: Kraken
       url: https://www.kraken.com/
       img: kraken.png
-      doc: https://support.kraken.com/hc/en-us/articles/203395513-How-do-I-set-up-two-factor-authentication-
       tfa: Yes
       software: Yes
       hardware: Yes
+      otp: Yes
+      doc: https://support.kraken.com/hc/en-us/articles/203395513-How-do-I-set-up-two-factor-authentication-
 
     - name: LiteBit
       url: https://www.litebit.eu/
@@ -205,6 +218,8 @@ websites:
       img: localbitcoins.png
       tfa: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
       doc: https://localbitcoins.blogspot.com.au/2013/05/using-two-factor-authentication-on.html
 
     - name: Luno

--- a/_data/developer.yml
+++ b/_data/developer.yml
@@ -5,8 +5,9 @@ websites:
       tfa: Yes
       sms: Yes
       phone: Yes
-      hardware: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
       doc: http://support.aha.io/hc/en-us/articles/202000957-Add-two-factor-authentication-2FA-
 
     - name: Airbrake
@@ -36,6 +37,7 @@ websites:
       tfa: Yes
       software: Yes
       hardware: Yes
+      otp: Yes
       doc: https://atechmedia.com/blog/general/launches/two-factor-authentication
 
     - name: Balsamiq
@@ -57,6 +59,8 @@ websites:
       tfa: Yes
       software: Yes
       hardware: Yes
+      otp: Yes
+      u2f: Yes
       doc: https://confluence.atlassian.com/x/425QLg
 
     - name: Bugsnag
@@ -109,6 +113,8 @@ websites:
       tfa: Yes
       sms: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
       doc: https://docs.codeclimate.com/docs/enabling-two-factor-authentication
 
     - name: Codeanywhere
@@ -188,16 +194,20 @@ websites:
       img: github.png
       tfa: Yes
       sms: Yes
-      hardware: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
+      u2f: Yes
       doc: https://help.github.com/articles/about-two-factor-authentication
 
     - name: GitLab
       url: https://gitlab.com
       img: gitlab.png
       tfa: Yes
-      hardware: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
+      u2f: Yes
       doc: https://docs.gitlab.com/ee/security/two_factor_authentication.html
 
     - name: Hashicorp Atlas
@@ -240,8 +250,9 @@ websites:
       url: https://launchpad.net
       img: launchpad.png
       tfa: Yes
-      hardware: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
       doc: https://help.ubuntu.com/community/SSO/FAQs/2FA
 
     - name: Looker
@@ -256,6 +267,8 @@ websites:
       img: mapbox.png
       tfa: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
       doc: https://www.mapbox.com/help/two-step-verification/
 
     - name: Metrological
@@ -353,6 +366,9 @@ websites:
       img: pythonanywhere.png
       tfa: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
+      u2f: No
 
     - name: Raygun
       url: https://raygun.com
@@ -404,8 +420,10 @@ websites:
       img: sentry.png
       tfa: Yes
       sms: Yes
-      hardware: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
+      u2f: Yes
       doc: https://blog.getsentry.com/2016/06/22/introducing-2fa.html
 
     - name: SourceForge
@@ -492,4 +510,6 @@ websites:
       img: zapier.png
       tfa: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
       doc: https://zapier.com/help/two-factor-authentication/

--- a/_data/domains.yml
+++ b/_data/domains.yml
@@ -54,6 +54,8 @@ websites:
       img: cloudflare.png
       tfa: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
       doc: https://support.cloudflare.com/hc/en-us/articles/200167866-What-is-Authy-2-Factor-Authentication-
 
     - name: ClouDNS
@@ -61,6 +63,9 @@ websites:
       img: cloudns.png
       tfa: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
+      u2f: No
       doc: https://www.cloudns.net/wiki/article/201/
 
     - name: Crazy Domains
@@ -76,6 +81,7 @@ websites:
       tfa: Yes
       software: Yes
       hardware: Yes
+      otp: Yes
       doc: https://directnic.com/knowledge/article/137:how+do+i+set+up+two-factor+authentication%3F
 
     - name: DNS Made Easy
@@ -83,6 +89,8 @@ websites:
       img: dnsmadeeasy.png
       tfa: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
       doc: http://help.dnsmadeeasy.com/managed-dns/administrative/enable-two-factor-authentication/
 
     - name: DNSimple
@@ -90,6 +98,8 @@ websites:
       img: dnsimple.png
       tfa: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
       doc: https://blog.dnsimple.com/2012/08/protect-your-dnsimple-account-with-two-factor-authentication-from-authy/
 
     - name: Domain Monster
@@ -160,6 +170,8 @@ websites:
       tfa: Yes
       sms: Yes
       email: Yes
+      hardware: Yes
+      otp: Yes
       doc: https://fusion.easydns.com/Knowledgebase/Article/View/347/0/account-security
 
     - name: eNom
@@ -203,7 +215,9 @@ websites:
       tfa: Yes
       software: Yes
       hardware: Yes
-      doc: https://doc.gandi.net/en/organization/users/security
+      otp: Yes
+      u2f: Yes
+      doc: https://wiki.gandi.net/en/contacts/login/2-factor-activation
 
     - name: GoDaddy
       img: godaddy.png
@@ -211,6 +225,8 @@ websites:
       tfa: Yes
       sms: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
       doc: https://www.godaddy.com/help/enable-two-step-verification-7502
 
     - name: Google Domains
@@ -265,6 +281,8 @@ websites:
       img: internetbs.png
       tfa: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
       doc: /notes/internetbs/
 
     - name: INWX
@@ -347,6 +365,8 @@ websites:
       img: namesilo.png
       tfa: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
       doc: https://www.namesilo.com/Support/2~Factor-Authentication
 
     - name: NamesPro.ca
@@ -461,6 +481,8 @@ websites:
       img: register4less.png
       tfa: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
       doc: http://blog.register4less.com/?p=43
 
     - name: Registro.br
@@ -491,6 +513,8 @@ websites:
       img: uniregistry.png
       tfa: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
       doc: https://uniregistry.help/my-account-en/what-is-two-step-verification/
 
     - name: United Domains USA

--- a/_data/education.yml
+++ b/_data/education.yml
@@ -75,6 +75,8 @@ websites:
       tfa: Yes
       sms: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
       doc: https://support.clever.com/hc/en-us/articles/202062333-Two-Factor-Authentication
 
     - name: Code School

--- a/_data/email.yml
+++ b/_data/email.yml
@@ -5,6 +5,7 @@ websites:
       tfa: Yes
       sms: Yes
       phone: Yes
+      software: Yes
       doc: https://help.aol.com/articles/2-step-verification-stronger-than-your-password-alone
 
     - name: FastMail
@@ -14,6 +15,8 @@ websites:
       sms: Yes
       software: Yes
       hardware: Yes
+      otp: Yes
+      u2f: Yes
       doc: https://www.fastmail.com/help/account/2fa.html
 
     - name: Freenet
@@ -30,6 +33,8 @@ websites:
       phone: Yes
       software: Yes
       hardware: Yes
+      otp: Yes
+      u2f: Yes
       doc: https://www.google.com/intl/en-US/landing/2step/features.html
 
     - name: GMX
@@ -45,6 +50,8 @@ websites:
       sms: Yes
       email: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
       doc: https://help.hushmail.com/entries/63282756-Two-step-verification
 
     - name: Legalmail
@@ -84,6 +91,7 @@ websites:
       tfa: Yes
       software: Yes
       hardware: Yes
+      otp: Yes
       doc: https://support-en.mailbox.org/knowledge-base/article/is-there-a-two-factor-authentication
 
     - name: Mailfence
@@ -111,6 +119,8 @@ websites:
       tfa: Yes
       sms: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
       doc: http://windows.microsoft.com/en-us/windows/two-step-verification-faq
 
     - name: Pobox
@@ -119,6 +129,7 @@ websites:
       tfa: Yes
       software: Yes
       hardware: Yes
+      otp: Yes
       doc: https://pobox.com/helpspot/index.php?pg=kb.chapter&id=65
 
     - name: Posteo
@@ -126,6 +137,9 @@ websites:
       img: posteo.png
       tfa: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
+      u2f: No
       doc: https://posteo.de/en/help/what-is-two-factor-authentication-and-how-do-i-set-it-up
 
     - name: ProtonMail
@@ -133,6 +147,8 @@ websites:
       img: protonmail.png
       tfa: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
       doc: https://protonmail.com/support/knowledge-base/two-factor-authentication/
 
     - name: Riseup Mail
@@ -150,9 +166,12 @@ websites:
 
     - name: StartMail
       url: https://www.startmail.com
+      twitter: MyStartMail
       img: startmail.png
       tfa: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
       doc: https://support.startmail.com/index.php?/Knowledgebase/Article/View/704/4/how-to-set-up-two-factor-authentication-2fa
 
     - name: T-Online

--- a/_data/entertainment.yml
+++ b/_data/entertainment.yml
@@ -173,4 +173,6 @@ websites:
       software: Yes
       phone: Yes
       hardware: Yes
+      otp: Yes
+      u2f: Yes
       doc: https://www.google.com/intl/en-US/landing/2step/features.html

--- a/_data/finance.yml
+++ b/_data/finance.yml
@@ -102,6 +102,9 @@ websites:
       phone: Yes
       email: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
+      u2f: No
       doc: https://ttlc.intuit.com/questions/2902682-what-is-two-step-verification
 
     - name: Invoiced
@@ -161,6 +164,16 @@ websites:
       img: nexonia.png
       tfa: No
 
+    - name: Neteller
+      url: http://www.neteller.com/
+      twitter: neteller
+      img: neteller.png
+      tfa: Yes
+      software: Yes
+      hardware: Yes
+      otp: Yes
+      doc: https://support.neteller.com/ACCOUNT/Two-Factor-Authentication/85238429/What-is-two-step-authentication-and-how-to-use-it.htm
+
     - name: Noddle
       url: https://www.noddle.co.uk
       twitter: useyournoddle
@@ -202,6 +215,8 @@ websites:
       img: pocketsmith.png
       tfa: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
       doc: https://www.pocketsmith.com/blog/2014/07/18/2fa-orginal-merchant-and-other-updates
 
     - name: Popmoney
@@ -310,6 +325,8 @@ websites:
       img: xero.png
       tfa: Yes
       software: Yes
+      hardware: Yes
+      otp: yes
       doc: https://help.xero.com/nz/MyXero_Two-Step_About
 
     - name: You Need A Budget (YNAB)

--- a/_data/gaming.yml
+++ b/_data/gaming.yml
@@ -28,6 +28,7 @@ websites:
       sms: Yes
       software: Yes
       hardware: Yes
+      otp: Yes
       doc: https://us.battle.net/support/en/article/Blizzard-Authenticator
 
     - name: Curse
@@ -51,6 +52,8 @@ websites:
       email: Yes
       sms: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
       doc: https://help.ea.com/en-us/help/account/origin-login-verification-information/
 
     - name: Enjin
@@ -68,7 +71,7 @@ websites:
       img: epicgames.png
       tfa: Yes
       email: Yes
-      doc: http://epicgames.desk.com/customer/en/portal/articles/2879127-what-is-two-factor-sign-in-and-how-do-i-opt-in-
+      doc: http://help.epicgames.com/customer/en/portal/articles/2879127-what-is-two-factor-sign-in-and-how-do-i-opt-in
 
     - name: EVE Online
       url: https://www.eveonline.com/
@@ -131,6 +134,8 @@ websites:
       img: gree.png
       tfa: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
       doc: /notes/gree/
 
     - name: Guild Wars 2
@@ -141,6 +146,8 @@ websites:
       email: Yes
       phone: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
       doc: https://help.guildwars2.com/hc/en-us/articles/230672927-Securing-Your-Account-With-Authentication
 
     - name: Humble Bundle

--- a/_data/health.yml
+++ b/_data/health.yml
@@ -26,6 +26,8 @@ websites:
       img: drchrono.png
       tfa: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
       doc: https://www.drchrono.com/blog/two-factor-authentication-extra-security-for-your-health-records/
 
     - name: Drugs.com
@@ -75,6 +77,8 @@ websites:
       tfa: Yes
       sms: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
       doc: http://windows.microsoft.com/en-au/windows/two-step-verification-faq
 
     - name: Hint Health

--- a/_data/hosting.yml
+++ b/_data/hosting.yml
@@ -88,6 +88,8 @@ websites:
       img: dreamhost.png
       tfa: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
       doc: http://wiki.dreamhost.com/Enabling_Multifactor_Authentication
 
     - name: Easy
@@ -102,6 +104,8 @@ websites:
       img: fastly.png
       tfa: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
       doc: https://docs.fastly.com/guides/account-management-and-security/enabling-and-disabling-two-factor-authentication
 
     - name: FS Data
@@ -132,6 +136,7 @@ websites:
       tfa: Yes
       software: Yes
       hardware: Yes
+      otp: Yes
 
     - name: Hostens
       url: https://www.hostens.com/
@@ -228,6 +233,8 @@ websites:
       img: maxcdn.png
       tfa: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
       doc: https://www.maxcdn.com/one/tutorial/enable-two-step-verification/
 
     - name: Media Temple
@@ -257,6 +264,8 @@ websites:
       tfa: Yes
       sms: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
       doc: https://blog.nearlyfreespeech.net/2014/02/28/price-cuts-more-security-and-recovery-options/
 
     - name: Netcup
@@ -272,6 +281,7 @@ websites:
       tfa: Yes
       software: Yes
       hardware: Yes
+      u2f: Yes
       doc: https://server.nitrado.net/deu/news2/view/nitrado-bietet-zweifaktorauthentifizierung/?f=index/mode:0/page:2
 
     - name: Noez
@@ -311,6 +321,9 @@ websites:
       sms: Yes
       software: Yes
       hardware: Yes
+      u2f: Yes
+      otp: Yes
+      doc: http://www.ovh.com/us/about-us/security.xml#double-authentification
 
     - name: PlanetHoster
       url: https://planethoster.net
@@ -359,6 +372,8 @@ websites:
       img: speedit.png
       tfa: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
 
     - name: Squarespace
       url: https://squarespace.com/
@@ -437,6 +452,7 @@ websites:
       tfa: Yes
       software: Yes
       hardware: Yes
+      otp: Yes
       doc: https://www.vultr.com/faq/#authy
 
     - name: WebFaction

--- a/_data/identity.yml
+++ b/_data/identity.yml
@@ -2,16 +2,19 @@ websites:
     - name: 1Password
       url: https://1password.com/
       img: 1password.png
-      tfa: Yes
-      software: Yes
-      doc: https://support.1password.com/two-factor-authentication/
+      tfa: No
+      email_address: support@1password.com
+      facebook: 1Password
+      twitter: 1Password
+      status: https://twitter.com/1Password/status/809091553381777409
 
     - name: Bitium
       url: https://www.bitium.com
       img: bitium.png
       tfa: Yes
-      hardware: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
       doc: https://support.bitium.com/customer/portal/articles/1417358-enabling-two-factor-authentication-2fa-
 
     - name: bitwarden
@@ -43,7 +46,47 @@ websites:
       tfa: Yes
       software: Yes
       hardware: Yes
+      otp: Yes
+      u2f: Yes
       doc: https://support.dashlane.com/hc/en-us/articles/202625042-Protect-your-account-using-Two-Factor-Authentication#title3
+
+    - name: Digidentity
+      url: https://www.digidentity.eu/en/
+      img: digidentity.png
+      tfa: Yes
+      software: Yes
+      hardware: Yes
+      otp: Yes
+      u2f: Yes
+
+    - name: Duo Security
+      url: https://duo.com
+      img: duo_security.png
+      tfa: Yes
+      software: Yes
+      hardware: Yes
+      otp: Yes
+      u2f: Yes
+      doc: https://guide.duo.com/u2f
+
+    - name: Gluu
+      url: https://www.gluu.org
+      img: gluu.png
+      tfa: Yes
+      hardware: Yes
+      otp: No
+      u2f: Yes
+      doc: https://www.gluu.org/identify-people-with-fido-u2f-tokens-using-the-gluu-server/
+
+    - name: GreenRADIUS
+      url: http://www.greenrocketsecurity.com
+      img: greenradius.png
+      tfa: Yes
+      software: Yes
+      hardware: Yes
+      otp: Yes
+      u2f: Yes
+      doc: http://www.greenrocketsecurity.com/greenradius/2fa/fido-1-0-u2f/
 
     - name: ID.me
       url: https://www.id.me/
@@ -57,9 +100,11 @@ websites:
       url: https://keepersecurity.com/
       img: keeper.png
       tfa: Yes
-      software: Yes
       phone: Yes
       sms: Yes
+      software: Yes
+      hardware: Yes
+      otp: Yes
       doc: https://www.keepersecurity.com/security#twoFactor
 
     - name: Keybase
@@ -74,7 +119,28 @@ websites:
       tfa: Yes
       software: Yes
       hardware: Yes
+      otp: Yes
       doc: https://helpdesk.lastpass.com/security-options/multifactor-authentication-options/
+
+    - name: LinOTP
+      url: https://www.linotp.org
+      img: linotp.png
+      tfa: Yes
+      software: Yes
+      hardware: Yes
+      otp: Yes
+      u2f: Yes
+      doc: https://www.linotp.org/doc/latest/part-management/managingtokens/fido_u2f.html
+
+    - name: MiiCard
+      url: http://www.miicard.com/
+      img: miicard.png
+      tfa: Yes
+      sms: Yes
+      software: Yes
+      hardware: Yes
+      otp: Yes
+      doc: http://support.miicard.com/hc/communities/public/questions/204691829-Add-a-YubiKey-to-your-miiCard
 
     - name: MyDigipass.com
       url: https://mydigipass.com/
@@ -83,6 +149,7 @@ websites:
       sms: Yes
       software: Yes
       hardware: Yes
+      otp: Yes
       doc: https://www.mydigipass.com/en/fp/signup
 
     - name: Okta
@@ -94,6 +161,8 @@ websites:
       phone: Yes
       email: Yes
       hardware: Yes
+      otp: Yes
+      u2f: Yes
       doc: https://help.okta.com/en/prod/Content/Topics/Security/MFA.htm
 
     - name: OneLogin
@@ -112,6 +181,16 @@ websites:
       email: Yes
       hardware: Yes
       doc: https://help.passpack.com/knowledgebase/idx.php/44/0/
+
+    - name: privacyIDEA
+      url: https://privacyidea.org
+      img: privacyidea.png
+      tfa: Yes
+      software: Yes
+      hardware: Yes
+      otp: Yes
+      u2f: Yes
+      doc: http://privacyidea.readthedocs.io
 
     - name: RoboForm
       url: https://www.roboform.com/

--- a/_data/investing.yml
+++ b/_data/investing.yml
@@ -16,8 +16,11 @@ websites:
       url: https://www.betterment.com/
       img: betterment.png
       tfa: Yes
-      software: Yes
       sms: Yes
+      software: Yes
+      hardware: Yes
+      otp: Yes
+      u2f: No
       doc: https://support.betterment.com/customer/en/portal/topics/1026376-two-factor-authentication-2fa-?b_id=9042
 
     - name: Charles Schwab
@@ -162,6 +165,12 @@ websites:
       url: https://www.scottrade.com/
       twitter: scottrade
       img: scottrade.png
+      tfa: No
+
+    - name: Sharebuilder
+      url: https://www.sharebuilder.com/
+      twitter: sharebuilder
+      img: sharebuilder.png
       tfa: No
 
     - name: SigFig

--- a/_data/other.yml
+++ b/_data/other.yml
@@ -113,6 +113,8 @@ websites:
       tfa: Yes
       sms: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
       doc: https://documentation.meraki.com/zGeneral_Administration/Managing_Dashboard_Access/Using_Google_Authenticator_for_Two-factor_Authentication_in_Dashboard
 
     - name: Clickworker
@@ -312,6 +314,8 @@ websites:
       sms: Yes
       phone: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
       doc: https://www.kickstarter.com/help/faq/backer+questions#faq_63004
 
     - name: Liftopia
@@ -329,6 +333,25 @@ websites:
       email: Yes
       software: Yes
       doc: https://www.mathworks.com/mw_account/two_step_verification/frequently-asked-questions.html
+
+    - name: Linux PAM
+      url: http://www.linux-pam.org/
+      img: pam.png
+      tfa: Yes
+      software: Yes
+      hardware: Yes
+      otp: Yes
+      u2f: Yes
+      doc: https://github.com/Yubico/pam-u2f
+
+    - name: Mandrill
+      url: https://mandrill.com/
+      img: mandrill.png
+      tfa: Yes
+      software: Yes
+      hardware: Yes
+      otp: Yes
+      doc: http://help.mandrill.com/entries/57465557
 
     - name: Mixpanel
       url: https://mixpanel.com/
@@ -378,8 +401,10 @@ websites:
     - name: PhraseApp
       url: https://phraseapp.com
       img: phraseapp.png
-      software: Yes
       tfa: Yes
+      software: Yes
+      hardware: Yes
+      otp: Yes
       doc: https://phraseapp.com/blog/posts/multi-factor-how-to-secure-your-account-using-multi-factor/
 
     - name: Pinboard
@@ -516,6 +541,16 @@ websites:
       img: wikipedia.png
       tfa: No
 
+    - name: WordPress (software)
+      url: https://wordpress.org
+      img: wordpress.png
+      tfa: Yes
+      software: Yes
+      hardware: Yes
+      otp: Yes
+      u2f: Yes
+      doc: https://github.com/georgestephanis/two-factor
+
     - name: Yclas
       url: https://yclas.com/
       img: yclas.png
@@ -527,6 +562,9 @@ websites:
       url: https://www.zendesk.com
       img: zendesk.png
       tfa: Yes
-      software: Yes
       sms: Yes
+      software: Yes
+      hardware: Yes
+      otp: Yes
+      u2f: No
       doc: https://support.zendesk.com/hc/en-us/articles/203824246

--- a/_data/payments.yml
+++ b/_data/payments.yml
@@ -22,6 +22,8 @@ websites:
       img: buycraft.png
       tfa: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
       sms: Yes
       exceptions:
           text: "SMS-capable phone required."
@@ -32,6 +34,8 @@ websites:
       img: dwolla.png
       tfa: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
       doc: http://help.dwolla.com/customer/portal/articles/2068158-two-factor-authentication-faq?b_id=5438
 
     - name: Flattr
@@ -54,6 +58,8 @@ websites:
       phone: Yes
       software: Yes
       hardware: Yes
+      otp: Yes
+      u2f: Yes
       doc: https://www.google.com/intl/en-US/landing/2step/features.html
 
     - name: Klarna
@@ -166,6 +172,8 @@ websites:
       sms: Yes
       software: Yes
       hardware: Yes
+      otp: Yes
+      u2f: Yes
       doc: https://support.stripe.com/questions/how-do-i-enable-two-step-verification
 
     - name: Vantiv

--- a/_data/remote.yml
+++ b/_data/remote.yml
@@ -4,6 +4,7 @@ websites:
       doc: https://aws.amazon.com/blogs/aws/multi-factor-auth-for-workspaces/
       tfa: Yes
       hardware: Yes
+      otp: Yes
       software: Yes
       img: awsworkspaces.png
 
@@ -59,6 +60,15 @@ websites:
       software: Yes
       doc: https://www.syspectr.com/en/faq/how-do-i-activate-deactivate-two-factor-authentication-for-my-account
 
+    - name: OpenSSH
+      url: http://www.openssh.com
+      img: openssh.png
+      tfa: Yes
+      hardware: Yes
+      otp: Yes
+      u2f: No
+      status: https://bugzilla.mindrot.org/show_bug.cgi?id=2319
+
     - name: Parsec
       url: https://www.parsecgaming.com
       img: parsec.png
@@ -80,4 +90,6 @@ websites:
       img: teamviewer.png
       tfa: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
       doc: https://www.teamviewer.com/en/help/402-How-do-I-activate-deactivate-two-factor-authentication-for-my-TeamViewer-account.aspx

--- a/_data/retail.yml
+++ b/_data/retail.yml
@@ -24,6 +24,8 @@ websites:
       img: amazon.png
       tfa: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
       sms: Yes
       exceptions:
           text: "SMS or phone call required to enable 2FA. Enabling on Amazon.com activates 2FA on other regional Amazon sites, such as UK and DE."
@@ -35,6 +37,8 @@ websites:
       tfa: Yes
       sms: Yes
       software: Yes
+      hardware: Yes
+      opt: Yes
       exceptions:
           text: "See http://support.apple.com/kb/HT5593 for a list of supported SMS carriers."
       doc: http://support.apple.com/kb/ht5570

--- a/_data/security.yml
+++ b/_data/security.yml
@@ -68,6 +68,8 @@ websites:
       img: digicert.png
       tfa: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
       doc: https://www.digicert.com/two-factor-authentication.htm
 
     - name: Dome9 Security
@@ -76,6 +78,7 @@ websites:
       tfa: Yes
       software: Yes
       hardware: Yes
+      otp: Yes
       doc: https://dome9.com/overview/strong-2-factor-authentication
 
     - name: Entrust
@@ -111,6 +114,7 @@ websites:
       tfa: Yes
       software: Yes
       hardware: Yes
+      uf2: Yes
       sms: Yes
       phone: Yes
       doc: https://support.norton.com/sp/en/us/home/current/solutions/v100023155_NortonM_Retail_1_en_us
@@ -120,6 +124,8 @@ websites:
       img: opendns.png
       tfa: Yes
       sms: Yes
+      hardware: Yes
+      otp: Yes
       software: Yes
       exceptions:
           text: "Only available for enterprise accounts."
@@ -166,6 +172,8 @@ websites:
       img: ssltrust.png
       tfa: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
       doc: http://www.ssltrust.com.au/enable-two-factor-authentication.html
 
     - name: Threat X
@@ -198,6 +206,8 @@ websites:
       img: tinfoil.png
       tfa: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
       doc: http://support.tinfoilsecurity.com/customer/portal/articles/1559364-do-you-support-two-factor-authentication-how-do-i-set-it-up-
 
     - name: TorGuard

--- a/_data/social.yml
+++ b/_data/social.yml
@@ -31,6 +31,8 @@ websites:
       tfa: Yes
       sms: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
       doc: https://blog.bufferapp.com/introducing-the-safest-social-media-publishing-on-the-web
 
     - name: DeviantArt
@@ -54,6 +56,8 @@ websites:
       sms: Yes
       software: Yes
       hardware: Yes
+      otp: Yes
+      u2f: Yes
       exceptions:
           text: "SMS required for 2FA. 1 account per phone number."
       doc: https://www.facebook.com/help/148233965247823
@@ -84,6 +88,8 @@ websites:
       phone: Yes
       software: Yes
       hardware: Yes
+      otp: Yes
+      u2f: Yes
       doc: https://www.google.com/intl/en-US/landing/2step/features.html
 
     - name: HootSuite
@@ -91,6 +97,8 @@ websites:
       img: hootsuite.png
       tfa: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
       doc: https://help.hootsuite.com/entries/22527304-Managing-Google-Authenticator
 
     - name: ICQ
@@ -207,6 +215,8 @@ websites:
       img: reddit.png
       tfa: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
       doc: https://www.reddithelp.com/en/categories/using-reddit/your-reddit-account/how-set-two-factor-authentication
 
     - name: Snapchat
@@ -229,6 +239,8 @@ websites:
       tfa: Yes
       sms: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
       doc: https://www.tumblr.com/docs/en/two_factor_auth
 
     - name: Twitter
@@ -236,6 +248,8 @@ websites:
       img: twitter.png
       tfa: Yes
       sms: Yes
+      hardware: Yes
+      otp: Yes
       exceptions:
           text: "SMS only available on select providers. Phone number associated with account required for 2FA. 10 accounts per phone number, 1 phone number per account."
       software: Yes
@@ -272,6 +286,8 @@ websites:
       tfa: Yes
       sms: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
       exceptions:
           text: "SMS-capable phone required."
       doc: https://en.support.wordpress.com/security/two-step-authentication/

--- a/_data/task.yml
+++ b/_data/task.yml
@@ -72,6 +72,8 @@ websites:
       tfa: Yes
       sms: Yes
       software: Yes
+      hardware: Yes
+      otp: Yes
       doc: http://help.trello.com/article/993-enabling-two-factor-authentication-for-your-trello-account
 
     - name: Wunderlist


### PR DESCRIPTION
Hi,

sorry, that this is a very big PR, but it contains basically notes regarding the hardware tokens based on dongleauth.info.

I would like to make both repos more up-to-date than it is now (our fault). 

I am quite aware of the [discussions](https://github.com/2factorauth/twofactorauth/issues?utf8=%E2%9C%93&q=dongleauth) around the hardware column. I totally don't want to start this again!

Instead I would like to ask, if it would be an option for you, to merge the "u2f" and "otp" notes without actually using them on twofactorauth.org. This would allow easier transfer between the repos. It would be easier for me to include your changes to dongleauth.info and to submit hardware changes here as well...

If you don't like this idea at all, please let me know, I'll try to find time to adapt PR accordingly.

Kind regards
Alex