### PR TITLE
USAA does not support hardware tokens or email

### DIFF
--- a/_data/banking.yml
+++ b/_data/banking.yml
@@ -1160,8 +1160,8 @@ websites:
       img: usaa.png
       tfa: Yes
       sms: Yes
-      hardware: Yes
-      email: Yes
+      hardware: No
+      email: No
       software: Yes
       doc: https://www.usaa.com/inet/pages/security_token_logon_options
 

--- a/_data/banking.yml
+++ b/_data/banking.yml
@@ -1160,8 +1160,7 @@ websites:
       img: usaa.png
       tfa: Yes
       sms: Yes
-      hardware: No
-      email: No
+      email: Yes
       software: Yes
       doc: https://www.usaa.com/inet/pages/security_token_logon_options
 


### PR DESCRIPTION
USAA only supports three 'levels' of security: normal username and password, username and password with an SMS OTP, or username with PIN+OTP generated by a symantec app.