### PR TITLE
Update to Nationwide Building Society

### DIFF
--- a/_data/banking.yml
+++ b/_data/banking.yml
@@ -702,8 +702,9 @@ websites:
       url: https://www.nationwide.co.uk/
       img: nationwide.png
       tfa: Yes
+      sms: yes
       hardware: Yes
-      doc: https://www.nationwide.co.uk/support/security-centre/internet-banking-security/card-reader-and-security-questions
+      doc: https://www.nationwide.co.uk/support/security-centre/internet-banking-security/new-log-in-experience
 
     - name: Natwest UK
       url: https://www.natwest.com/personal.ashx


### PR DESCRIPTION
Nationwide now supports SMS as login option since 10 September 2019.