### PR TITLE
Typo correction in CONTRIBUTING.MD

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -189,7 +189,7 @@ website.
       img: site.png
       tfa:
         - sms
-      exceptions: "Specific text goes here."
+      exception: "Specific text goes here."
       doc: <link to site TFA documentation>
    ```
 


### PR DESCRIPTION
When API v2 was created with #4090, website_schema.yml was changed from `exceptions:` to `exception:`, the entry in CONTRIBUTING.MD was overlooked.