### PR TITLE
method refactor of rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,10 +3,12 @@ require 'jekyll'
 
 task default: %w[proof verify rubocop]
 
+dest = './_site'.freeze
+
 task :build do
   config = Jekyll.configuration(
     'source' => './',
-    'destination' => './_site'
+    'destination' => dest
   )
   site = Jekyll::Site.new(config)
   Jekyll::Commands::Build.build site, config
@@ -33,10 +35,9 @@ RuboCop::RakeTask.new
 
 def check_site(options = {})
   require 'html-proofer'
-  dir = './_site'
   defaults = {
     assume_extension: true,
     check_html: true
   }
-  HTMLProofer.check_directory(dir, defaults.merge(options)).run
+  HTMLProofer.check_directory(dest, defaults.merge(options)).run
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,3 @@
-require 'html-proofer'
 require 'rubocop/rake_task'
 require 'jekyll'
 
@@ -14,22 +13,16 @@ task :build do
 end
 
 task proof: 'build' do
-  HTMLProofer.check_directory(
-    './_site', \
-    assume_extension: true, \
-    check_html: true, \
+  check_site(
     disable_external: true
-  ).run
+  )
 end
 
 task proof_external: 'build' do
-  HTMLProofer.check_directory(
-    './_site', \
-    assume_extension: true, \
-    check_html: true, \
-    cache: { timeframe: '1w' }, \
+  check_site(
+    cache: { timeframe: '1w' },
     hydra: { max_concurrency: 12 }
-  ).run
+  )
 end
 
 task :verify do
@@ -37,3 +30,13 @@ task :verify do
 end
 
 RuboCop::RakeTask.new
+
+def check_site(options = {})
+  require 'html-proofer'
+  dir = './_site'
+  defaults = {
+    assume_extension: true,
+    check_html: true
+  }
+  HTMLProofer.check_directory(dir, defaults.merge(options)).run
+end


### PR DESCRIPTION
I noticed in my own repo that it makes a bit more sense to call HTMLProofer from a single place, and the overlapping settings be configured as defaults. This makes it a bit easier to manage if you add to your configuration, but also to understand what the expected difference between tests is without having to mentally keep track of what is common between them.

I threw in a small change to move the require for the HTML Proofer to the method itself. By doing this, it gets loaded only if that method gets called, which means rake tasks will not fail for windows machines that commonly do not have libcurl properly installed, making your rake tasks fail because it cannot load up the HTML Proofer library properly even though it installed the ruby library, because the ruby library has a dependency on something annoying and likely not configured for windows based machines. The change however does not any other effect on its ability to run, so its a rather safe change