### PR TITLE
Update HSBC

### DIFF
--- a/_data/banking.yml
+++ b/_data/banking.yml
@@ -507,10 +507,9 @@ websites:
     url: https://www.hsbc.com/
     img: hsbc.png
     tfa:
-      - software
+      - proprietary
       - hardware
-    doc: https://www.hsbc.co.uk/1/2/customer-support/online-banking-security/secure-key
-    exception: "Software 2FA requires HSBC app."
+    doc: https://www.hsbc.com/online-security
 
   - name: Huntington National Bank
     url: https://www.huntington.com

--- a/_data/banking.yml
+++ b/_data/banking.yml
@@ -509,7 +509,7 @@ websites:
     tfa:
       - proprietary
       - hardware
-    doc: https://www.hsbc.com/online-security
+    doc: https://www.hsbc.co.uk/help/security-centre/secure-key/secure-key-help/
 
   - name: Huntington National Bank
     url: https://www.huntington.com


### PR DESCRIPTION
Fixes #2926
Fixes #3872

Digital and Physical Secure Key are prevalent 2FA methods.
I checked AU, FR, HK, UK and US web pages.