### PR TITLE
Updated MailChimp doc to prioritize app over SMS

### DIFF
--- a/_data/communication.yml
+++ b/_data/communication.yml
@@ -126,7 +126,7 @@ websites:
       tfa: Yes
       sms: Yes
       software: Yes
-      doc: http://kb.mailchimp.com/accounts/login/set-up-two-factor-authentication-with-sms
+      doc: https://kb.mailchimp.com/accounts/login/set-up-a-two-factor-authentication-app-at-login
 
     - name: Mailgun
       url: https://www.mailgun.com


### PR DESCRIPTION
MailChimp has two KB articles on 2FA, one for [SMS](https://kb.mailchimp.com/accounts/login/set-up-two-factor-authentication-with-sms) and one for [software/apps](https://kb.mailchimp.com/accounts/login/set-up-a-two-factor-authentication-app-at-login). I think it is more beneficial to have a documentation link to the app article because something like Google Authenticator or Duo tends to be more secure than SMS. I see you guys are actively discussing this here: https://github.com/2factorauth/frontend/issues/20.