### PR TITLE
Change Betting icon

### DIFF
--- a/_data/sections.yml
+++ b/_data/sections.yml
@@ -8,7 +8,7 @@
 
 - id: betting
   title: Betting
-  icon: bullseye
+  icon: trophy
 
 - id: cloud
   title: Cloud Computing


### PR DESCRIPTION
The "bullseye" icon is hardly recognizable as such.
Since betting is mainly sports-related, the "trophy" icon fits better.