### PR TITLE
Update 500px

### DIFF
--- a/_data/social.yml
+++ b/_data/social.yml
@@ -1,12 +1,9 @@
 websites:
   - name: 500px
     url: https://500px.com/
+    twitter: 500px
+    facebook: 500px
     img: 500px.png
-    tfa:
-      - sms
-      - totp
-    doc: https://support.500px.com/hc/en-us/articles/205115877
-    exception: "A verified phone number is required for the use of two-factor authentication software."
 
   - name: about.me
     url: https://about.me

--- a/_data/social.yml
+++ b/_data/social.yml
@@ -1,6 +1,6 @@
 websites:
   - name: 500px
-    url: https://500px.com/
+    url: https://web.500px.com/
     twitter: 500px
     facebook: 500px
     img: 500px.png


### PR DESCRIPTION
The TOTP code is currently not used for login purposes, but only for authorisation, as outlined in the doc:
> You can enable two factor authentication on your account, to keep your payment and password settings extra secure.

(checked this myself)