### PR TITLE
change for netcup

### DIFF
--- a/_data/hosting.yml
+++ b/_data/hosting.yml
@@ -275,7 +275,7 @@ websites:
       doc: https://blog.nearlyfreespeech.net/2014/02/28/price-cuts-more-security-and-recovery-options/
 
     - name: Netcup
-      url: https://netcup.eu/
+      url: https://ccp.netcup.net/
       img: netcup.png
       tfa: Yes
       software: Yes


### PR DESCRIPTION
Corrected domain, the 2fa is available for ccp.netcup.net, the customer control panel.