### PR TITLE
Adding Tesla Vehicles to iot list

### DIFF
--- a/_data/iot.yml
+++ b/_data/iot.yml
@@ -69,6 +69,13 @@ websites:
       tfa: No
       twitter: TeslaMotors
 
+    - name: Tesla Vehicles
+      url: https://www.tesla.com
+      img: tesla.png
+      tfa: Yes
+      software: Yes
+      twitter: TeslaMotors
+
     - name: Total Connect Comfort
       url: https://www.mytotalconnectcomfort.com
       twitter: Honeywell_Home

--- a/_data/iot.yml
+++ b/_data/iot.yml
@@ -74,7 +74,6 @@ websites:
       img: tesla.png
       tfa: Yes
       software: Yes
-      twitter: TeslaMotors
 
     - name: Total Connect Comfort
       url: https://www.mytotalconnectcomfort.com


### PR DESCRIPTION
Tesla's Vehicles have a 'PIN to Drive' feature. This requires not only a key for the vehicle to be present, but the driver to know a preset PIN. This is a form of software 2FA.

The Tesla account does not have a form of 2FA, which is why I did not change that one.

I do not know of any official documentation on this feature.