### PR TITLE
Add software 2FA entry to Instagram.

### DIFF
--- a/_data/social.yml
+++ b/_data/social.yml
@@ -117,6 +117,7 @@ websites:
       img: instagram.png
       tfa: Yes
       sms: Yes
+      software: Yes
       doc: https://help.instagram.com/566810106808145
 
     - name: LinkedIn


### PR DESCRIPTION
As of today, Instagram [supports software-based 2FA](https://instagram-press.com/blog/2018/08/28/new-tools-to-help-keep-instagram-safe/). This PR marks Instagram as supporting software 2FA. The doc support page seems to already reflect this, so this PR doesn't update that.