### PR TITLE
Update Adobe 2FA status

### DIFF
--- a/_data/other.yml
+++ b/_data/other.yml
@@ -5,10 +5,7 @@ websites:
       tfa: Yes
       sms: Yes
       software: Yes
-      email: Yes
-      doc: https://helpx.adobe.com/x-productkb/global/adobe-id-account-change.html#2-step-verification
-      exceptions:
-          text: "To activate 2-Step Verification, you must provide a mobile phone number."
+      doc: https://helpx.adobe.com/manage-account/using/secure-your-adobe-account.html
 
     - name: Aerohive Networks
       url: https://www.aerohive.com/

--- a/_data/other.yml
+++ b/_data/other.yml
@@ -3,6 +3,7 @@ websites:
       url: https://accounts.adobe.com/
       img: adobe.png
       tfa: Yes
+      email: Yes
       sms: Yes
       software: Yes
       doc: https://helpx.adobe.com/manage-account/using/secure-your-adobe-account.html


### PR DESCRIPTION
This PR closes #3486.
I also removed the email tag as there's no mention of supporting email authentication any longer (except from password recovery)