### PR TITLE
Update Twitter

### DIFF
--- a/_data/social.yml
+++ b/_data/social.yml
@@ -253,7 +253,7 @@ websites:
       - software
       - hardware
     doc: https://support.twitter.com/articles/20170388
-    exception: "Mobile apps do not support Hardware 2FA. Cannot add multiple security keys. SMS only available on select providers."
+    exception: "Mobile apps do not support Hardware 2FA. Hardware 2FA requires enabling back-up method. Cannot add multiple security keys. SMS only available on select providers."
 
   - name: VanillaForums.com
     url: https://vanillaforums.com

--- a/_data/social.yml
+++ b/_data/social.yml
@@ -253,7 +253,7 @@ websites:
       - software
       - hardware
     doc: https://support.twitter.com/articles/20170388
-    exception: "SMS only available on select providers."
+    exception: "Mobile apps do not support Hardware 2FA. Cannot add multiple security keys. SMS only available on select providers."
 
   - name: VanillaForums.com
     url: https://vanillaforums.com


### PR DESCRIPTION
- Cannot add more than one security key
- Mobile apps do not support hardware keys