### PR TITLE
Update Sentry's urls

### DIFF
--- a/_data/developer.yml
+++ b/_data/developer.yml
@@ -450,13 +450,13 @@ websites:
       software: Yes
 
     - name: Sentry
-      url: https://getsentry.com
+      url: https://sentry.io
       img: sentry.png
       tfa: Yes
       sms: Yes
       software: Yes
       hardware: Yes
-      doc: https://blog.getsentry.com/2016/06/22/introducing-2fa.html
+      doc: https://blog.sentry.io/2016/06/22/introducing-2fa
 
     - name: SourceForge
       url: https://sourceforge.net/


### PR DESCRIPTION
Sentry used to be at https://getsentry.com. That domain is now a permanent redirect (301) to https://sentry.io.