### PR TITLE
Fix input search lag via debounced keyup function

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -30,7 +30,7 @@ $(window).resize(function () {
 
 var isSearching = false;
 var jets = new Jets({
-  searchTag: '#jets-search',
+  callSearchManually: true,
   contentTag: '.jets-content',
   didSearch: function (searchPhrase) {
     document.location.hash = '';
@@ -77,6 +77,14 @@ var jets = new Jets({
     return $(tag).find('.keywords').text();
   }
 });
+
+// Wrap the jets.search function with a debounced function
+var debouncedSearch = debounce(function(e) {
+  jets.search(e.target.value);
+}, 350);
+
+// Attach a keyup event listener to the input
+$('#jets-search').keyup(debouncedSearch);
 
 /**
  * Ensure searching is conducted with regard to the user's viewport
@@ -139,3 +147,28 @@ function closeCategory(category) {
   $('.' + category + '-table').css('display', 'none');
   document.location.hash = '';
 }
+
+/**
+ * Returns a function, that, as long as it continues to be invoked, will not
+ * be triggered. The function will be called after it stops being called for
+ * N milliseconds.
+ * 
+ * leading edge, instead of the trailing.
+ * @param func The function to be debounced
+ * @param wait The time in ms to debounce 
+ */
+function debounce(func, wait) {
+  var timeout;
+  
+	return function() {
+		var context = this, args = arguments;
+		var later = function() {
+			timeout = null;
+			func.apply(context, args);
+    };
+    
+		clearTimeout(timeout);
+		timeout = setTimeout(later, wait);
+		if (!timeout) func.apply(context, args);
+	};
+};

--- a/js/app.js
+++ b/js/app.js
@@ -153,7 +153,6 @@ function closeCategory(category) {
  * be triggered. The function will be called after it stops being called for
  * N milliseconds.
  * 
- * leading edge, instead of the trailing.
  * @param func The function to be debounced
  * @param wait The time in ms to debounce 
  */


### PR DESCRIPTION
I noticed that the search input box on the main screen had some serious lag.  I wrote a debounce function, switched jets.js to manual search mode and wrote a jquery keyup handler to use the debounced function on the input box. 