### PR TITLE
Update WSL/Ubuntu requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,7 @@ bundle exec jekyll serve
 If you're using Ubuntu or [Bash on Windows (WSL)](https://docs.microsoft.com/en-us/windows/wsl/install-win10) you'll probably need to install these dependencies first:
 
 ```shell
-sudo apt install libffi-dev nodejs python-dev gcc ruby rails make zlib1g-dev ruby-dev libcurl3
-gem install bundler
+sudo apt install build-essential ruby-bundler ruby-dev make gcc g++ zlib1g-dev
 ```
 
 The TwoFactorAuth website should then be accessible from `http://localhost:4000`.


### PR DESCRIPTION
Looks like more tools are available by default and thus only the following packages need to be installed for jekyll to work.

Tested on clean versions of Ubuntu 18.04 LTS (WSL & VM)