### PR TITLE
Fix dead link for Commonwealth Bank of Australia

### DIFF
--- a/_data/banking.yml
+++ b/_data/banking.yml
@@ -312,7 +312,7 @@ websites:
       tfa: Yes
       sms: Yes
       hardware: Yes
-      doc: https://www.commbank.com.au/support.digital-banking.explain-netcode-token.html
+      doc: https://www.commbank.com.au/support/security/netcode.html
 
     - name: Community America Credit Union
       url: https://www.communityamerica.com/


### PR DESCRIPTION
Previous one was redirecting to an unrelated Lenders Mortgage Insurance page.