### PR TITLE
Update Halifax show 2FA methods used

### DIFF
--- a/_data/banking.yml
+++ b/_data/banking.yml
@@ -512,9 +512,12 @@ websites:
 
   - name: Halifax
     url: https://www.halifax.co.uk
-    twitter: AskHalifaxBank
-    facebook: halifax
     img: halifax.png
+    tfa:
+      - proprietary
+      - phone
+      - sms
+    doc: https://www.halifax.co.uk/aboutonline/changes-to-online-banking/
 
   - name: Handelsbanken
     url: https://www.handelsbanken.se/
@@ -609,7 +612,7 @@ websites:
     facebook: labanquepostale
     img: labanquepostale.png
     lang: fr
-    
+
   - name: Lake Michigan Credit Union
     url: https://www.lmcu.org/
     img: lakemichigancreditunion.png

--- a/_data/banking.yml
+++ b/_data/banking.yml
@@ -612,7 +612,7 @@ websites:
     facebook: labanquepostale
     img: labanquepostale.png
     lang: fr
-
+    
   - name: Lake Michigan Credit Union
     url: https://www.lmcu.org/
     img: lakemichigancreditunion.png


### PR DESCRIPTION
As referenced in PR #4473 this updates Halifax to show that they support proprietary (app), phone & SMS options - the same as Bank of Scotland