### PR TITLE
Update WordPress exception

### DIFF
--- a/_data/social.yml
+++ b/_data/social.yml
@@ -277,8 +277,6 @@ websites:
       tfa: Yes
       sms: Yes
       software: Yes
-      exceptions:
-          text: "SMS-capable phone required."
       doc: https://en.support.wordpress.com/security/two-step-authentication/
 
     - name: XING

--- a/_data/social.yml
+++ b/_data/social.yml
@@ -271,12 +271,14 @@ websites:
       img: weibo.png
       tfa: No
 
-    - name: WordPress.com
+    - name: WordPress
       url: https://wordpress.com
       img: wordpress.png
       tfa: Yes
       sms: Yes
       software: Yes
+      exceptions:
+        text: "SMS required for 2FA."
       doc: https://en.support.wordpress.com/security/two-step-authentication/
 
     - name: XING


### PR DESCRIPTION
Since we have the sms label, the exception was redundant and unnecessary.