### PR TITLE
Reference TinyPNG instead of OptiPNG

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,8 +17,8 @@ are stored in folders corresponding to each of those categories in their own
    If you want to test locally, instructions are listed below. Keep reading!
 2. **Use a Nice Icon**: The icon must have a resolution of 32x32. PNG is the
    preferred format. If possible, please also run the image through an optimizing
-   utility such as OptiPNG before committing it to the repo and keep the file
-   to be under 2.5 kB.
+   utility such as [TinyPNG][tinypng] before committing it to the repo and keep
+   the file to be under 2.5 kB.
 3. **HTTPS links**: All sites that support HTTPS should also be linked with an
    HTTPS address.
 4. **Alexa top 200K**: A new site, that is not already listed, has to be within the
@@ -238,3 +238,4 @@ For context, check out the discussion in issue [#242][242].
 [alexa]: https://www.alexa.com/siteinfo
 [github-tutorial]: https://help.github.com/articles/creating-and-deleting-branches-within-your-repository/
 [do-tutorial]: https://www.digitalocean.com/community/tutorials/how-to-use-git-branches
+[tinypng]: https://tinypng.com/


### PR DESCRIPTION
1. The Wiki mentions it as well.
2. TinyPNG yields smaller icons with similar quality.