### PR TITLE
Add documentation URL for XING

### DIFF
--- a/_data/social.yml
+++ b/_data/social.yml
@@ -290,6 +290,7 @@ websites:
       tfa: Yes
       sms: Yes
       software: Yes
+      doc: https://faq.xing.com/en/settings-security/two-factor-login-two-factor-authentication
 
     - name: Zocle
       url: https://zocle.com/


### PR DESCRIPTION
The proper documentation for the XING 2FA settings was missing and I added them.