### PR TITLE
Update TransIP

### DIFF
--- a/_data/hosting.yml
+++ b/_data/hosting.yml
@@ -465,7 +465,6 @@ websites:
       url: https://www.transip.nl/
       img: transip.png
       tfa: Yes
-      sms: Yes
       software: Yes
       doc: https://www.transip.nl/knowledgebase/artikel/162
 

--- a/_data/hosting.yml
+++ b/_data/hosting.yml
@@ -467,8 +467,7 @@ websites:
       tfa: Yes
       sms: Yes
       software: Yes
-      hardware: Yes
-      doc: https://www.transip.nl/vragen/574-hoe-stel-two-factor-authentication/
+      doc: https://www.transip.nl/knowledgebase/artikel/162
 
     - name: UKFast
       url: https://www.ukfast.co.uk/

--- a/_data/hosting.yml
+++ b/_data/hosting.yml
@@ -467,7 +467,8 @@ websites:
       tfa: Yes
       software: Yes
       doc: https://www.transip.nl/knowledgebase/artikel/162
-
+      exceptions:
+          text: "While both the main control panel and STACK support 2FA, each system is separate and requires its own setup."
     - name: UKFast
       url: https://www.ukfast.co.uk/
       img: ukfast.png


### PR DESCRIPTION
Closes #3755.

While the information in the #3755 are quite sparse, I read from the (now new) documentation-link for software-2FA and https://www.transip.nl/knowledgebase/artikel/163 for SMS-2FA that these are the only methods available.