### PR TITLE
Add Shopify hardware support

### DIFF
--- a/_data/retail.yml
+++ b/_data/retail.yml
@@ -348,6 +348,7 @@ websites:
       tfa: Yes
       sms: Yes
       software: Yes
+      hardware: Yes
       doc: https://help.shopify.com/manual/your-account/account-security/two-step-authentication
 
     - name: Sierra Trading Post


### PR DESCRIPTION
https://help.shopify.com/en/manual/your-account/account-security/two-step-authentication#enable-two-step-authentication-with-security-keys