### PR TITLE
Add Vodafone (DE)

### DIFF
--- a/_data/utilities.yml
+++ b/_data/utilities.yml
@@ -394,7 +394,7 @@ websites:
 
   - name: Vodafone (DE)
     url: https://www.vodafone.de/
-    twitter: vodafone_de
+    twitter: vodafoneservice
     facebook: vodafoneDE
     img: vodafone.png
     lang: de

--- a/_data/utilities.yml
+++ b/_data/utilities.yml
@@ -392,6 +392,13 @@ websites:
     facebook: virgin
     img: virginmobile.png
 
+  - name: Vodafone (DE)
+    url: https://www.vodafone.de/
+    twitter: vodafone_de
+    facebook: vodafoneDE
+    img: vodafone.png
+    lang: de
+
   - name: Vodafone (IE)
     url: https://www.vodafone.ie/
     twitter: VodafoneIreland


### PR DESCRIPTION
Similar to other Vodafone entries, does not offer 2FA options in Germany either.