### PR TITLE
Update Scaleway

### DIFF
--- a/_data/cloud.yml
+++ b/_data/cloud.yml
@@ -184,6 +184,7 @@ websites:
       url: https://www.scaleway.com
       img: scaleway.png
       tfa: Yes
+      email: Yes
       software: Yes
       doc: https://blog.online.net/2017/06/13/introducing-two-factor-authentication-on-scaleway/
 


### PR DESCRIPTION
Scaleway now support for a while mail-based password-less authentication by the way of a magic link.

See: https://www.scaleway.com/en/docs/console-magic-link-authentication/