### PR TITLE
Add Mint doc

### DIFF
--- a/_data/finance.yml
+++ b/_data/finance.yml
@@ -163,7 +163,7 @@ websites:
       sms: Yes
       email: Yes
       software: Yes
-      doc: https://ttlc.intuit.com/questions/2902682-what-is-two-step-verification
+      doc: https://ttlc.intuit.com/questions/2905185
 
     - name: money by Envestnet | Yodlee
       url: https://money.yodlee.com/

--- a/_data/finance.yml
+++ b/_data/finance.yml
@@ -163,6 +163,7 @@ websites:
       sms: Yes
       email: Yes
       software: Yes
+      doc: https://ttlc.intuit.com/questions/2902682-what-is-two-step-verification
 
     - name: money by Envestnet | Yodlee
       url: https://money.yodlee.com/


### PR DESCRIPTION
MFA for Mint must be configured via another Intuit site, since Mint itself doesn't support setting it up. I added a link to the TurboTax documentation which describes how to do this. Unfortunately this is rather confusing so it would be nice to add an extra note describing the process, but the current schema doesn't seem to allow that.