### PR TITLE
Update Lloyds Bank to show 2FA methods used 

### DIFF
--- a/_data/banking.yml
+++ b/_data/banking.yml
@@ -640,9 +640,12 @@ websites:
 
   - name: Lloyds Bank
     url: https://www.lloydsbank.com/
-    twitter: AskLloydsBank
-    facebook: lloydsbank
     img: lloydsbank.png
+    tfa:
+      - proprietary
+      - phone
+      - sms
+    doc: https://www.lloydsbank.com/online-banking/changes-to-internet-banking.asp
 
   - name: Länsförsäkringar
     url: https://www.lansforsakringar.se/


### PR DESCRIPTION
As referenced in PR #4473 this updates Lloyds Bank to show that they support proprietary (app), phone & SMS options - the same as Bank of Scotland