### PR TITLE
statuspage.io changed their twitter handle

### DIFF
--- a/_data/developer.yml
+++ b/_data/developer.yml
@@ -480,7 +480,7 @@ websites:
 
     - name: StatusPage.io
       url: https://www.statuspage.io
-      twitter: statuspageio
+      twitter: statuspage
       facebook: statuspageio
       img: statuspageio.png
       tfa: No


### PR DESCRIPTION
from `statuspageio` to `statuspage`, see https://twitter.com/statuspageio/status/972153097496682496 (https://twitter.com/statuspageio)