### PR TITLE
Allow entries in multiple categories

### DIFF
--- a/_includes/desktop-table.html
+++ b/_includes/desktop-table.html
@@ -1,6 +1,7 @@
 {% assign section_id = include.id-param %}
 {% assign section_title = include.title-param %}
 {% assign section_file = site.data[section_id] %}
+{% assign multi_section_file = site.data["multi"] %}
 <div class="website-table desktop-table {{ section_id }}-table" id="{{ section_id }}-desktoptable">
   <table class="ui celled table content-wrapper">
     <thead>
@@ -15,8 +16,9 @@
     </tr>
     </thead>
     <tbody class="jets-content">
-    {% for website in section_file.websites %}
-    {% if website.lang and site.data.languages[website.lang] %}
+    {% assign multi_sites = multi_section_file.websites | where: "categories", section_id | concat: section_file.websites | sort: "name" %}
+    {% for website in multi_sites %}
+      {% if website.lang and site.data.languages[website.lang] %}
       {% assign progress_tweet = site.data.languages[website.lang].progress_tweet %}
       {% assign workonit_tweet = site.data.languages[website.lang].work_tweet %}
     {% else %}

--- a/_includes/mobile-table.html
+++ b/_includes/mobile-table.html
@@ -1,12 +1,14 @@
 {% assign section_id = include.id-param %}
 {% assign section_title = include.title-param %}
 {% assign section_file = site.data[section_id] %}
+{% assign multi_section_file = site.data["multi"] %}
 <div class="website-table mobile-table {{ section_id }}-table" id="{{ section_id }}-mobiletable">
   <div class="label">
     <h3>{{ section_title }}</h3>
   </div>
   <div class="jets-content">
-    {% for website in section_file.websites %}
+    {% assign multi_sites = multi_section_file.websites | where: "categories", section_id | concat: section_file.websites | sort: "name" %}
+    {% for website in multi_sites %}
     {% if website.lang and site.data.languages[website.lang] %}
       {% assign progress_tweet = site.data.languages[website.lang].progress_tweet %}
       {% assign workonit_tweet = site.data.languages[website.lang].work_tweet %}

--- a/_includes/row-title.html
+++ b/_includes/row-title.html
@@ -1,5 +1,9 @@
 {%- assign website = include.website -%}
+{%- if website contains "categories" -%}
+{%- assign img_path = '/img/multi/' | append: website.img -%}
+{%- else -%}
 {%- assign img_path = '/img/' | append: include.section | append: '/' | append: website.img -%}
+{%- endif -%}
 <div class="title">
   <div class="keywords" style="display:none;">{{ website.name }}&nbsp;{{ website.url }}</div>
   <noscript>


### PR DESCRIPTION
This Pull Request is a first try on solving #3707.

To create an entry, that is supposed to be listed in multiple categories, those are NOT to be listed in their respective categories but in the new file `multi.yml`. Subsequently, their images/logos are also to be places in the directory `img/multi`.

As I said in https://github.com/2factorauth/twofactorauth/issues/3707#issuecomment-484370254, those three entries shall be listed in Domains _and_ Hosting/VPS, so the multi.yml would look like this:

```websites:
    - name: Rackspace
      url: https://www.rackspace.com/
      img: rackspace.png
      tfa: Yes
      sms: Yes
      doc: https://support.rackspace.com/how-to/myrackspace-multi-factor-authentication/
      categories:
        - hosting
        - domains

    - name: UpCloud
      url: https://www.upcloud.com
      img: upcloud.png
      tfa: Yes
      software: Yes
      exceptions:
          text: "SMS is required for password recovery."
      doc: https://www.upcloud.com/support/two-factor-authentication/
      categories:
        - hosting
        - domains

    - name: VentraIP
      url: https://ventraip.com.au/
      img: ventraip.png
      tfa: Yes
      software: Yes
      sms: Yes
      email: Yes
      doc: https://ventraip.com.au/faq/article/two-factor-authentication-faq-vipcontrol/
      categories:
        - hosting
        - domains
```

See how this works here: http://2fa.poppe.work:4001.

Comments are very welcome!

// Kai