### PR TITLE
Add Boxcryptor hardware token

### DIFF
--- a/_data/security.yml
+++ b/_data/security.yml
@@ -25,6 +25,7 @@ websites:
       img: boxcryptor.png
       tfa: Yes
       software: Yes
+      hardware: Yes
       doc: https://www.boxcryptor.com/help/boxcryptor-account/#two-factor-authentication
 
     - name: bugcrowd


### PR DESCRIPTION
Boxcryptor now also supports Security Keys (U2F / WebAuthN) as hardware tokens.

See: https://www.boxcryptor.com/en/blog/post/2-fa-with-security-keys/