### PR TITLE
Added exceptions for QNAP and Synology

### DIFF
--- a/_data/backup.yml
+++ b/_data/backup.yml
@@ -157,6 +157,8 @@ websites:
     tfa: Yes
     email: Yes
     software: Yes
+    exceptions:
+      text: "Only covers NAS system on local IP or custom domains"
     doc: https://www.qnap.com/en-us/how-to/tutorial/article/how-to-enhance-account-security-using-2-step-verification
 
   - name: SmartBox
@@ -196,6 +198,8 @@ websites:
     tfa: Yes
     software: Yes
     email: Yes
+    exceptions:
+      text: "Only covers NAS system on local IP or custom domains"
     doc: https://originwww.synology.com/en-us/knowledgebase/tutorials/615#t5
 
   - name: ThisData


### PR DESCRIPTION
We got some reports at 1Password regarding QNAP and Synology being listed as 2FA enabled when a user creates a login for a site like QNAP forums (a subdomain at https://forum.qnap.com/), but the other websites do not allow for it. Turns out, this is because the 2FA is associated with a local IP address or custom domain the NAS is hosted on.

Would love some feedback regarding my exception text--is it confusing or unclear?