### PR TITLE
Update Apple's 2fa

### DIFF
--- a/_data/backup.yml
+++ b/_data/backup.yml
@@ -4,10 +4,9 @@ websites:
     img: icloud.png
     tfa: Yes
     sms: Yes
+    phone: Yes
     software: Yes
-    exceptions:
-        text: "See https://support.apple.com/HT202656 for a list of supported SMS carriers."
-    doc: https://support.apple.com/HT204152
+    doc: https://support.apple.com/en-us/HT204915
 
   - name: Backblaze
     url: https://www.backblaze.com

--- a/_data/retail.yml
+++ b/_data/retail.yml
@@ -42,7 +42,7 @@ websites:
       img: apple.png
       tfa: Yes
       sms: Yes
-      phones: Yes
+      phone: Yes
       software: Yes
       doc: https://support.apple.com/en-us/HT204915
 

--- a/_data/retail.yml
+++ b/_data/retail.yml
@@ -42,10 +42,9 @@ websites:
       img: apple.png
       tfa: Yes
       sms: Yes
+      phones: Yes
       software: Yes
-      exceptions:
-          text: "See http://support.apple.com/kb/HT5593 for a list of supported SMS carriers."
-      doc: http://support.apple.com/kb/ht5570
+      doc: https://support.apple.com/en-us/HT204915
 
     - name: Arcaplanet
       url: https://www.arcaplanet.it/


### PR DESCRIPTION
Seems like there's a difference between Apple's "2-step verification" and "2-factor authentication", so this update points to the newer (presumably more secure) one. It also doesn't seem to be listing any restricted carriers like previous one so removing `exceptions` block.