### PR TITLE
Update doc link for mailbox.org

### DIFF
--- a/_data/email.yml
+++ b/_data/email.yml
@@ -84,7 +84,7 @@ websites:
       tfa: Yes
       software: Yes
       hardware: Yes
-      doc: https://support-en.mailbox.org/knowledge-base/article/is-there-a-two-factor-authentication
+      doc: https://kb.mailbox.org/display/MBOKBEN/How+to+use+two-factor+authentication+-+2FA
 
     - name: Mailfence
       url: https://mailfence.com/


### PR DESCRIPTION
The old one leads to a 404 error page.