### PR TITLE
Add totp for Gusto

### DIFF
--- a/_data/finance.yml
+++ b/_data/finance.yml
@@ -140,6 +140,7 @@ websites:
     img: gusto.png
     tfa:
       - sms
+      - totp
     doc: https://support.gusto.com/1066223171
 
   - name: H&R Block


### PR DESCRIPTION
Gusto's initial 2FA support was text message only, but they've since added standard authenticator app support. This change updates the definition to include that.