### PR TITLE
Mobile: stop opening all categories

### DIFF
--- a/css/base.scss
+++ b/css/base.scss
@@ -321,10 +321,6 @@ span.progress {
 }
 
 @media(max-width: 768px) {
-  .mobile-table {
-    display: block;
-  }
-
   .desktop-table {
     display: none;
   }


### PR DESCRIPTION
`.mobile-table` is the table for each category, so this block actually displays all table.