### PR TITLE
Added exception to SendGrid

### DIFF
--- a/_data/communication.yml
+++ b/_data/communication.yml
@@ -171,6 +171,8 @@ websites:
       tfa: Yes
       sms: Yes
       software: Yes
+      exceptions:
+          text: "Software authentication requires the Authy app"
       doc: https://sendgrid.com/docs/User_Guide/Settings/two_factor_authentication.html
 
     - name: Sendloop


### PR DESCRIPTION
SendGrid requires Authy in order to use the software option (requires a 7 digit Authy token), otherwise you must use SMS.

<img width="721" alt="screen shot 2018-05-28 at 6 26 28 pm" src="https://user-images.githubusercontent.com/7388203/40623068-4385b94a-62a5-11e8-94fc-bf4a549a9ca6.png">
<img width="720" alt="screen shot 2018-05-28 at 6 17 08 pm" src="https://user-images.githubusercontent.com/7388203/40623074-4a040aba-62a5-11e8-99da-03645f71c8fd.png">
