### PR TITLE
update 2fa for web.de email provider

### DIFF
--- a/_data/email.yml
+++ b/_data/email.yml
@@ -231,7 +231,6 @@ websites:
     - name: Web.de
       url: https://web.de
       img: webde.png
-      lang: de
       tfa: Yes
       software: Yes
       doc: https://hilfe.web.de/sicherheit/2fa/index.html

--- a/_data/email.yml
+++ b/_data/email.yml
@@ -230,11 +230,11 @@ websites:
 
     - name: Web.de
       url: https://web.de
-      twitter: WEBDE
-      facebook: WEB.DE
       img: webde.png
       lang: de
-      tfa: No
+      tfa: Yes
+      software: Yes
+      doc: https://hilfe.web.de/sicherheit/2fa/index.html
 
     - name: Yahoo Japan Mail
       url: https://mail.yahoo.co.jp/


### PR DESCRIPTION
web.de supports 2fa via software token.
Fixes #3992 