### PR TITLE
Make documentation links open in new tab

### DIFF
--- a/_includes/desktop-table.html
+++ b/_includes/desktop-table.html
@@ -45,7 +45,7 @@
 
         <td class="positive icon">
           {% if website.doc %}
-          <a href="{{ website.doc }}"><i class="external url link large icon"></i></a>
+          <a href="{{ website.doc }}" target="_blank" rel="noopener"><i class="external url link large icon"></i></a>
           {% endif %}
         </td>
 

--- a/_includes/mobile-table.html
+++ b/_includes/mobile-table.html
@@ -37,7 +37,7 @@
       </div>
       {% if website.doc %}
       <div class="button-group">
-        <a alt="Documentation" href="{{ website.doc }}" class="ui twitter mini button"><i class="large book icon"></i> Docs</a>
+        <a alt="Documentation" href="{{ website.doc }}" target="_blank" rel="noopener" class="ui twitter mini button"><i class="large book icon"></i> Docs</a>
       </div>
       {% endif %}
     </div>


### PR DESCRIPTION
The icon used for documentation links (the box with an arrow pointing out) [generally means a link will open with a new tab](https://www.google.com/search?q=open+in+new+tab+icon&num=20&client=firefox-b-1-d&source=lnms&tbm=isch&sa=X). It always throws me off and makes it harder to return to the twofactorauth website.

(Use of the "noopener" attribute is [explained here](https://mathiasbynens.github.io/rel-noopener/), FYI.)