### PR TITLE
Add Semantic-ui website for icon usage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,6 +96,7 @@ and follow the template below:
   title: Category Name
   icon: icon-class
 ```
+The `icon-class` value needs to be chosen from [Semantic-Ui][semantic-ui]https://semantic-ui.com/elements/icon.html.
 
 Then create a new file in the `_data` directory with the same name as your section's
 id, using the `.yml` extension.
@@ -239,3 +240,4 @@ For context, check out the discussion in issue [#242][242].
 [github-tutorial]: https://help.github.com/articles/creating-and-deleting-branches-within-your-repository/
 [do-tutorial]: https://www.digitalocean.com/community/tutorials/how-to-use-git-branches
 [tinypng]: https://tinypng.com/
+[semantic-ui]: https://semantic-ui.com/elements/icon.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,7 @@ and follow the template below:
   title: Category Name
   icon: icon-class
 ```
-The `icon-class` value needs to be chosen from [Semantic-Ui][semantic-ui]https://semantic-ui.com/elements/icon.html.
+The `icon-class` value needs to be chosen from [Semantic-Ui][semantic-ui].
 
 Then create a new file in the `_data` directory with the same name as your section's
 id, using the `.yml` extension.


### PR DESCRIPTION
This will add the semantic-ui website under the "New Categories"  section for the proper naming convention to be used for the `icon-class`.