### PR TITLE
Update Commonwealth Bank of Australia

### DIFF
--- a/_data/banking.yml
+++ b/_data/banking.yml
@@ -275,9 +275,10 @@ websites:
     - name: Commonwealth Bank of Australia
       url: https://www.commbank.com.au/
       img: commbank.png
-      tfa: Yes
-      sms: Yes
+      tfa: No
       doc: https://www.commbank.com.au/security-privacy/netcode.html
+      twitter: CommBank
+      facebook: commonwealthbank
 
     - name: Credit Union Australia
       url: https://www.cua.com.au/


### PR DESCRIPTION
As per our working definition for 2fa, Commonwealth Bank does not satisfy it. (See Issue #1811)

The [document that is provided in support of its addition](https://www.commbank.com.au/security-privacy/netcode.html) itself states that:

> NetCode SMS is a highly effective yet convenient authentication system requiring single-use passwords to authorise certain NetBank activities and transactions.

The entry has been updated to include the financial institution's social media information instead.