### PR TITLE
Update UK2

### DIFF
--- a/_data/domains.yml
+++ b/_data/domains.yml
@@ -495,10 +495,11 @@ websites:
 
     - name: UK2
       url: https://www.uk2.net/
-      twitter: UK2
-      facebook: UK2.net
       img: uk2.png
-      tfa: No
+      tfa: Yes
+      software: Yes
+      sms: Yes
+      doc: https://www.uk2.net/knowledgebase/display/UK2/Two+Factor+Authentication+Security+-+2FA
 
     - name: Uniregistry
       url: https://uniregistry.com/


### PR DESCRIPTION
UK2 now supports Software or SMS authentication.
NB: Documentation is outdated, and only refers to SMS authentication. Unable to locate any newer documentation.