### PR TITLE
Namecheap now supports hardware 2FA

### DIFF
--- a/_data/domains.yml
+++ b/_data/domains.yml
@@ -343,7 +343,6 @@ websites:
       img: namecheap.png
       tfa: Yes
       sms: Yes
-      phone: Yes
       software: Yes
       hardware: Yes
       doc: https://www.namecheap.com/support/knowledgebase/article.aspx/9253/45/how-to-two-factor-authentication

--- a/_data/domains.yml
+++ b/_data/domains.yml
@@ -345,6 +345,7 @@ websites:
       sms: Yes
       phone: Yes
       software: Yes
+      hardware: Yes
       doc: https://www.namecheap.com/support/knowledgebase/article.aspx/9253/45/how-to-two-factor-authentication
 
     - name: NameSilo.com


### PR DESCRIPTION
See https://www.namecheap.com/support/knowledgebase/article.aspx/10102/45/how-can-i-use-the-u2f-method-for-twofactor-authentication