### PR TITLE
Capital One has no 2FA solution

### DIFF
--- a/_data/banking.yml
+++ b/_data/banking.yml
@@ -202,11 +202,7 @@ websites:
     - name: Capital One
       url: https://www.capitalone.com/
       img: capitalone.png
-      tfa: Yes
-      sms: Yes
-      email: Yes
-      software: Yes
-      doc: https://www.capitalone.com/identity-protection/swiftid/
+      tfa: No
 
     - name: CDC Federal Credit Union
       url: https://www.cdcfcu.com


### PR DESCRIPTION
I'm a customer. There is no 2FA solution. They started something 2FA-like in 2015 but you can't get anything but username and password as a current customer.