### PR TITLE
Add Hebrew language support

### DIFF
--- a/_data/languages.yml
+++ b/_data/languages.yml
@@ -12,6 +12,9 @@ en:
 fr:
   progress_tweet: Merci d'avoir commencé à mettre en place un système de double authentification (2FA), @TWITTERHANDLE!
   work_tweet: La sécurité est importante @TWITTERHANDLE. C'est pour quand la double authentification (2FA)?
+he:
+  progress_tweet: תודה שהתחלתם לעבוד על תמיכה באימות דו-שלבי, @TWITTERHANDLE!
+  work_tweet: אבטחת מידע היא דבר חשוב, @TWITTERHANDLE. מתי תתמכו באימות דו-שלבי?
 it:
   progress_tweet: Grazie per l'interesse nel supportare l'autenticazione a due fattori (2FA), @TWITTERHANDLE!
   work_tweet: La sicurezza è importante, @TWITTERHANDLE. Ci piacerebbe che supportaste l'autenticazione a due fattori (2FA).


### PR DESCRIPTION
Hebrew language support is a requirement for adding Israeli banks, which I plan to do once this is merged.