### PR TITLE
Remove Allegro software TFA

### DIFF
--- a/_data/retail.yml
+++ b/_data/retail.yml
@@ -23,8 +23,7 @@ websites:
     img: allegro.png
     tfa:
       - sms
-      - software
-    doc: https://allegro.pl/pomoc/faq/dwustopniowe-logowanie-faq-oGgdkGDqXCq
+    doc: https://allegro.pl/pomoc/dla-kupujacych/logowanie-i-haslo/dwustopniowe-logowanie-najczesciej-zadawane-pytania-dykqg9nMKSZ
 
   - name: Amazon
     url: https://www.amazon.com


### PR DESCRIPTION
Allegro does not support software 2FA anymore, their support page only mentions SMS tokens and there is no option to configure software tokens: https://allegro.pl/pomoc/dla-kupujacych/logowanie-i-haslo/dwustopniowe-logowanie-najczesciej-zadawane-pytania-dykqg9nMKSZ

I also updated the link.