### PR TITLE
Update site alphabetical error message

### DIFF
--- a/verify.rb
+++ b/verify.rb
@@ -93,7 +93,7 @@ begin
 
     # Check section alphabetization
     if websites != (sites_sort = websites.sort_by { |s| s['name'].downcase })
-      error(websites['name']" in _data/#{section['id']}.yml is not correctly ordered by alphabetical name. Correct order:" \
+      error("websites['name'] in _data/#{section['id']}.yml is not correctly ordered by alphabetical name. Correct order:" \
         "\n" + Diffy::Diff.new(websites.to_yaml, sites_sort.to_yaml, \
                                context: 10).to_s(:color))
     end

--- a/verify.rb
+++ b/verify.rb
@@ -93,7 +93,7 @@ begin
 
     # Check section alphabetization
     if websites != (sites_sort = websites.sort_by { |s| s['name'].downcase })
-      error("_data/#{section['id']}.yml is not ordered alphabetically by name. Correct order:" \
+      error("_data/#{section['id']}.yml is not alphabetical. Correct order:" \
         "\n" + Diffy::Diff.new(websites.to_yaml, sites_sort.to_yaml, \
                                context: 10).to_s(:color))
     end

--- a/verify.rb
+++ b/verify.rb
@@ -93,7 +93,7 @@ begin
 
     # Check section alphabetization
     if websites != (sites_sort = websites.sort_by { |s| s['name'].downcase })
-      error("websites['name'] in _data/#{section['id']}.yml is not ordered alphabetically." \
+      error("_data/#{section['id']}.yml is not ordered alphabetically by name. Correct order:" \
         "\n" + Diffy::Diff.new(websites.to_yaml, sites_sort.to_yaml, \
                                context: 10).to_s(:color))
     end

--- a/verify.rb
+++ b/verify.rb
@@ -93,7 +93,7 @@ begin
 
     # Check section alphabetization
     if websites != (sites_sort = websites.sort_by { |s| s['name'].downcase })
-      error("_data/#{section['id']}.yml not ordered by name. Correct order:" \
+      error(websites['name']" in _data/#{section['id']}.yml is not correctly ordered by alphabetical name. Correct order:" \
         "\n" + Diffy::Diff.new(websites.to_yaml, sites_sort.to_yaml, \
                                context: 10).to_s(:color))
     end

--- a/verify.rb
+++ b/verify.rb
@@ -93,7 +93,7 @@ begin
 
     # Check section alphabetization
     if websites != (sites_sort = websites.sort_by { |s| s['name'].downcase })
-      error("websites['name'] in _data/#{section['id']}.yml is not ordered alphabetically. Correct order:" \
+      error("websites['name'] in _data/#{section['id']}.yml is not ordered alphabetically." \
         "\n" + Diffy::Diff.new(websites.to_yaml, sites_sort.to_yaml, \
                                context: 10).to_s(:color))
     end

--- a/verify.rb
+++ b/verify.rb
@@ -93,7 +93,7 @@ begin
 
     # Check section alphabetization
     if websites != (sites_sort = websites.sort_by { |s| s['name'].downcase })
-      error("websites['name'] in _data/#{section['id']}.yml is not correctly ordered by alphabetical name. Correct order:" \
+      error("websites['name'] in _data/#{section['id']}.yml is not ordered alphabetically. Correct order:" \
         "\n" + Diffy::Diff.new(websites.to_yaml, sites_sort.to_yaml, \
                                context: 10).to_s(:color))
     end


### PR DESCRIPTION
Update error message for sites not in correct alphabetical order to better display the actual error in helping diagnose failure.

Example #4276

https://github.com/2factorauth/twofactorauth/runs/292677087
https://github.com/2factorauth/twofactorauth/commit/9f21a16ed2857d242a462410b831d889134b514c