### PR TITLE
Natwest SMS

### DIFF
--- a/_data/banking.yml
+++ b/_data/banking.yml
@@ -658,6 +658,7 @@ websites:
       url: https://www.natwest.com/personal.ashx
       img: natwest.png
       tfa: Yes
+      sms: Yes
       hardware: Yes
       doc: http://www.natwest.com/personal/online-banking/g1/banking-safely-online/card-reader.ashx
 


### PR DESCRIPTION
Incorrect info - Natwest now supports SMS 2fa. 