### PR TITLE
Sticky table header

### DIFF
--- a/css/base.scss
+++ b/css/base.scss
@@ -40,6 +40,14 @@ p {
   margin: 1em 0;
 }
 
+table {
+  thead {
+    top: 0;
+    position: sticky;
+    z-index: 1;
+  }
+}
+
 .website-table .left,
 .website-table .right {
   display: inline-block;


### PR DESCRIPTION
Give thead `position: sticky` to make it easier to see what category the checkmark belongs to.

This feature does not yet work in Chromium based browsers. See [https://caniuse.com/#feat=css-sticky](https://caniuse.com/#feat=css-sticky) for more details. However, the change is non-breaking.