### PR TITLE
Add Tutanota exception

### DIFF
--- a/_data/email.yml
+++ b/_data/email.yml
@@ -213,6 +213,7 @@ websites:
       - totp
       - hardware
     doc: https://tutanota.com/howto/#2fa
+    exception: "Hardware 2FA not supported for the desktop & mobile apps."
 
   - name: Virgin Media E-Mail
     url: https://www.virginmedia.com/

--- a/_data/email.yml
+++ b/_data/email.yml
@@ -211,7 +211,7 @@ websites:
     img: tutanota.png
     tfa:
       - totp
-      - hardware
+      - u2f
     doc: https://tutanota.com/howto/#2fa
     exception: "Hardware 2FA not yet supported for their desktop & mobile apps."
 

--- a/_data/email.yml
+++ b/_data/email.yml
@@ -213,7 +213,7 @@ websites:
       - totp
       - hardware
     doc: https://tutanota.com/howto/#2fa
-    exception: "Hardware 2FA not supported for the desktop & mobile apps."
+    exception: "Hardware 2FA not yet supported for their desktop & mobile apps."
 
   - name: Virgin Media E-Mail
     url: https://www.virginmedia.com/


### PR DESCRIPTION
Tutanota doesn't currently support U2F through their desktop or mobile apps. It is only supported when logging in through a browser. [According to Tutanota,](https://www.reddit.com/r/tutanota/comments/e5dti7/u2f_on_linux_app_security_key_not_registered_for/) support for this is coming "soon" as of a month ago. Since it's on their roadmap, I included "yet" in the exception language to differentiate them from companies who have not indicated eventual support.

Closes out #4515.

