### PR TITLE
Update Figma doc url

### DIFF
--- a/_data/other.yml
+++ b/_data/other.yml
@@ -206,7 +206,7 @@ websites:
       tfa: Yes
       sms: Yes
       software: Yes
-      doc: https://help.figma.com/#_two-factor-authentication
+      doc: https://help.figma.com/managing-your-account/creating-and-managing-your-account
 
     - name: Findmyshift
       url: https://www.findmyshift.com/


### PR DESCRIPTION
It looks like Figma updated their help docs recently and the doc URL broke. This URL is the most relevant that I could find. It talks about enabling 2FA during account setup.