### PR TITLE
Write down existing excluded categories from twofactorauth.org

### DIFF
--- a/EXCLUSION.md
+++ b/EXCLUSION.md
@@ -4,7 +4,7 @@ Below is a list of categories and websites that we've opted out from listing on 
 
 Apart from the reasons stated below, these exclusions are also intended to prevent TwoFactorAuth.org from being added to any professional or academic web filters, where automatic addition of sites supersedes human checks during which the goal of our project would be weighted higher than the link to a potentially questionable site.
 
-If you want to make a copy (fork) of our site to list any of these sites you're welcome to do so as long as you comply with our [license](https://github.com/2factorauth/twofactorauth/blob/master/LICENSE).
+If you want to make a copy (fork) of our site to list any of these sites you're welcome to do so as long as you comply with our [license](LICENSE).
 
 ## Categories
 
@@ -15,8 +15,15 @@ If you want to make a copy (fork) of our site to list any of these sites you're 
 
 *   #### Self-hosted services
 
-    The category "self-hosted services/sites" includes all types of software that's designed to be hosted by the end user (such as [ownCloud](https://owncloud.org/), [Nextcloud](https://nextcloud.com/), [Mastodon](https://joinmastodon.org/), [phpBB](https://www.phpbb.com/), [XenForo](https://xenforo.com/) etc).  
-    It also includes [Wordpress.org](https://wordpress.org/) (the open source software) but not [Wordpress.com](https://wordpress.com/) (the company).
+    The category "self-hosted services/sites" includes all types of software that's designed to be hosted by the end user. These are excluded from listing unless all these points are met:
+
+    1. All [Site Criteria](CONTRIBUTING.md#site-criteria) and [Guidelines](CONTRIBUTING.md#guidelines) are met
+
+    2. Public interest and public accessibility are given  
+
+    3. The site has an independent authentication database
+
+    4. The underlying service supports 2FA natively or through a first-party (developer) plugin
 
     There are several resons for why we've opted to not list such sites and services.
 
@@ -24,16 +31,8 @@ If you want to make a copy (fork) of our site to list any of these sites you're 
 
     -   If the core project doesn't support two factor authentication but instead through plugins it would mean that we would have to list all plugins that enable two factor authentication for the service. Something that is currently impossible with our website layout.
 
-    However, this exclusion can be lifted by the active maintainers given all these points are met:
+    If you have any questions regarding whether or not a site qualifies for listing, simply open an issue and we'll take a look.
 
-    1.  All [Site Criteria](CONTRIBUTING.md#site-criteria) and [Guidelines](CONTRIBUTING.md#guidelines) are met
-
-    1.  Public interest and public accessibility are given  
-
-    1.  The site has an independent authentication database
-
-    1.  The underlying service supports 2FA natively or through a first-party (developer) plugin
-    
 *   #### Potential controversial sites 
 
     Any site that could damage the reputation of TwoFactorAuth.org and/or lead to any controversy with either the maintainers or users, should not be listed.

--- a/EXCLUSION.md
+++ b/EXCLUSION.md
@@ -6,12 +6,12 @@ Below is a list of categories and websites that we've opted out from listing on 
 
 *   #### Pornographic sites
 
-    As the volunteers of [2factorauth](https://github.com/2factorauth) need to go through all sites to validate that the site/service provides 2FA to it's users and verify that the pull request meets our style guidelines we've chosen not   to list pornographic sites.
+    As the volunteers of [2factorauth](https://github.com/2factorauth) need to go through all sites to validate that the site/service provides 2FA to it's users and verify that the pull request meets our style guidelines we've chosen not   to list pornographic sites.  
     We've also chosen to do this so that we don't have to go through potentially disturbing or illegal material.
 
 *   #### Religious and Political sites
 
-    The line between Religious/political views protected by free speech and hate speech can sometimes be very hard to distinguish between.
+    The line between Religious/political views protected by free speech and hate speech can sometimes be very hard to distinguish between.  
     To avoid having to make those decisions we've opted out from listing any Religious or Political sites.
 
     Our goal with twofactorauth.org is
@@ -22,12 +22,12 @@ Below is a list of categories and websites that we've opted out from listing on 
 
 *   #### Self-hosted services
 
-    The category "self-hosted services/sites" includes all types of software that's designed to be hosted by the end user (such as [ownCloud](https://owncloud.org/), [NextCloud](https://nextcloud.com/), [Mastodon](https://joinmastodon.org/), [phpBB](https://www.phpbb.com/), [XenForo](https://xenforo.com/) etc).
+    The category "self-hosted services/sites" includes all types of software that's designed to be hosted by the end user (such as [ownCloud](https://owncloud.org/), [NextCloud](https://nextcloud.com/), [Mastodon](https://joinmastodon.org/), [phpBB](https://www.phpbb.com/), [XenForo](https://xenforo.com/) etc).  
     It also includes [Wordpress.org](https://wordpress.org/) (the open source software) but not [Wordpress.com](https://wordpress.com/) (the company).
 
     There are several resons for why we've opted to not list such sites and services.
 
-      -   TwoFactorAuth.org is targeted towards consumers and not website     administrators. As of right now, very few general internet users choose to host their own websites and services. Therefore we think that the effort on our part to maintain such a list of self hosted alternatives would outweigh the minimal theoretical change in the internet landscape by listing such services.
+      -   TwoFactorAuth.org is targeted towards consumers and not website administrators. As of right now, very few general internet users choose to host their own websites and services. Therefore we think that the effort on our part to maintain such a list of self hosted alternatives would outweigh the minimal theoretical change in the internet landscape by listing such services.
 
       -   If the core project doesn't support two factor authentication but instead through plugins it would mean that we would have to list all plugins that enable two factor authentication for the service. Something that is currently impossible with out website layout.
 

--- a/EXCLUSION.md
+++ b/EXCLUSION.md
@@ -9,11 +9,6 @@ Below is a list of categories and websites that we've opted out from listing on 
     As the volunteers of [2factorauth](https://github.com/2factorauth) need to go through all sites to validate that the site/service provides 2FA to it's users and verify that the pull request meets our style guidelines we've chosen not   to list pornographic sites.  
     We've also chosen to do this so that we don't have to go through potentially disturbing or illegal material.
 
-*   #### Religious and Political sites
-
-    The line between Religious/political views protected by free speech and hate speech can sometimes be very hard to distinguish between.  
-    To avoid having to make those decisions we've opted out from listing any Religious or Political sites.
-
 *   #### Self-hosted services
 
     The category "self-hosted services/sites" includes all types of software that's designed to be hosted by the end user (such as [ownCloud](https://owncloud.org/), [NextCloud](https://nextcloud.com/), [Mastodon](https://joinmastodon.org/), [phpBB](https://www.phpbb.com/), [XenForo](https://xenforo.com/) etc).  

--- a/EXCLUSION.md
+++ b/EXCLUSION.md
@@ -18,8 +18,6 @@ Below is a list of categories and websites that we've opted out from listing on 
 
     > [...] to build a website (TwoFactorAuth.org) with a comprehensive list of sites that support Two Factor Authentication, as well as the methods that they provide.
 
-    As a member of a religion or political party most likely won't change their views based on whether or not a site provides 2FA we feel that this is outside of out scope.
-
 *   #### Self-hosted services
 
     The category "self-hosted services/sites" includes all types of software that's designed to be hosted by the end user (such as [ownCloud](https://owncloud.org/), [NextCloud](https://nextcloud.com/), [Mastodon](https://joinmastodon.org/), [phpBB](https://www.phpbb.com/), [XenForo](https://xenforo.com/) etc).  
@@ -27,9 +25,9 @@ Below is a list of categories and websites that we've opted out from listing on 
 
     There are several resons for why we've opted to not list such sites and services.
 
-      -   TwoFactorAuth.org is targeted towards consumers and not website administrators. As of right now, very few general internet users choose to host their own websites and services. Therefore we think that the effort on our part to maintain such a list of self hosted alternatives would outweigh the minimal theoretical change in the internet landscape by listing such services.
+    -   TwoFactorAuth.org is targeted towards consumers and not website administrators. As of right now, very few general internet users choose to host their own websites and services. Therefore we think that the effort on our part to maintain such a list of self hosted alternatives would outweigh the minimal theoretical change in the internet landscape by listing such services.
 
-      -   If the core project doesn't support two factor authentication but instead through plugins it would mean that we would have to list all plugins that enable two factor authentication for the service. Something that is currently impossible with out website layout.
+    -   If the core project doesn't support two factor authentication but instead through plugins it would mean that we would have to list all plugins that enable two factor authentication for the service. Something that is currently impossible with out website layout.
 
 ## Sites
 

--- a/EXCLUSION.md
+++ b/EXCLUSION.md
@@ -1,8 +1,8 @@
 # TwoFactorAuth.org excluded categories and websites
 
-Below is a list of categories and websites that we've opted out from listing on TwoFactorAuth.org.
+Below is a list of categories and websites that we, [the collaborators](https://github.com/orgs/2factorauth/teams/collaborators/members), have opted to not list on TwoFactorAuth.org.
 
-Apart from the reasons stated below, these exclusions are also intended to prevent TwoFactorAuth.org from being added to any professional or academic web filters, where automatic addition of sites supersedes human checks during which the goal of our project would be weighted higher than the link to a potentially questionable site.
+One of the primary concerns we seek to address with these exclusions is professional and academic web filters. We believe that the service that this site provides should be as accessible as possible, to help as many people as possible, in as many environments as possible. Dynamic web filters can block websites based solely on the existence of keywords which could lead to this service being filtered for mentioning or linking out to categories of websites that web admins have deemed unacceptable for their domain. While we believe that every site should make an effort to protect their users (which often includes enabling Two Factor Authentication), we also believe that accessibility to this list for all has more value than listing every possible site and service.
 
 If you want to make a copy (fork) of our site to list any of these sites you're welcome to do so as long as you comply with our [license](LICENSE).
 
@@ -10,8 +10,7 @@ If you want to make a copy (fork) of our site to list any of these sites you're 
 
 *   #### Pornographic sites
 
-    As the volunteers of [2factorauth](https://github.com/2factorauth) need to go through all sites to validate that the site/service provides 2FA to it's users and verify that the pull request meets our style guidelines we've chosen not to list sites that primarily host and serve pornographic content.
-    We've also chosen to do this so that we don't have to go through potentially disturbing or illegal material.
+    As the volunteers of [2factorauth](https://github.com/2factorauth) need to review all submissions to validate that the site/service provides 2FA to its users in addition to verifying that the pull request meets our style guidelines, we've chosen to not list sites that primarily host and serve pornographic content. Given the volunteer driven nature of this project, there is no guarantee that there will always be a collaborator available to review a submission that also does not have an  objection to reviewing such material. Special consideration must also be given due to the potential for content in this category to quickly cross subjective personal boundaries that vary widely from person to person.
 
 *   #### Self-hosted services
 
@@ -37,7 +36,6 @@ If you want to make a copy (fork) of our site to list any of these sites you're 
 
     Any site that could damage the reputation of TwoFactorAuth.org and/or lead to any controversy with either the maintainers or users, should not be listed.
     The group of active maintainers will decide on whether to include or exclude a site within a specific timeframe. Once an exclusion was decided upon, the site will be listed in the section below and - if a pull request exists - it will be closed.
-    This decision will also be in effect for pull requests that already existed before this exclusion documentation was published. 
 
 ## Sites
 

--- a/EXCLUSION.md
+++ b/EXCLUSION.md
@@ -6,7 +6,7 @@ Below is a list of categories and websites that we've opted out from listing on 
 
 *   #### Pornographic sites
 
-    As the volunteers of [2factorauth](https://github.com/2factorauth) need to go through all sites to validate that the site/service provides 2FA to it's users and verify that the pull request meets our style guidelines we've chosen not   to list pornographic sites.  
+    As the volunteers of [2factorauth](https://github.com/2factorauth) need to go through all sites to validate that the site/service provides 2FA to it's users and verify that the pull request meets our style guidelines we've chosen not to list pornographic sites.  
     We've also chosen to do this so that we don't have to go through potentially disturbing or illegal material.
 
 *   #### Self-hosted services

--- a/EXCLUSION.md
+++ b/EXCLUSION.md
@@ -20,6 +20,12 @@ Below is a list of categories and websites that we've opted out from listing on 
 
     -   If the core project doesn't support two factor authentication but instead through plugins it would mean that we would have to list all plugins that enable two factor authentication for the service. Something that is currently impossible with our website layout.
 
+*   #### Potential controversial sites 
+
+    Any site that could damage the reputation of TwoFactorAuth.org and/or lead to any controversy with either the maintainers or users, should not be listed.
+    The group of active maintainers will decide on whether to include or exclude a site within a specific timeframe. Once an exclusion was decided upon, the site will be listed in the section below and - if a pull request exists - it will be closed.
+    This decision will also be in effect for pull requests that already existed before this exclusion documentation was published. 
+
 ## Sites
 
 Below is a list of specific sites/services excluded from TwoFactorAuth.org.

--- a/EXCLUSION.md
+++ b/EXCLUSION.md
@@ -1,12 +1,16 @@
 # TwoFactorAuth.org excluded categories and websites
 
-Below is a list of categories and websites that we've opted out from listing on TwoFactorAuth.org. If you want to make a copy (fork) of our site to list any of these sites you're welcome to do so as long as you comply with our [license](https://github.com/2factorauth/twofactorauth/blob/master/LICENSE).
+Below is a list of categories and websites that we've opted out from listing on TwoFactorAuth.org.
+
+Apart from the reasons stated below, these exclusions are also intended to prevent TwoFactorAuth.org from being added to any professional or academic web filters, where automatic addition of sites supersedes human checks during which the goal of our project would be weighted higher than the link to a potentially questionable site.
+
+If you want to make a copy (fork) of our site to list any of these sites you're welcome to do so as long as you comply with our [license](https://github.com/2factorauth/twofactorauth/blob/master/LICENSE).
 
 ## Categories
 
 *   #### Pornographic sites
 
-    As the volunteers of [2factorauth](https://github.com/2factorauth) need to go through all sites to validate that the site/service provides 2FA to it's users and verify that the pull request meets our style guidelines we've chosen not to list pornographic sites.  
+    As the volunteers of [2factorauth](https://github.com/2factorauth) need to go through all sites to validate that the site/service provides 2FA to it's users and verify that the pull request meets our style guidelines we've chosen not to list sites that primarily host and serve pornographic content.
     We've also chosen to do this so that we don't have to go through potentially disturbing or illegal material.
 
 *   #### Self-hosted services

--- a/EXCLUSION.md
+++ b/EXCLUSION.md
@@ -11,7 +11,7 @@ Below is a list of categories and websites that we've opted out from listing on 
 
 *   #### Self-hosted services
 
-    The category "self-hosted services/sites" includes all types of software that's designed to be hosted by the end user (such as [ownCloud](https://owncloud.org/), [NextCloud](https://nextcloud.com/), [Mastodon](https://joinmastodon.org/), [phpBB](https://www.phpbb.com/), [XenForo](https://xenforo.com/) etc).  
+    The category "self-hosted services/sites" includes all types of software that's designed to be hosted by the end user (such as [ownCloud](https://owncloud.org/), [Nextcloud](https://nextcloud.com/), [Mastodon](https://joinmastodon.org/), [phpBB](https://www.phpbb.com/), [XenForo](https://xenforo.com/) etc).  
     It also includes [Wordpress.org](https://wordpress.org/) (the open source software) but not [Wordpress.com](https://wordpress.com/) (the company).
 
     There are several resons for why we've opted to not list such sites and services.

--- a/EXCLUSION.md
+++ b/EXCLUSION.md
@@ -12,7 +12,7 @@ Below is a list of categories and websites that we've opted out from listing on 
 *   #### Religious and Political sites
 
     The line between Religious/political views protected by free speech and hate speech can sometimes be very hard to distinguish between.
-    To skip having to make those decisions we've opted out from listing any Religious or Political sites.
+    To avoid having to make those decisions we've opted out from listing any Religious or Political sites.
 
     Our goal with twofactorauth.org is
 

--- a/EXCLUSION.md
+++ b/EXCLUSION.md
@@ -20,6 +20,16 @@ Below is a list of categories and websites that we've opted out from listing on 
 
     -   If the core project doesn't support two factor authentication but instead through plugins it would mean that we would have to list all plugins that enable two factor authentication for the service. Something that is currently impossible with our website layout.
 
+    However, this exclusion can be lifted by the active maintainers given all these points are met:
+
+    1.  All [Site Criteria](CONTRIBUTING.md#site-criteria) and [Guidelines](CONTRIBUTING.md#guidelines) are met
+
+    1.  Public interest and public accessibility are given  
+
+    1.  The site has an independent authentication database
+
+    1.  The underlying service supports 2FA natively or through a first-party (developer) plugin
+    
 *   #### Potential controversial sites 
 
     Any site that could damage the reputation of TwoFactorAuth.org and/or lead to any controversy with either the maintainers or users, should not be listed.

--- a/EXCLUSION.md
+++ b/EXCLUSION.md
@@ -18,7 +18,7 @@ Below is a list of categories and websites that we've opted out from listing on 
 
     -   TwoFactorAuth.org is targeted towards consumers and not website administrators. As of right now, very few general internet users choose to host their own websites and services. Therefore we think that the effort on our part to maintain such a list of self hosted alternatives would outweigh the minimal theoretical change in the internet landscape by listing such services.
 
-    -   If the core project doesn't support two factor authentication but instead through plugins it would mean that we would have to list all plugins that enable two factor authentication for the service. Something that is currently impossible with out website layout.
+    -   If the core project doesn't support two factor authentication but instead through plugins it would mean that we would have to list all plugins that enable two factor authentication for the service. Something that is currently impossible with our website layout.
 
 ## Sites
 

--- a/EXCLUSION.md
+++ b/EXCLUSION.md
@@ -14,10 +14,6 @@ Below is a list of categories and websites that we've opted out from listing on 
     The line between Religious/political views protected by free speech and hate speech can sometimes be very hard to distinguish between.  
     To avoid having to make those decisions we've opted out from listing any Religious or Political sites.
 
-    Our goal with twofactorauth.org is
-
-    > [...] to build a website (TwoFactorAuth.org) with a comprehensive list of sites that support Two Factor Authentication, as well as the methods that they provide.
-
 *   #### Self-hosted services
 
     The category "self-hosted services/sites" includes all types of software that's designed to be hosted by the end user (such as [ownCloud](https://owncloud.org/), [NextCloud](https://nextcloud.com/), [Mastodon](https://joinmastodon.org/), [phpBB](https://www.phpbb.com/), [XenForo](https://xenforo.com/) etc).  

--- a/EXCLUSION.md
+++ b/EXCLUSION.md
@@ -1,3 +1,36 @@
-TwoFactorAuth.org Blacklist
-=================
+# TwoFactorAuth.org excluded categories and websites
 
+Below is a list of categories and websites that we've opted out from listing on TwoFactorAuth.org. If you want to make a copy (fork) of our site to list any of these sites you're welcome to do so as long as you comply with our [license](https://github.com/2factorauth/twofactorauth/blob/master/LICENSE).
+
+## Categories
+
+*   #### Pornographic sites
+
+    As the volunteers of [2factorauth](https://github.com/2factorauth) need to go through all sites to validate that the site/service provides 2FA to it's users and verify that the pull request meets our style guidelines we've chosen not   to list pornographic sites.
+    We've also chosen to do this so that we don't have to go through potentially disturbing or illegal material.
+
+*   #### Religious and Political sites
+
+    The line between Religious/political views protected by free speech and hate speech can sometimes be very hard to distinguish between.
+    To skip having to make those decisions we've opted out from listing any Religious or Political sites.
+
+    Our goal with twofactorauth.org is
+
+    > [...] to build a website (TwoFactorAuth.org) with a comprehensive list of sites that support Two Factor Authentication, as well as the methods that they provide.
+
+    As a member of a religion or political party most likely won't change their views based on whether or not a site provides 2FA we feel that this is outside of out scope.
+
+*   #### Self-hosted services
+
+    The category "self-hosted services/sites" includes all types of software that's designed to be hosted by the end user (such as [ownCloud](https://owncloud.org/), [NextCloud](https://nextcloud.com/), [Mastodon](https://joinmastodon.org/), [phpBB](https://www.phpbb.com/), [XenForo](https://xenforo.com/) etc).
+    It also includes [Wordpress.org](https://wordpress.org/) (the open source software) but not [Wordpress.com](https://wordpress.com/) (the company).
+
+    There are several resons for why we've opted to not list such sites and services.
+
+      -   TwoFactorAuth.org is targeted towards consumers and not website     administrators. As of right now, very few general internet users choose to host their own websites and services. Therefore we think that the effort on our part to maintain such a list of self hosted alternatives would outweigh the minimal theoretical change in the internet landscape by listing such services.
+
+      -   If the core project doesn't support two factor authentication but instead through plugins it would mean that we would have to list all plugins that enable two factor authentication for the service. Something that is currently impossible with out website layout.
+
+## Sites
+
+Below is a list of specific sites/services excluded from TwoFactorAuth.org.


### PR DESCRIPTION
I've written down the categories that we've previously decided not to include on twofactorauth.org.

If you think a category shouldn't be excluded then open a new issue or comment in an existing one about the topic and we'll discuss it there. Let's just try and get this merged so that we have a something to reference to in said issues/PRs.

That being said, please let me know if there's any spelling mistakes or possible improvements to the text.
Thanks! 😃 