### PR TITLE
Update Mint doc

### DIFF
--- a/_data/finance.yml
+++ b/_data/finance.yml
@@ -183,7 +183,7 @@ websites:
       sms: Yes
       email: Yes
       software: Yes
-      doc: https://ttlc.intuit.com/questions/2905185
+      doc: https://help.mint.com/Security/908045661/How-do-I-use-Google-Authenticator-to-login-to-Mint
 
     - name: money by Envestnet | Yodlee
       url: https://money.yodlee.com/

--- a/_data/finance.yml
+++ b/_data/finance.yml
@@ -183,7 +183,7 @@ websites:
       sms: Yes
       email: Yes
       software: Yes
-      doc: https://help.mint.com/Security/908045661/How-do-I-use-Google-Authenticator-to-login-to-Mint
+      doc: https://help.mint.com/Security/908045661
 
     - name: money by Envestnet | Yodlee
       url: https://money.yodlee.com/


### PR DESCRIPTION
The current doc link points to a TurboTax-specific help page which does not give correct 2FA info for mint.com

I was able to locate two potentially relevant help pages for mint.com:
https://help.mint.com/Security/908045661/How-do-I-use-Google-Authenticator-to-login-to-Mint
https://help.mint.com/Mint-Account-Management/888963021/How-to-protect-your-Mint-account

I chose the former since it is wholly about 2FA and because it contains instructions for enabling both sms/email 2FA and an authenticator app 2FA, though it isn't explicit about where to stop in the event that you only want sms/email 2FA. I'm amenable to using the other link if it better fits this project's definition requirements but it didn't seem to.