### PR TITLE
Santander UK doesn't support 2FA

### DIFF
--- a/_data/banking.yml
+++ b/_data/banking.yml
@@ -912,9 +912,7 @@ websites:
     - name: Santander UK
       url: https://www.santander.co.uk
       img: santander.png
-      tfa: Yes
-      sms: Yes
-      doc: https://www.santander.co.uk/uk/help-support/security-centre
+      tfa: No
 
     - name: SchoolsFirst FCU
       url: https://www.schoolsfirstfcu.org/


### PR DESCRIPTION
SMS is used to send codes for authorising some transactions but it is not possible to configure this to be required at login, so as per [the definitions](https://github.com/2factorauth/twofactorauth/blob/master/CONTRIBUTING.md#a-note-on-definitions), this should be `tfa: No`.