### PR TITLE
Remove Citibank AU

### DIFF
--- a/_data/banking.yml
+++ b/_data/banking.yml
@@ -272,13 +272,6 @@ websites:
       tfa: No
       lang: de
 
-    - name: Commonwealth Bank of Australia
-      url: https://www.commbank.com.au/
-      img: commbank.png
-      tfa: Yes
-      sms: Yes
-      doc: https://www.commbank.com.au/security-privacy/netcode.html
-
     - name: Credit Union Australia
       url: https://www.cua.com.au/
       img: cua.png

--- a/_data/banking.yml
+++ b/_data/banking.yml
@@ -264,6 +264,13 @@ websites:
       tfa: No
       lang: de
 
+    - name: Commonwealth Bank of Australia
+      url: https://www.commbank.com.au/
+      img: commbank.png
+      tfa: Yes
+      sms: Yes
+      doc: https://www.commbank.com.au/security-privacy/netcode.html
+
     - name: Credit Union Australia
       url: https://www.cua.com.au/
       img: cua.png

--- a/_data/banking.yml
+++ b/_data/banking.yml
@@ -231,14 +231,6 @@ websites:
       img: citibank.png
       tfa: No
 
-    - name: Citibank Australia
-      url: https://www.citibank.com.au/
-      img: citibank.png
-      tfa: Yes
-      software: Yes
-      sms: Yes
-      doc: https://www.citibank.com.au/otp/
-
     - name: Citizens Bank
       url: https://www.citizensbank.com
       twitter: citizensbank

--- a/_data/banking.yml
+++ b/_data/banking.yml
@@ -231,6 +231,14 @@ websites:
       img: citibank.png
       tfa: No
 
+    - name: Citibank Australia
+      url: https://www.citibank.com.au/
+      img: citibank.png
+      tfa: Yes
+      software: Yes
+      sms: Yes
+      doc: https://www.citibank.com.au/otp/
+
     - name: Citizens Bank
       url: https://www.citizensbank.com
       twitter: citizensbank


### PR DESCRIPTION
As per #3232 Citibank AU does not require 2FA upon logging in, only upon performing certain transactions. This does not satisfy the 2FA definition for this site.

(Sorry for the messy commits - I don't `git` much :wink:)