### PR TITLE
Remove www. from Synology.com

### DIFF
--- a/_data/backup.yml
+++ b/_data/backup.yml
@@ -205,7 +205,7 @@ websites:
     doc: https://www.sync.com/help/how-do-i-setup-two-factor-authentication/
 
   - name: Synology
-    url: https://www.synology.com/
+    url: https://synology.com/
     img: synology.png
     tfa: Yes
     software: Yes


### PR DESCRIPTION
2FA is supported by account.synology.com but did not appear on 1Password