### PR TITLE
Move WEX to new tld

### DIFF
--- a/_data/cryptocurrencies.yml
+++ b/_data/cryptocurrencies.yml
@@ -389,7 +389,7 @@ websites:
       doc: https://support.uphold.com/hc/en-us/articles/206119683-How-does-phone-number-verification-work-
 
     - name: WEX (BTC-E)
-      url: https://wex.nz/
+      url: https://wex.link/
       img: wex.png
       tfa: Yes
       software: Yes


### PR DESCRIPTION
see https://bitcoinexchangeguide.com/wex-nz-crypto-exchange-formerly-btc-e-sees-domain-suspended-by-new-zealands-dnc/