### PR TITLE
Update Twilio

### DIFF
--- a/_data/developer.yml
+++ b/_data/developer.yml
@@ -563,7 +563,7 @@ websites:
       - sms
       - phone
       - proprietary
-    doc: https://support.twilio.com/hc/en-us/articles/223136307-Enabling-two-factor-authentication-on-your-Twilio-project
+    doc: https://support.twilio.com/hc/en-us/articles/223136307
 
   - name: Unfuddle
     url: https://unfuddle.com/

--- a/_data/developer.yml
+++ b/_data/developer.yml
@@ -564,7 +564,6 @@ websites:
       - phone
       - proprietary
     doc: https://support.twilio.com/hc/en-us/articles/223136307-Enabling-two-factor-authentication-on-your-Twilio-project
-    exception: Software authentication requires the Authy app.
 
   - name: Unfuddle
     url: https://unfuddle.com/

--- a/_data/developer.yml
+++ b/_data/developer.yml
@@ -562,7 +562,7 @@ websites:
     tfa:
       - sms
       - phone
-      - software
+      - proprietary
     doc: https://support.twilio.com/hc/en-us/articles/223136307-Enabling-two-factor-authentication-on-your-Twilio-project
     exception: Software authentication requires the Authy app.
 

--- a/_data/developer.yml
+++ b/_data/developer.yml
@@ -561,7 +561,10 @@ websites:
     img: twilio.png
     tfa:
       - sms
-    doc: https://www.twilio.com/help/faq/twilio-basics/what-happens-when-i-enable-two-factor-authentication
+      - phone
+      - software
+    doc: https://support.twilio.com/hc/en-us/articles/223136307-Enabling-two-factor-authentication-on-your-Twilio-project
+    exception: Software authentication requires the Authy app.
 
   - name: Unfuddle
     url: https://unfuddle.com/


### PR DESCRIPTION
Updated Twilio 2FA methods and its documentation. Twilio supports 2FA over phone calls, sms, and the Authy app.

https://support.twilio.com/hc/en-us/articles/223136307-Enabling-two-factor-authentication-on-your-Twilio-project