### PR TITLE
Remove Bank of America hardware token support

### DIFF
--- a/_data/banking.yml
+++ b/_data/banking.yml
@@ -94,8 +94,6 @@ websites:
       tfa: Yes
       sms: Yes
       email: Yes
-      hardware: Yes
-      doc: https://www.bankofamerica.com/privacy/online-mobile-banking-privacy/safepass.go
 
     - name: Bank of China (Hong Kong)
       url: http://www.bochk.com


### PR DESCRIPTION
Bank of America no longer supports using SafePass hardware tokens for two-factor auth. The tokens are only used for authorizing high-value transactions, but not login. Fixes #3185.