### PR TITLE
Fix bundler cache & speed up html-proofer

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -9,18 +9,18 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
-    - name: Get Cache
-      id: cache
-      uses: actions/cache@v1
+    - uses: actions/cache@v1
       with:
         path: vendor/bundle
-        key: ${{ runner.os }}-bundler
+        key: ${{ runner.os }}-bundle
+        restore-keys: ${{ runner.os }}-bundle
 
-    - name: Install requirements
-      run: sudo snap install ruby --classic
-
-    - name: Run Bundler
-      run: bundle install --path vendor/bundle
+    - name: Install dependencies
+      run: |
+         sudo snap install ruby --classic
+         bundle config set path 'vendor/bundle'
+         bundle config set cache_all true
+         bundle install --jobs 4 --retry 3
 
     - name: Build site
       run: bundle exec jekyll build
@@ -29,10 +29,10 @@ jobs:
     - name: Run build checks
       run: bundle exec rake verify
 
+    - name: Test JSON files
+      run: bundle exec rake jsonlint
+
     - name: Test HTML files
       run: bundle exec rake proof
       env:
         NOKOGIRI_USE_SYSTEM_LIBRARIES: true
-
-    - name: Test JSON files
-      run: bundle exec rake jsonlint

--- a/Rakefile
+++ b/Rakefile
@@ -18,11 +18,11 @@ end
 
 task :proof do
   HTMLProofer.check_directory(
-    './_site', \
-    assume_extension: true, \
-    check_html: true, \
-    disable_external: true, \
-    cache: { timeframe: '2d', storage_dir: '/tmp/html-proofer' }
+    './_site',
+    assume_extension: true,
+    check_html: true,
+    disable_external: true,
+    parallel: { in_threads: 5 }
   ).run
 end
 


### PR DESCRIPTION
In this PR I've:
* Sped up the bundler dependency installation
* Fixed the bundler gem cache
* Made html-proofer use 5 threads instead of 1 (~5s improvement)
* Moved html-proofer to the end of the script to make it more likely that the other parts of the script finds the error in a bad build and therefore fails the build faster.

html-proofer takes up the majority of the time for our PR checks to run and I can't find any reason for it to be this slow. We might need to search for a replacement in the future.