### PR TITLE
Add Leaseweb software token support and update documentation link

### DIFF
--- a/_data/cloud.yml
+++ b/_data/cloud.yml
@@ -103,12 +103,13 @@ websites:
       software: Yes
       doc: https://docs.joyent.com/public-cloud/getting-started/2fa
 
-    - name: LeaseWeb
+    - name: Leaseweb
       url: https://www.leaseweb.com/
       img: leaseweb.png
       tfa: Yes
       sms: Yes
-      doc: https://kb.leaseweb.com/display/KB/Two+factor+authentication%3A+Cyber+Security
+      software: Yes
+      doc: https://kb.leaseweb.com/display/KB/2-step+verification
 
     - name: Linode
       url: https://www.linode.com/


### PR DESCRIPTION
- Rename LeaseWeb to Leaseweb
- Add Leaseweb software token
- Updated documentation url 