### PR TITLE
Use user facing GitLab doc link

### DIFF
--- a/_data/developer.yml
+++ b/_data/developer.yml
@@ -198,7 +198,7 @@ websites:
       tfa: Yes
       hardware: Yes
       software: Yes
-      doc: https://docs.gitlab.com/ee/security/two_factor_authentication.html
+      doc: https://docs.gitlab.com/ee/user/profile/account/two_factor_authentication.html
 
     - name: Hashicorp Atlas
       url: https://atlas.hashicorp.com/


### PR DESCRIPTION
The current link is how to configure 2FA as a server admin, rather than how to enable it for a personal account.