### PR TITLE
Future proof data.json by creating different versions

### DIFF
--- a/api/v1/data.json
+++ b/api/v1/data.json
@@ -1,0 +1,30 @@
+---
+---
+{
+{%-  assign tfa_tags = "tfa, sms, phone, software, hardware" | split: ', ' -%}
+
+    {%- for section in site.data.sections -%}
+    {%- assign section_file = site.data[section.id] -%}
+    "{{ section.title }}": {
+                        {%- for website in section_file.websites -%}
+                                "{{ website.name }}": {
+                                    {%-for tag in website -%}
+                                      {%- unless tfa_tags contains tag[0] -%}
+                                    {%-if tag[0] != "exceptions"-%}"{{ tag[0] }}": {%- if tag[1] == true or tag[1] == false -%}{{tag[1]}}{%-else-%}"{{ tag[1] }}"{%-endif-%}{%-else-%}"{{ tag[0] }}": {
+                                    {%- for exception in tag[1] -%}
+                                     "{{ exception[0] }}": "{{ exception[1] }}"{%-if forloop.last != true-%},{%-endif-%}
+                                {%-endfor-%}}{%-endif-%}
+                                      {%- else -%}
+                                        {%- unless tag[1] == false -%}
+                                         "{{ tag[0] }}": true
+                                          {%- else -%}
+                                          "{{ tag[0] }}": false
+                                          {%-  endunless -%}
+                                        {%- endunless -%}
+                                      {%-if forloop.last != true-%},{%-endif-%}
+                                    {%-endfor-%}
+                               }{%- if forloop.last != true -%},{%- endif -%}
+                        {%- endfor -%}
+                        }{%- if forloop.last != true -%},{%- endif -%}
+    {%- endfor -%}
+}

--- a/api/v2/data.json
+++ b/api/v2/data.json
@@ -1,0 +1,22 @@
+---
+---
+{% raw %}{{% endraw %}{%
+for section in site.data.sections %}{%
+    assign section_file = site.data[section.id] %}"{{ section.title }}":{% raw %}{{% endraw %}{%
+    for website in section_file.websites %}"{{ website.name }}":{% raw %}{{% endraw %}{%
+        for tag in website %}{%
+            if tag[0] != "exceptions" %}"{{ tag[0] }}":{%
+                if tag[1] == true or tag[1] == false %}{{tag[1]}}{%
+                else %}"{{ tag[1] }}"{%
+                endif %}{%
+            else %}"{{ tag[0] }}":{% raw %}{{% endraw %}{%
+                for exception in tag[1] %}"{{ exception[0] }}":"{{ exception[1] }}"{%
+                    if forloop.last != true %},{% endif %}{%
+                endfor %}}{%
+            endif %}{%
+        if forloop.last != true %},{% endif %}{%
+        endfor %}}{%
+    if forloop.last != true %},{% endif %}{%
+    endfor %}}{%
+if forloop.last != true %},{% endif %}{%
+endfor %}}


### PR DESCRIPTION
As of right now, the `data.json` prints out the value of the YML tags regardless of the content. If we, in the future rework, let's say the `tfa`-tag, it would mean that third party scripts relying on the `data.json` would break.

Therefore I created two versions of the data.json:
* __Version 2__ is our current `data.json`. It spits out every tag and data.
* __Version 1__ is a little different. For tfa tags it returns true unless the data of the tag is false. This would allow us to in the future compress the YMLs or add new tags such as U2F and WebAuthN tags without breaking third party scripts.

In this PR I haven't removed the `data.json` in the root directory since that would break scripts if the PR got merged. However, if/when this PR gets merged we can redirect requests for `twofactorauth.org/data.json` to the `data.json` inside `api/v1` using CloudFlare.