### PR TITLE
Ampersand correction

### DIFF
--- a/_data/banking.yml
+++ b/_data/banking.yml
@@ -134,7 +134,7 @@ websites:
       phone: Yes
       email: Yes
 
-    - name: BB&amp;T
+    - name: 'BB&T'
       url: https://www.bbt.com/
       twitter: BBT
       facebook: BBTBank

--- a/_data/remote.yml
+++ b/_data/remote.yml
@@ -52,7 +52,7 @@ websites:
       software: Yes
       doc: http://www.cc-onlinehelp.com/en/#index/administrati/users/authenticati/authenticati.html
 
-    - name: O&amp;O Syspectr
+    - name: 'O&O Syspectr'
       url: https://www.syspectr.com
       img: oosyspectr.png
       tfa: Yes

--- a/_data/utilities.yml
+++ b/_data/utilities.yml
@@ -6,7 +6,7 @@ websites:
       img: aep.png
       tfa: No
 
-    - name: Andrews &amp; Arnold
+    - name: 'Andrews & Arnold'
       url: https://aa.net.uk
       img: aaisp.png
       tfa: Yes
@@ -23,7 +23,7 @@ websites:
       img: arcadia.png
       tfa: No
 
-    - name: AT&amp;T
+    - name: 'AT&T'
       url: https://www.att.com/
       twitter: ATTCares
       facebook: ATT
@@ -243,7 +243,7 @@ websites:
       tfa: No
       lang: fr
 
-    - name: Pacific Gas and Electric Company PG&amp;E
+    - name: 'Pacific Gas and Electric Company PG&E'
       url: https://www.pge.com/
       twitter: PGE4Me
       facebook: pacificgasandelectric


### PR DESCRIPTION
When a site name contains an ampersand (&) the normal HTML-notation would be to use &amp;. Yet, this &amp; will show up in the JSON-export and not the &.
Other examples in the data show, that the ampersand can be used without the HTML notation in the name when it's in single quotation marks (') - thus also resulting in a correct JSON-export.
All names with ampersands are now in single quotes.