### PR TITLE
Add exception for TransferWise

### DIFF
--- a/_data/finance.yml
+++ b/_data/finance.yml
@@ -351,6 +351,8 @@ websites:
       phone: Yes
       software: Yes
       doc: https://transferwise.com/help/article/2811597/borderless-account/how-can-i-setup-2-step-login
+      exceptions:
+        text: "Software verification requires use of the TransferWise Mobile app. SMS-capable phone is required."
 
     - name: Treasury Direct
       url: https://www.treasurydirect.gov


### PR DESCRIPTION
TransferWise requires the app to be installed on your phone, and there doesn't seem to be a way to use TOTP codes from Google Authenticator. I've added an exception to TransferWise mentioning that.