### PR TITLE
PyPI supports TFA

### DIFF
--- a/_data/developer.yml
+++ b/_data/developer.yml
@@ -422,10 +422,12 @@ websites:
       doc: https://pushover.net/faq#security-2fa
 
     - name: PyPI
-      url: https://pypi.python.org/
-      twitter: pypi
+      url: https://pypi.org/
       img: pypi.png
-      tfa: No
+      tfa: Yes
+      software: Yes
+      hardware: Yes
+      doc: https://pypi.org/help/#2fa
 
     - name: PythonAnywhere
       url: https://www.pythonanywhere.com

--- a/_data/developer.yml
+++ b/_data/developer.yml
@@ -427,7 +427,7 @@ websites:
       tfa: Yes
       software: Yes
       hardware: Yes
-      doc: https://pypi.org/help/#2fa
+      doc: https://pypi.org/help/#twofa
 
     - name: PythonAnywhere
       url: https://www.pythonanywhere.com


### PR DESCRIPTION
PyPI supports both software (TOPT) and hardware (via WebAuthn) two factor auth.

This also updates to the dedicated PyPI URL.