### PR TITLE
Update Braintree hardware 2FA

### DIFF
--- a/_data/payments.yml
+++ b/_data/payments.yml
@@ -15,6 +15,7 @@ websites:
       tfa: Yes
       sms: Yes
       software: Yes
+      hardware: Yes
       doc: https://articles.braintreepayments.com/reference/security/two-factor-authentication
 
     - name: Buycraft


### PR DESCRIPTION
Braintree recently introduced hardware auth (webauthn) to its control panel.