### PR TITLE
Remove phone auth from Guild Wars 2

### DIFF
--- a/_data/gaming.yml
+++ b/_data/gaming.yml
@@ -148,7 +148,6 @@ websites:
       sms: Yes
       tfa: Yes
       email: Yes
-      phone: Yes
       software: Yes
       doc: https://help.guildwars2.com/hc/en-us/articles/230672927-Securing-Your-Account-With-Authentication
 


### PR DESCRIPTION
They seem to have removed this feature, it isn't referenced anymore on the help page: https://help.guildwars2.com/hc/en-us/articles/230672927-Securing-Your-Account-With-Authentication