### PR TITLE
Update gmail.com to mail.google.com

### DIFF
--- a/_data/email.yml
+++ b/_data/email.yml
@@ -23,7 +23,7 @@ websites:
       facebook: freenet
 
     - name: Gmail
-      url: https://gmail.com
+      url: https://mail.google.com
       img: gmail.png
       tfa: Yes
       sms: Yes


### PR DESCRIPTION
There are many URLs in the data.json data set that
redirect before landing on the final site. This
causes problems for third party clients (e.g. 2FA Notifier)
because they match on the origin URL.

Updating the data to reflect the final URL allows these
third party services to function correctly while also
preserving the functionality of twofactorauth.org
for end-users of the website.

We need to be careful when working with temporary redirects
since they could change in the future, but this PR is
just for gmail, which has a very VERY low likelihood of
redirecting to a new subdomain any time soon.