### PR TITLE
Allow both 644 and 664 permissions on images

### DIFF
--- a/verify.rb
+++ b/verify.rb
@@ -45,6 +45,7 @@ def test_img(img, name, imgs)
 end
 
 # rubocop:disable Metrics/AbcSize
+# rubocop:disable Metrics/MethodLength
 def test_img_file(img)
   # Check image file extension and type
   error("#{img} is not using the #{@img_extension} format.")\
@@ -59,10 +60,15 @@ def test_img_file(img)
 
   # Check image permissions
   perms = File.stat(img).mode.to_s(8).split(//).last(3).join
-  error("#{img} permissions must be one of: #{@img_permissions.join(',')}. It is currently #{perms}.")\
+  # rubocop:disable Style/GuardClause
   unless @img_permissions.include?(perms)
+    error("#{img} permissions must be one of: #{@img_permissions.join(',')}. "\
+    "It is currently #{perms}.")
+  end
+  # rubocop:enable Style/GuardClause
 end
 # rubocop:enable Metrics/AbcSize
+# rubocop:enable Metrics/MethodLength
 
 # Load each section, check for errors such as invalid syntax
 # as well as if an image is missing

--- a/verify.rb
+++ b/verify.rb
@@ -20,6 +20,9 @@ require 'kwalify'
 # Image format used for all images in the 'img/' directories.
 @img_extension = '.png'
 
+# Permissions set for all the images in the 'img/' directories.
+@img_permissions = %w[644 664]
+
 # Send error message
 def error(msg)
   @output += 1
@@ -41,6 +44,7 @@ def test_img(img, name, imgs)
   test_img_file(img)
 end
 
+# rubocop:disable Metrics/AbcSize
 def test_img_file(img)
   # Check image file extension and type
   error("#{img} is not using the #{@img_extension} format.")\
@@ -54,10 +58,11 @@ def test_img_file(img)
   end
 
   # Check image permissions
-  perms = File.stat(img).mode
-  error("#{img} is not set 644. It is currently #{perms.to_s(8)}")\
-    unless perms.to_s(8) == '100644'
+  perms = File.stat(img).mode.to_s(8).split(//).last(3).join
+  error("#{img} is not set 644 or 664. It is currently #{perms}")\
+  unless @img_permissions.include?(perms)
 end
+# rubocop:enable Metrics/AbcSize
 
 # Load each section, check for errors such as invalid syntax
 # as well as if an image is missing

--- a/verify.rb
+++ b/verify.rb
@@ -59,7 +59,7 @@ def test_img_file(img)
 
   # Check image permissions
   perms = File.stat(img).mode.to_s(8).split(//).last(3).join
-  error("#{img} is not set 644 or 664. It is currently #{perms}")\
+  error("#{img} permissions must be one of: #{@img_permissions.join(',')}. It is currently #{perms}.")\
   unless @img_permissions.include?(perms)
 end
 # rubocop:enable Metrics/AbcSize


### PR DESCRIPTION
Due to our latest Travis builds failing I think it would be a good idea to also allow 664 octal permissions.
By comparing the default permissions on different operative systems we've seen that some use 644 and some use 664.
The difference between 644 and 664 is that the group of the owner can edit the image. The group is usually just the owner so it shouldn't really matter here.

The result of this change caused rubocop to complain that the Assignment Branch Condition size was too high. I disabled the check for the method in question as I didn't want to redo the entire method or split it into two functions.

I also made a variable for the permissions for easier editing.