### PR TITLE
Update eBay - documentation link

### DIFF
--- a/_data/retail.yml
+++ b/_data/retail.yml
@@ -131,6 +131,7 @@ websites:
       img: ebay.png
       tfa: Yes
       sms: Yes
+      doc: https://community.ebay.com/t5/Getting-Started/HOW-TO-add-Two-Factor-Authentication-2FA-when-signing-in-on-EBay/td-p/27465876
 
     - name: ePRICE
       url: https://www.eprice.it/


### PR DESCRIPTION
This community-link describes where to go to activate 2FA - it seems there's no "offical" entry in eBay's help for this 🙄 