### PR TITLE
Fix GitHub corner clickable area

### DIFF
--- a/css/corner.scss
+++ b/css/corner.scss
@@ -11,6 +11,11 @@
     right: 0;
     top: 0;
     width: 80px;
+    pointer-events: none;
+  }
+
+  .octo-triangle {
+    pointer-events:auto;
   }
 
   .octo-arm {

--- a/index.html
+++ b/index.html
@@ -28,9 +28,9 @@ hash: SupportTwoFactorAuth
   </div>
 </noscript>
 
-<a href="https://github.com/2factorauth/twofactorauth" class="github-corner">
+<a href="https://github.com/2factorauth/twofactorauth" class="github-corner" aria-label="View source on Github">
   <svg viewBox="0 0 250 250">
-    <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+    <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z" class="octo-triangle"></path>
     <path
       d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2"
       class="octo-arm"></path>


### PR DESCRIPTION
This PR fixes a bug where the clickable area for the GitHub corner is in the form of a square instead of the actual triangle-formed corner.