### PR TITLE
Remove Commonwealth Bank as it does not meet requirements

### DIFF
--- a/_data/banking.yml
+++ b/_data/banking.yml
@@ -272,13 +272,6 @@ websites:
       tfa: No
       lang: de
 
-    - name: Commonwealth Bank of Australia
-      url: https://www.commbank.com.au/
-      img: commbank.png
-      tfa: Yes
-      sms: Yes
-      doc: https://www.commbank.com.au/security-privacy/netcode.html
-
     - name: Credit Union Australia
       url: https://www.cua.com.au/
       img: cua.png

--- a/_data/banking.yml
+++ b/_data/banking.yml
@@ -231,14 +231,6 @@ websites:
       img: citibank.png
       tfa: No
 
-    - name: Citibank Australia
-      url: https://www.citibank.com.au/
-      img: citibank.png
-      tfa: Yes
-      software: Yes
-      sms: Yes
-      doc: https://www.citibank.com.au/otp/
-
     - name: Citizens Bank
       url: https://www.citizensbank.com
       twitter: citizensbank

--- a/_data/banking.yml
+++ b/_data/banking.yml
@@ -231,6 +231,14 @@ websites:
       img: citibank.png
       tfa: No
 
+    - name: Citibank Australia
+      url: https://www.citibank.com.au/
+      img: citibank.png
+      tfa: Yes
+      software: Yes
+      sms: Yes
+      doc: https://www.citibank.com.au/otp/
+
     - name: Citizens Bank
       url: https://www.citizensbank.com
       twitter: citizensbank


### PR DESCRIPTION
Per the [Definition](https://github.com/2factorauth/twofactorauth/blob/master/CONTRIBUTING.md#a-note-on-definitions) of two-factor authentication, as a service that does not require a second factor upon logging in, the Commonwealth Bank should be removed from this database.

The [document that is provided in support of its addition](https://www.commbank.com.au/security-privacy/netcode.html) itself states that:

> NetCode SMS is a highly effective yet convenient authentication system requiring single-use passwords to authorise certain NetBank activities and transactions.

That is, not all activities and transactions require two-factor authentication, and so logging in cannot require it (as otherwise, _all_ activities and transactions would effectively require it.

(As an aside, I would venture that most Australian banks will fall into this non-compliant category.)