### PR TITLE
Remove duplicate Vultr entry from hosting

### DIFF
--- a/_data/hosting.yml
+++ b/_data/hosting.yml
@@ -446,15 +446,7 @@ websites:
       tfa: Yes
       software: Yes
       doc: https://github.com/2factorauth/twofactorauth/pull/2311#issuecomment-273424695
-
-    - name: Vultr
-      url: https://www.vultr.com/
-      img: vultr.png
-      tfa: Yes
-      software: Yes
-      hardware: Yes
-      doc: https://www.vultr.com/faq/#authy
-
+      
     - name: WebFaction
       url: https://www.webfaction.com
       img: webfaction.png


### PR DESCRIPTION
Vultr is already in `cloud`, so this duplicate entry makes maintenance hard.

Resolves https://github.com/2factorauth/twofactorauth/issues/3258