### PR TITLE
Fix Pennsylvania State University doc link

### DIFF
--- a/_data/education.yml
+++ b/_data/education.yml
@@ -276,7 +276,7 @@ websites:
       phone: Yes
       software: Yes
       hardware: Yes
-      doc: https://www.identity.psu.edu/services/authentication-services/two-factor/
+      doc: http://www.identity.psu.edu/services/authentication-services/two-factor/
 
     - name: Purdue University
       url: https://www.purdue.edu/


### PR DESCRIPTION
HTTPS site currently returns a cert error (has for a few weeks now)

have an email into their hostmaster, but probably makes sense to link to a resolving site until it's resolved (pun intended)