### PR TITLE
Update USAA exception with Symantec VIP app requirement

### DIFF
--- a/_data/banking.yml
+++ b/_data/banking.yml
@@ -1101,6 +1101,8 @@ websites:
       email: Yes
       software: Yes
       doc: https://www.usaa.com/inet/pages/security_token_logon_options
+      exceptions:
+       text: "Software authentication requires the Symantec VIP mobile app."
 
     - name: UW Credit Union
       url: https://www.uwcu.org/


### PR DESCRIPTION
USAA annoyingly requires a Symantec app ([Symantec VIP](https://vip.symantec.com/)) to get the software token.

Info here: https://www.usaa.com/inet/pages/security_token_logon_options (CyberCode Token tab)