### PR TITLE
Add Congressional Federal Credit Union

### DIFF
--- a/_data/banking.yml
+++ b/_data/banking.yml
@@ -290,6 +290,14 @@ websites:
       tfa: No
       twitter: CommBank
       facebook: commonwealthbank
+      
+     - name: Congressional Federal Credit Union
+       url: https://www.congressionalfcu.org/
+       twitter: congressfed
+       facebook: CongressionalFederal
+       email_address: email@congressionalfcu.org
+       img: congressionalfcu.png
+       tfa: No
 
     - name: Credit Union Australia
       url: https://www.cua.com.au/


### PR DESCRIPTION
Attempting to add Congressional Federal Credit Union to the list. They support anti-phishing by asking you to make sure the passphrase and Image shown are correct when you sign in, and that's it. They don't support two-step verification, much less a software or hardware key.