### PR TITLE
Add INWX (Germany)

### DIFF
--- a/_data/domains.yml
+++ b/_data/domains.yml
@@ -279,6 +279,13 @@ websites:
       software: Yes
       doc: https://www.inwx.com/en/offer/mobiletan
 
+    - name: INWX (Germany)
+      url: https://www.inwx.de/de/
+      img: internetworx.png
+      tfa: Yes
+      software: Yes
+      doc: https://www.inwx.de/de/offer/mobiletan
+
     - name: iWantMyName
       url: https://iwantmyname.com/
       img: iwantmyname.png


### PR DESCRIPTION
Added INWX for German TLD (.de) so that 1password correctly finds the other domain and shows it as supporting 2FA.