### PR TITLE
Removed Facebook Exception

### DIFF
--- a/_data/social.yml
+++ b/_data/social.yml
@@ -54,8 +54,6 @@ websites:
       sms: Yes
       software: Yes
       hardware: Yes
-      exceptions:
-          text: "SMS required for 2FA. 1 account per phone number."
       doc: https://www.facebook.com/help/148233965247823
 
     - name: Flipboard


### PR DESCRIPTION
Today, Facebook revamped their 2FA setup process https://www.facebook.com/notes/facebook-security/two-factor-authentication-for-facebook-now-easier-to-set-up/10155341377090766/) and it now does not require a phone number.