### PR TITLE
Add exception to Skype

### DIFF
--- a/_data/communication.yml
+++ b/_data/communication.yml
@@ -195,7 +195,7 @@ websites:
       email: Yes
       sms: Yes
       software: Yes
-      exceptions: Yes
+      exceptions:
           text: "Must be associated with a Microsoft Account."
       doc: https://support.microsoft.com/en-us/help/12408/microsoft-account-about-two-step-verification
 

--- a/_data/communication.yml
+++ b/_data/communication.yml
@@ -195,6 +195,8 @@ websites:
       email: Yes
       sms: Yes
       software: Yes
+      exceptions: Yes
+          text: "Must be associated with a Microsoft Account."
       doc: https://support.microsoft.com/en-us/help/12408/microsoft-account-about-two-step-verification
 
     - name: Slack


### PR DESCRIPTION
Since a Microsoft account is needed to enable 2FA (according to the doc), old accounts that were created with a username (and not MS Account) will not have the ability to do this.

# Discussion
I was thinking about how to approach this. I happen to have an old Skype account (pre MS acquisition) and 1Password 7 tells me that Skype supports 2FA, but I do not have it enabled. I tried to figure out how to enable it, and found out that my old Skype account is not associated with my MS Account. Thus, I cannot enable it. I feel like the Skype entry as a whole may be unnecessary and should be removed as Skype is now under the "Microsoft Account" umbrella, and locking down the security of that encompasses Skype. It is a bit misleading to tell people with old Skype accounts that are not associated with a MS Account that 2FA does not work.

Let me know and I will adjust the PR.