### PR TITLE
Update WageWorks 2FA status

### DIFF
--- a/_data/other.yml
+++ b/_data/other.yml
@@ -528,7 +528,6 @@ websites:
       tfa: Yes
       sms: Yes
       email: Yes
-      doc: https://www.wageworks.com/media/567495/terms-of-use.pdf
       exceptions:
           text: "Employer/plan sponsor may opt to not offer 2FA."
 

--- a/_data/other.yml
+++ b/_data/other.yml
@@ -525,8 +525,13 @@ websites:
     - name: WageWorks
       url: https://www.wageworks.com
       img: wageworks.png
-      tfa: No
-      twitter: WageWorksCares
+      tfa: Yes
+      sms: Yes
+      email: Yes
+      doc: https://www.wageworks.com/media/567495/terms-of-use.pdf
+      exceptions:
+          text: "Employer/plan sponsor may opt to not offer 2FA."
+
 
     - name: Watchman Monitoring
       url: https://www.watchmanmonitoring.com

--- a/_data/other.yml
+++ b/_data/other.yml
@@ -532,7 +532,6 @@ websites:
       exceptions:
           text: "Employer/plan sponsor may opt to not offer 2FA."
 
-
     - name: Watchman Monitoring
       url: https://www.watchmanmonitoring.com
       img: watchmanmonitoring.png


### PR DESCRIPTION
WageWorks now supports SMS and email 2FA.