### PR TITLE
Reverts the value of all doc fields to URLs

### DIFF
--- a/_data/banking.yml
+++ b/_data/banking.yml
@@ -208,7 +208,7 @@ websites:
       sms: Yes
       phone: Yes
       email: Yes
-      doc: /notes/chase/
+      doc: https://twofactorauth.org/notes/chase/
 
     - name: Chime
       url: https://www.chimebank.com

--- a/_data/domains.yml
+++ b/_data/domains.yml
@@ -258,7 +258,7 @@ websites:
       img: internetbs.png
       tfa: Yes
       software: Yes
-      doc: /notes/internetbs/
+      doc: http://twofactorauth.org/notes/internetbs/
 
     - name: INWX
       url: https://www.inwx.com/en/

--- a/_data/domains.yml
+++ b/_data/domains.yml
@@ -258,7 +258,7 @@ websites:
       img: internetbs.png
       tfa: Yes
       software: Yes
-      doc: http://twofactorauth.org/notes/internetbs/
+      doc: https://twofactorauth.org/notes/internetbs/
 
     - name: INWX
       url: https://www.inwx.com/en/

--- a/_data/gaming.yml
+++ b/_data/gaming.yml
@@ -131,7 +131,7 @@ websites:
       img: gree.png
       tfa: Yes
       software: Yes
-      doc: /notes/gree/
+      doc: https://twofactorauth.org/notes/gree/
 
     - name: Guild Wars 2
       url: https://www.guildwars2.com

--- a/_data/investing.yml
+++ b/_data/investing.yml
@@ -50,7 +50,7 @@ websites:
       hardware: Yes
       exceptions:
           text: "Only available for some account types"
-      doc: /notes/fidelity/
+      doc: https://twofactorauth.org/notes/fidelity/
 
     - name: Flatex
       url: https://www.flatex.de/


### PR DESCRIPTION
# Description
Some of the service entries contain a relative path in
their doc field that points to a local page on
twofactorauth.org. This paradigm is followed for sites
that support 2FA, but do not have good documentation articles
on their websites.

The problem that this commit addresses is for external tools
and services that rely on the doc field to present the user
with a URL to access the 2FA documentation for a service.

For example:
- 1Password
- 2fanotifier.org

These tools will have to specifically address the scenarios
where the doc field is a relative path instead of a full URL.
Updating the source data allows third parties to use the data
without addressing edge cases.

# Context

This change was originally made in  146fa92b79a98f5dbf7b4900bb7a3666390cd989

# Test results

```
$> bundle exec rake
Configuration file: ./_config.yml
            Source: ./
       Destination: ./_site
 Incremental build: disabled. Enable with --incremental
      Generating...
                    done in 2.244 seconds.
Running ["ImageCheck", "ScriptCheck", "LinkCheck", "HtmlCheck"] on ["./_site"] on *.html...


Ran on 8 files!


HTML-Proofer finished successfully.
.rbenv/versions/2.5.0/bin/ruby ./verify.rb
<------------ No errors. You're good to go! ------------>
Running RuboCop...
Inspecting 3 files
...

3 files inspected, no offenses detected
```