### PR TITLE
Update HelloSign 2FA options

### DIFF
--- a/_data/legal.yml
+++ b/_data/legal.yml
@@ -21,6 +21,7 @@ websites:
       img: hellosign.png
       tfa: Yes
       sms: Yes
+      software: Yes
       exceptions:
-          text: "Two-factor authentication is only available to paid Business plan senders and above."
+          text: "SMS Two-factor authentication is only available to paid Business plan senders and above."
       doc: https://faq.hellosign.com/hc/en-us/articles/205714548-How-do-I-set-up-two-factor-authentication-

--- a/_data/legal.yml
+++ b/_data/legal.yml
@@ -24,4 +24,4 @@ websites:
       software: Yes
       exceptions:
           text: "SMS Two-factor authentication is only available to paid Business plan senders and above."
-      doc: https://faq.hellosign.com/hc/en-us/articles/205714548-How-do-I-set-up-two-factor-authentication-
+      doc: https://faq.hellosign.com/hc/en-us/articles/360025164091-Two-Factor-Authentication-Google-Authenticator

--- a/_data/legal.yml
+++ b/_data/legal.yml
@@ -24,4 +24,4 @@ websites:
       software: Yes
       exceptions:
           text: "SMS Two-factor authentication is only available to paid Business plan senders and above."
-      doc: https://faq.hellosign.com/hc/en-us/articles/360025164091-Two-Factor-Authentication-Google-Authenticator
+      doc: https://faq.hellosign.com/hc/en-us/articles/360025164091


### PR DESCRIPTION
HelloSign has recently added software 2FA support. More details about how to enable this one the website: https://faq.hellosign.com/hc/en-us/articles/360025164091-Two-Factor-Authentication-Google-Authenticator