### PR TITLE
Remove third 's' from ExpressVPN's name and handles

### DIFF
--- a/_data/security.yml
+++ b/_data/security.yml
@@ -86,12 +86,12 @@ websites:
       hardware: Yes
       doc: http://www.entrust.net/certificate-services/cms-authentication.htm
 
-    - name: ExpresssVPN
+    - name: ExpressVPN
       img: expressvpn.png
       url: https://www.expressvpn.com
       tfa: No
-      twitter: ExpresssVPN
-      facebook: ExpresssVPN
+      twitter: expressvpn
+      facebook: ExpressVPN
 
     - name: GeoTrust
       url: https://www.geotrust.com/


### PR DESCRIPTION
* Remove third 's' from ExpressVPN's name, facebook, and twitter handles.
* Use 'expressvpn' instead of 'ExpressVPN' for twitter handle styling per: https://twitter.com/expressvpn