### PR TITLE
Change desktop docs icon to match book icon on mobile site

### DIFF
--- a/_includes/desktop-table.html
+++ b/_includes/desktop-table.html
@@ -45,7 +45,7 @@
 
         <td class="positive icon">
           {% if website.doc %}
-          <a href="{{ website.doc }}"><i class="external url link large icon"></i></a>
+          <a href="{{ website.doc }}"><i class="book link large icon"></i></a>
           {% endif %}
         </td>
 


### PR DESCRIPTION
As discussed in #3712 and #3643. External links still open in same window but changing the "arrow pointing to outside of box" icon makes the default choice more obvious, as that icon [typically symbolises](https://ux.stackexchange.com/q/79127) a link that will open in a new window/tab.

The book icon is already used instead on the mobile site, as [noted](https://github.com/2factorauth/twofactorauth/pull/3712#issuecomment-462387351) by @jamcat22.

<img width="991" alt="screen shot 2019-02-11 at 3 00 39 pm" src="https://user-images.githubusercontent.com/1703673/52589864-ebfa1b00-2e0d-11e9-9fe8-ff31106147b6.png">

Totally up to you guys whether or not this is appropriate, no hurt feelings if you disagree. :) 

(Removed the "url" class because I found no match for it in the CSS, by the way.)