### PR TITLE
Change "Email" icon

### DIFF
--- a/_data/sections.yml
+++ b/_data/sections.yml
@@ -36,7 +36,7 @@
 
 - id: email
   title: Email
-  icon: mail
+  icon: at
 
 - id: entertainment
   title: Entertainment


### PR DESCRIPTION
The @ symbol is one of the most recognizable icons in the world and should therefore be used for the "Email" category.
This also frees up the envelope icon for other (future) uses, e.g. postal delivery services.