### PR TITLE
Update VentraIP Australia 2FA status

### DIFF
--- a/_data/hosting.yml
+++ b/_data/hosting.yml
@@ -452,6 +452,7 @@ websites:
       tfa: Yes
       sms: Yes
       email: Yes
+      software: Yes
       doc: https://ventraip.com.au/blog/products-and-services/vipcontrol-2-1/
 
     - name: Versio

--- a/_data/hosting.yml
+++ b/_data/hosting.yml
@@ -453,7 +453,7 @@ websites:
       sms: Yes
       email: Yes
       software: Yes
-      doc: https://ventraip.com.au/blog/products-and-services/vipcontrol-2-1/
+      doc: https://ventraip.com.au/faq/article/two-factor-authentication-faq-vipcontrol/
 
     - name: Versio
       url: https://www.versio.nl


### PR DESCRIPTION
I've added the "Software" option for VentraIP as they support Google 2FA