### PR TITLE
Add Ubisoft email 2FA

### DIFF
--- a/_data/gaming.yml
+++ b/_data/gaming.yml
@@ -346,6 +346,7 @@ websites:
       img: uplay.png
       tfa: Yes
       software: Yes
+      email: Yes
       doc: https://support.ubi.com/en-GB/Faqs/000025170/Secure-your-account-with-2-Step-Verification
 
     - name: Wargaming


### PR DESCRIPTION
Ubisoft does support 2FA by email, it says so [here](https://support.ubi.com/en-US/Faqs/000039952). It is not part of Ubisoft's official 2FA documentation, only in an official FAQ.