### PR TITLE
Updated Moneybird to the dotcom domain

### DIFF
--- a/_data/finance.yml
+++ b/_data/finance.yml
@@ -163,7 +163,7 @@ websites:
       tfa: No
 
     - name: Moneybird
-      url: https://www.moneybird.nl/
+      url: https://www.moneybird.com/
       img: moneybird.png
       tfa: Yes
       software: Yes


### PR DESCRIPTION
The moneybird application lives in the .com domain (https://moneybird.com/login).
Applications like 1Password did not recognize Moneybird correctly because of this reason. 