### PR TITLE
Update Comcast software token support & mobile app exception

### DIFF
--- a/_data/utilities.yml
+++ b/_data/utilities.yml
@@ -71,8 +71,9 @@ websites:
       tfa: Yes
       sms: Yes
       email: Yes
+      software: Yes
       exceptions:
-          text: "SMS-capable phone and a non-Comcast.net email required for 2FA."
+          text: "SMS-capable phone and a non-Comcast.net email required for 2FA. Software authentication requires Xfinity Authenticator mobile app."
       doc: https://www.xfinity.com/support/account/enroll-2-step-verification/
 
     - name: ComEd


### PR DESCRIPTION
Comcast has added software token support, but it requires their own [Xfinity Authenticator](https://xfinity.com/support/articles/multi-factor-authentication-xfinity-authenticator-setup) app.