### PR TITLE
Updated Coinbase

### DIFF
--- a/_data/cryptocurrencies.yml
+++ b/_data/cryptocurrencies.yml
@@ -189,7 +189,7 @@ websites:
       sms: Yes
       software: Yes
       phone: Yes
-      doc: https://support.coinbase.com/customer/en/portal/articles/1658338-how-do-i-set-up-2-factor-authentication-with-authy-
+      doc: https://support.coinbase.com/customer/en/portal/articles/1658338-how-do-i-set-up-2-factor-authentication-
 
     - name: CoinDeal
       url: https://coindeal.com


### PR DESCRIPTION
Update doc to remove "authy" portion of the URL as they support multiple software options, not just Authy.