### PR TITLE
Be upfront about what you do not support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ are stored in folders corresponding to each of those categories in their own
 4. **Alexa top 200k**: A new site, that is not already listed, has to be within the
    Alexa top 200k ranking. You can check the ranking of a site [here](https://www.alexa.com/siteinfo).
 5. **No 2FA providers**: We do not list 2FA providers, such as [Authy](https://authy.com/), [Duo](https://duo.com/) or [Google Authenticator](https://github.com/google/google-authenticator).
-6. **No self-hosted software:**: We only support websites, not software you can self-host like Nextcloud, Mastodon etc.
+6. **No self-hosted software:** We only support centralized websites/web services, not (website) software you can self-host like Nextcloud, Mastodon etc.
 7. **Be Awesome**: You need to be awesome. That is all.
 
 ## Running Locally

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ are stored in folders corresponding to each of those categories in their own
 4. **Alexa top 200k**: A new site, that is not already listed, has to be within the
    Alexa top 200k ranking. You can check the ranking of a site [here](https://www.alexa.com/siteinfo).
 5. **No 2FA providers**: We do not list 2FA providers, such as [Authy](https://authy.com/), [Duo](https://duo.com/) or [Google Authenticator](https://github.com/google/google-authenticator).
-6. **No self-hosted software:** We only support centralized websites/web services, not (website) software you can self-host like Nextcloud, Mastodon etc.
+6. **No self-hosted software:** We only support centralized websites/web services, not (website) software you can self-host like [Nextcloud](https://nextcloud.com/), [Mastodon](https://joinmastodon.org/) etc.
 7. **Be Awesome**: You need to be awesome. That is all.
 
 ## Running Locally

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,8 @@ are stored in folders corresponding to each of those categories in their own
 4. **Alexa top 200k**: A new site, that is not already listed, has to be within the
    Alexa top 200k ranking. You can check the ranking of a site [here](https://www.alexa.com/siteinfo).
 5. **No 2FA providers**: We do not list 2FA providers, such as [Authy](https://authy.com/), [Duo](https://duo.com/) or [Google Authenticator](https://github.com/google/google-authenticator).
-6. **Be Awesome**: You need to be awesome. That is all.
+6. **No self-hosted software:**: We only support websites, not software you can self-host like Nextcloud, Mastodon etc.
+7. **Be Awesome**: You need to be awesome. That is all.
 
 ## Running Locally
 


### PR DESCRIPTION
You've declined https://github.com/2factorauth/twofactorauth/pull/3547 and in https://github.com/2factorauth/twofactorauth/pull/3546 you've explained:
> We don’t list self hosted sites/services.

However, that was actually **stated nowhere in your guidelines or so**! I mean this is your website/your rules, so it's totally your right to say what to support, but then you should be honest about what you not want to list here.

Without any indication of that you are essentially **wasting the time** of contributors. If they can read in the Contributing.md that self-hosted services are not supported, okay, they won't bother to create a PR here. Otherwise they'll do and this results in things like https://github.com/2factorauth/twofactorauth/pull/3546.