### PR TITLE
Update Squarespace TFA status

### DIFF
--- a/_data/hosting.yml
+++ b/_data/hosting.yml
@@ -369,9 +369,10 @@ websites:
 
     - name: Squarespace
       url: https://squarespace.com/
-      twitter: squarespace
       img: squarespace.png
-      tfa: No
+      tfa: Yes
+      software: Yes
+      doc: https://support.squarespace.com/hc/en-us/articles/360000044827
 
     - name: Time4VPS
       url: https://www.time4vps.eu/


### PR DESCRIPTION
Squarespace now supports 2FA.