### PR TITLE
Exceptions and Restrictions currently text only

### DIFF
--- a/_includes/exception.html
+++ b/_includes/exception.html
@@ -7,28 +7,16 @@
 <div class='content'>
     {% if include.website.exceptions.text %}
         {{ include.website.exceptions.text }}
-    {% else %}
-        {% if include.website.exceptions.link %}
-            Click to see more info on the restrictions.
-        {% else %}
-            Some restrictions on 2FA for this site exist.
-        {% endif %}
     {% endif %}
 </div>
 {% endcapture %}
 
-    {% if include.website.exceptions.link %}
-        <a class="popup exception"
-            href="/restrictions#{{ include.website.name | downcase | handle }}"
-            data-position="bottom center"
-            data-html="{{ html | strip_newlines }}">
-            <i class="warning sign red link icon"></i>
-        </a>
-    {% else %}
+    {% if include.website.exceptions.text %}
         <span class="popup exception"
             data-position="bottom center"
             data-html="{{ html | strip_newlines }}">
             <i class="warning sign red link icon"></i>
         </span>
     {% endif %}
+
 {% endif %}


### PR DESCRIPTION
Exceptions and Restrictions are currently used text only, thus removing exceptions.link from exception.html.
Closes #3116.