### PR TITLE
Update XING 2FA status

### DIFF
--- a/_data/social.yml
+++ b/_data/social.yml
@@ -285,8 +285,10 @@ websites:
     - name: XING
       url: https://www.xing.com
       img: xing.png
-      tfa: No
-      twitter: XING_com
+      tfa: Yes
+      sms: Yes
+      software: Yes
+      doc: https://www.xing.com/settings/account/credentials/twofa
 
     - name: Zocle
       url: https://zocle.com/

--- a/_data/social.yml
+++ b/_data/social.yml
@@ -288,7 +288,6 @@ websites:
       tfa: Yes
       sms: Yes
       software: Yes
-      doc: https://www.xing.com/settings/account/credentials/twofa
 
     - name: Zocle
       url: https://zocle.com/


### PR DESCRIPTION
XING now supports 2FA (https://www.xing.com/settings/account/credentials/twofa).