### PR TITLE
Call to Action email: Adding body proposal

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,7 @@
 
 source 'https://rubygems.org'
 
-# Dependencies are bundled with the github-pages gem
-gem 'github-pages', group: :jekyll_plugins
+gem 'jekyll', group: :jekyll_plugins
 
 group :test do
   gem 'diff-lcs', platforms: :mswin

--- a/_includes/desktop-table.html
+++ b/_includes/desktop-table.html
@@ -96,7 +96,7 @@
           {% if website.twitter or website.facebook or website.email_address %}<span>{{page.link}} </span>{% endif %}
           {% if website.twitter %} <a class="ui twitter mini button" href="https://twitter.com/share?url={{site.url|cgi_escape}}&amp;text={{workonit_tweet|replace:'TWITTERHANDLE',website.twitter|cgi_escape}}&amp;hashtags={{page.hash|cgi_escape}}" target="_blank"><i class="twitter icon"></i> on Twitter</a>{% endif %}
           {% if website.facebook %} <a class="ui facebook mini button" href="https://facebook.com/{{website.facebook}}/" target="_blank"><i class="facebook icon"></i> on Facebook</a>{%endif%}
-          {% if website.email_address %} <a class="ui green mini button" href="mailto:{{website.email_address}}?subject={{email_subject|uri_escape}}" target="_blank"><i class="mail icon"></i> via Email</a>{% endif %}
+          {% if website.email_address %} <a class="ui green mini button" href="mailto:{{website.email_address}}?subject={{email_subject|uri_escape}}&body={{workonit_tweet|replace:'@TWITTERHANDLE',website.name|uri_escape}}" target="_blank"><i class="mail icon"></i> via Email</a>{% endif %}
         </td>
       {% endif %}
     </tr>

--- a/_includes/desktop-table.html
+++ b/_includes/desktop-table.html
@@ -96,7 +96,7 @@
           {% if website.twitter or website.facebook or website.email_address %}<span>{{page.link}} </span>{% endif %}
           {% if website.twitter %} <a class="ui twitter mini button" href="https://twitter.com/share?url={{site.url|cgi_escape}}&amp;text={{workonit_tweet|replace:'TWITTERHANDLE',website.twitter|cgi_escape}}&amp;hashtags={{page.hash|cgi_escape}}" target="_blank"><i class="twitter icon"></i> on Twitter</a>{% endif %}
           {% if website.facebook %} <a class="ui facebook mini button" href="https://facebook.com/{{website.facebook}}/" target="_blank"><i class="facebook icon"></i> on Facebook</a>{%endif%}
-          {% if website.email_address %} <a class="ui green mini button" href="mailto:{{website.email_address}}?subject={{email_subject|uri_escape}}&amp;body={{workonit_tweet|replace:'@TWITTERHANDLE',website.name|uri_escape}}" target="_blank"><i class="mail icon"></i> via Email</a>{% endif %}
+          {% if website.email_address %} <a class="ui green mini button" href="mailto:{{website.email_address}}?subject={{email_subject|url_encode_mail}}&amp;body={{workonit_tweet|replace:'@TWITTERHANDLE',website.name|url_encode_mail}}" target="_blank"><i class="mail icon"></i> via Email</a>{% endif %}
         </td>
       {% endif %}
     </tr>

--- a/_includes/desktop-table.html
+++ b/_includes/desktop-table.html
@@ -96,7 +96,7 @@
           {% if website.twitter or website.facebook or website.email_address %}<span>{{page.link}} </span>{% endif %}
           {% if website.twitter %} <a class="ui twitter mini button" href="https://twitter.com/share?url={{site.url|cgi_escape}}&amp;text={{workonit_tweet|replace:'TWITTERHANDLE',website.twitter|cgi_escape}}&amp;hashtags={{page.hash|cgi_escape}}" target="_blank"><i class="twitter icon"></i> on Twitter</a>{% endif %}
           {% if website.facebook %} <a class="ui facebook mini button" href="https://facebook.com/{{website.facebook}}/" target="_blank"><i class="facebook icon"></i> on Facebook</a>{%endif%}
-          {% if website.email_address %} <a class="ui green mini button" href="mailto:{{website.email_address}}?subject={{email_subject|uri_escape}}&body={{workonit_tweet|replace:'@TWITTERHANDLE',website.name|uri_escape}}" target="_blank"><i class="mail icon"></i> via Email</a>{% endif %}
+          {% if website.email_address %} <a class="ui green mini button" href="mailto:{{website.email_address}}?subject={{email_subject|uri_escape}}&amp;body={{workonit_tweet|replace:'@TWITTERHANDLE',website.name|uri_escape}}" target="_blank"><i class="mail icon"></i> via Email</a>{% endif %}
         </td>
       {% endif %}
     </tr>

--- a/_includes/mobile-table.html
+++ b/_includes/mobile-table.html
@@ -59,7 +59,7 @@
       <div class="button-group">
         {% if website.twitter %} <a class="ui twitter mini button" alt="Twitter" href="https://twitter.com/share?url={{site.url|cgi_escape}}&amp;text={{workonit_tweet|replace:'TWITTERHANDLE',website.twitter|cgi_escape}}&amp;hashtags={{page.hash|cgi_escape}}" target="_blank"><i class="twitter icon"></i></a>{% endif %}
         {% if website.facebook %} <a class="ui facebook mini button" alt="Facebook" href="https://facebook.com/{{website.facebook}}/" target="_blank"><i class="facebook icon"></i></a>{%endif%}
-        {% if website.email_address %} <a class="ui green mini button" alt="Email" href="mailto:{{website.email_address}}?subject={{email_subject|uri_escape}}&body={{workonit_tweet|replace:'@TWITTERHANDLE',website.name|uri_escape}}" target="_blank"><i class="mail icon"></i></a>{% endif %}
+        {% if website.email_address %} <a class="ui green mini button" alt="Email" href="mailto:{{website.email_address}}?subject={{email_subject|uri_escape}}&amp;body={{workonit_tweet|replace:'@TWITTERHANDLE',website.name|uri_escape}}" target="_blank"><i class="mail icon"></i></a>{% endif %}
       </div>
     </div>
     {% endif %}

--- a/_includes/mobile-table.html
+++ b/_includes/mobile-table.html
@@ -59,7 +59,7 @@
       <div class="button-group">
         {% if website.twitter %} <a class="ui twitter mini button" alt="Twitter" href="https://twitter.com/share?url={{site.url|cgi_escape}}&amp;text={{workonit_tweet|replace:'TWITTERHANDLE',website.twitter|cgi_escape}}&amp;hashtags={{page.hash|cgi_escape}}" target="_blank"><i class="twitter icon"></i></a>{% endif %}
         {% if website.facebook %} <a class="ui facebook mini button" alt="Facebook" href="https://facebook.com/{{website.facebook}}/" target="_blank"><i class="facebook icon"></i></a>{%endif%}
-        {% if website.email_address %} <a class="ui green mini button" alt="Email" href="mailto:{{website.email_address}}?subject={{email_subject|uri_escape}}" target="_blank"><i class="mail icon"></i></a>{% endif %}
+        {% if website.email_address %} <a class="ui green mini button" alt="Email" href="mailto:{{website.email_address}}?subject={{email_subject|uri_escape}}&body={{workonit_tweet|replace:'@TWITTERHANDLE',website.name|uri_escape}}" target="_blank"><i class="mail icon"></i></a>{% endif %}
       </div>
     </div>
     {% endif %}

--- a/_includes/mobile-table.html
+++ b/_includes/mobile-table.html
@@ -59,7 +59,7 @@
       <div class="button-group">
         {% if website.twitter %} <a class="ui twitter mini button" alt="Twitter" href="https://twitter.com/share?url={{site.url|cgi_escape}}&amp;text={{workonit_tweet|replace:'TWITTERHANDLE',website.twitter|cgi_escape}}&amp;hashtags={{page.hash|cgi_escape}}" target="_blank"><i class="twitter icon"></i></a>{% endif %}
         {% if website.facebook %} <a class="ui facebook mini button" alt="Facebook" href="https://facebook.com/{{website.facebook}}/" target="_blank"><i class="facebook icon"></i></a>{%endif%}
-        {% if website.email_address %} <a class="ui green mini button" alt="Email" href="mailto:{{website.email_address}}?subject={{email_subject|uri_escape}}&amp;body={{workonit_tweet|replace:'@TWITTERHANDLE',website.name|uri_escape}}" target="_blank"><i class="mail icon"></i></a>{% endif %}
+        {% if website.email_address %} <a class="ui green mini button" alt="Email" href="mailto:{{website.email_address}}?subject={{email_subject|url_encode_mail}}&amp;body={{workonit_tweet|replace:'@TWITTERHANDLE',website.name|url_encode_mail}}" target="_blank"><i class="mail icon"></i></a>{% endif %}
       </div>
     </div>
     {% endif %}

--- a/_plugins/URLEncoding.rb
+++ b/_plugins/URLEncoding.rb
@@ -1,0 +1,13 @@
+# _plugins/URLEncoding.rb
+require 'liquid'
+require 'uri'
+
+# Percent encoding for URI conforming to RFC 3986.
+# Ref: http://tools.ietf.org/html/rfc3986#page-12
+module URLEncoding
+  def url_encode_mail(url)
+    return URI.escape(url, Regexp.new("[^#{URI::PATTERN::UNRESERVED}]")).gsub("\'", "%27").gsub("+", "%20")
+  end
+end
+
+Liquid::Template.register_filter(URLEncoding)


### PR DESCRIPTION
After the email subject was made translatable in #4261, this adds the call-to-action-tweet-text as the email body when clicking on the link.