### PR TITLE
Update US Bank 2FA status

### DIFF
--- a/_data/banking.yml
+++ b/_data/banking.yml
@@ -1019,7 +1019,8 @@ websites:
       twitter: usbank
       facebook: usbank
       img: usbank.png
-      tfa: No
+      tfa: Yes
+      sms: Yes
 
     - name: USAA
       url: https://www.usaa.com/

--- a/_data/banking.yml
+++ b/_data/banking.yml
@@ -1016,8 +1016,6 @@ websites:
 
     - name: US Bank
       url: https://www.usbank.com/
-      twitter: usbank
-      facebook: usbank
       img: usbank.png
       tfa: Yes
       sms: Yes


### PR DESCRIPTION
US bank supports SMS 2-factor auth. They do not have docs on it, but it's accessible under "My Profile" and "Additional Authenticators"