### PR TITLE
Add Alexa cache & Clean up all test scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,9 +9,7 @@ jobs:
 
       - run:
           name: Check Twitter handles
-          command: |
-            gem i twitter --no-post-install-message --no-suggestions --minimal-deps --no-verbose -N -q
-            bash twitter.sh
+          command: bash twitter.sh
           working_directory: ./.tests
 
       - run:
@@ -19,10 +17,19 @@ jobs:
          command: bash facebook.sh
          working_directory: ./.tests
 
+      - restore_cache:
+          keys:
+            - awis-cache
+
       - run:
           name: Check Alexa ranking
           command: bash alexa.sh
           working_directory: ./.tests
+
+      - save_cache:
+          key: awis-cache
+          paths:
+            - "/tmp/alexa/*"
 
 workflows:
   version: 2

--- a/.tests/alexa.rb
+++ b/.tests/alexa.rb
@@ -20,7 +20,9 @@ if File.exist?("/tmp/alexa/#{site}.txt")
   # Prettify rank
   rank = rank_i.to_s.reverse.scan(/\d{1,3}/).join(',').reverse
 else
-  url = URI("https://awis.api.alexa.com/api?Action=UrlInfo&ResponseGroup=Rank&Output=json&Url=#{site}")
+  url = URI('https://awis.api.alexa.com/api' \
+  "?Action=UrlInfo&ResponseGroup=Rank&Output=json&Url=#{site}")
+
   https = Net::HTTP.new(url.host, url.port)
   https.use_ssl = true
 

--- a/.tests/alexa.rb
+++ b/.tests/alexa.rb
@@ -1,86 +1,57 @@
-#/usr/bin/ruby
-require "cgi"
-require "base64"
-require "openssl"
-require "uri"
-require "net/https"
-require "rexml/document"
-require "time"
+# frozen_string_literal: true
 
-access_key_id = ENV["alexa_access_key"]
-secret_access_key = ENV["alexa_access_secret"]
-#
-# Sample request to Alexa Web Information Service
-#
+require 'uri'
+require 'net/http'
+require 'json'
+require 'fileutils'
 
-if ARGV.length < 1
-  $stderr.puts "Usage: urlinfo.rb site"
+max_ranking = 200_000
+max_ranking_string = max_ranking.to_s.reverse.scan(/\d{1,3}/).join(' ').reverse
+
+if ARGV.empty?
+  warn 'Usage: alexa.rb url'
   exit(-1)
+end
+
+site = ARGV[0]
+
+if File.exist?("/tmp/alexa/#{site}.txt")
+  rank = File.open("/tmp/alexa/#{site}.txt", &:readline).delete(' ')
+  # Prettify rank
+  rank = rank.to_i.to_s.reverse.scan(/\d{1,3}/).join(' ').reverse
 else
-  site = ARGV[0]
+  url = URI("https://awis.api.alexa.com/api?Action=UrlInfo&ResponseGroup=Rank&Output=json&Url=#{site}")
+  https = Net::HTTP.new(url.host, url.port)
+  https.use_ssl = true
+
+  request = Net::HTTP::Get.new(url)
+  request['x-api-key'] = ENV['alexa_access_key']
+  request['Accept'] = 'application/json'
+  response = https.request(request)
+
+  unless response.code == '200'
+    raise("Request failed. Check URL & API key. (#{response.code})")
+  end
+
+  # Parse response
+  body = JSON.parse(response.body)
+  body = body['Awis']['Results']['Result']['Alexa']['TrafficData']
+
+  # Prettify body['Rank'] output
+  rank = body['Rank'].to_s.reverse.scan(/\d{1,3}/).join(' ').reverse
+
+  # Create cache file
+  FileUtils.mkdir_p '/tmp/alexa'
+  file = File.new("/tmp/alexa/#{site}.txt", 'w')
+  file.puts(rank)
+  file.close
 end
 
-SERVICE_HOST = "awis.amazonaws.com"
-SERVICE_ENDPOINT = "awis.us-west-1.amazonaws.com"
-SERVICE_PORT = 443
-SERVICE_URI = "/api"
-SERVICE_REGION = "us-west-1"
-SERVICE_NAME = "awis"
+# rubocop:disable Layout/LineLength
+raise("\e[31m#{site} has an Alexa ranking above #{max_ranking_string}. (Currently: #{rank})\e[0m") if max_ranking < rank.to_i
 
-def getSignatureKey(key, dateStamp, regionName, serviceName)
-  kDate    = OpenSSL::HMAC.digest('sha256', "AWS4" + key, dateStamp)
-  kRegion  = OpenSSL::HMAC.digest('sha256', kDate, regionName)
-  kService = OpenSSL::HMAC.digest('sha256', kRegion, serviceName)
-  kSigning = OpenSSL::HMAC.digest('sha256', kService, "aws4_request")
-  kSigning
-end
+raise("\e[31m#{site} doesn't have an Alexa rank. #{max_ranking_string} or less required.\e[0m") if rank.to_i.zero?
 
-# escape str to RFC 3986
-def escapeRFC3986(str)
-  return URI.escape(str,/[^A-Za-z0-9\-_.~]/)
-end
+# rubocop:enable Layout/LineLength
 
-action = "UrlInfo"
-responseGroup = "Rank,LinksInCount"
-timestamp = ( Time::now ).utc.strftime("%Y%m%dT%H%M%SZ")
-datestamp = ( Time::now ).utc.strftime("%Y%m%d")
-
-headers = {
-  "host"        => SERVICE_ENDPOINT,
-  "x-amz-date"  => timestamp
-}
-
-query = {
-  "Action"           => action,
-  "ResponseGroup"    => responseGroup,
-  "Url"              => site
-}
-
-query_str = query.sort.map{|k,v| k + "=" + escapeRFC3986(v.to_s())}.join('&')
-headers_str = headers.sort.map{|k,v| k + ":" + v}.join("\n") + "\n"
-headers_lst = headers.sort.map{|k,v| k}.join(";")
-payload_hash = Digest::SHA256.hexdigest ""
-canonical_request = "GET" + "\n" + SERVICE_URI + "\n" + query_str + "\n" + headers_str + "\n" + headers_lst + "\n" + payload_hash
-algorithm = "AWS4-HMAC-SHA256"
-credential_scope = datestamp + "/" + SERVICE_REGION + "/" + SERVICE_NAME + "/" + "aws4_request"
-string_to_sign = algorithm + "\n" +  timestamp + "\n" +  credential_scope + "\n" + (Digest::SHA256.hexdigest canonical_request)
-signing_key = getSignatureKey(secret_access_key, datestamp, SERVICE_REGION, SERVICE_NAME)
-signature=OpenSSL::HMAC.hexdigest('sha256', signing_key, string_to_sign)
-authorization_header = algorithm + " " + "Credential=" + access_key_id + "/" + credential_scope + ", " +  "SignedHeaders=" + headers_lst + ", " + "Signature=" + signature;
-
-url = "https://" + SERVICE_HOST + SERVICE_URI + "?" + query_str
-uri = URI(url)
-req = Net::HTTP::Get.new(uri)
-req["Accept"] = "application/xml"
-req["Content-Type"] = "application/xml"
-req["x-amz-date"] = timestamp
-req["Authorization"] = authorization_header
-
-res = Net::HTTP.start(uri.host, uri.port,
-  :use_ssl => uri.scheme == 'https') {|http|
-  http.request(req)
-}
-
-xml  = REXML::Document.new( res.body )
-
-REXML::XPath.each(xml,"//aws:Rank"){|el| puts el.text}
+puts("\e[32m#{site} has an Alexa ranking of #{rank}.\e[0m")

--- a/.tests/alexa.sh
+++ b/.tests/alexa.sh
@@ -1,18 +1,8 @@
 #!/bin/bash
 
-export LC_NUMERIC=en_US.UTF-8
-format_number () {
-  numfmt --grouping "$@"
-}
-
-# Max allowed Alexa ranking
-max_ranking=200000
-
-formated_max_ranking="$(format_number ${max_ranking})"
-
 # Check Alexa rank
 check_rank () {
-  urls="$(git --no-pager diff origin/master..HEAD ../_data| grep ^+[[:space:]] | grep url | cut -c11-)"
+  urls="$(git log -p origin/master..HEAD ../_data | grep "^+[[:space:]]*url: " | cut -c11-)"
 
   if [ -z "$urls" ]; then
     echo "No URLs found."
@@ -26,24 +16,7 @@ check_rank () {
     domain="$(echo ${url} | cut -d'/' -f3)"
 
     # Get Alexa rank for the domain
-    alexa_rank="$(ruby alexa.rb ${domain})"
-
-    # Format ranking with thousands separator
-    formated_rank="$(format_number ${alexa_rank})"
-
-    # Check if the site is unranked
-    if [ -z "$alexa_rank" ]; then
-      echo "::error:: ${domain} doesn't have an Alexa rank."
-      exit 1
-    fi
-
-    # Check if the rank is at or below 200K
-    if [ "$alexa_rank" -gt "$max_ranking" ]; then
-      echo "::error:: ${domain} has an Alexa ranking above ${formated_max_ranking}. (${formated_rank})"
-      exit 1
-    else
-      echo "${domain} has an Alexa ranking of ${formated_rank}."
-    fi
+    echo "$(ruby alexa.rb ${domain})"
 
   done
 }

--- a/.tests/facebook.sh
+++ b/.tests/facebook.sh
@@ -2,7 +2,7 @@
 
 # Check Facebook handle
 check_facebook () {
-  handles="$(git --no-pager diff origin/master..HEAD ../_data | grep ^+[[:space:]] | grep facebook | cut -c16-)"
+  handles="$(git log -p origin/master..HEAD ../_data | grep ^+[[:space:]] | grep facebook | cut -c16-)"
 
   if [ -z "$handles" ]; then
     echo "No Facebook handles found."

--- a/.tests/twitter.sh
+++ b/.tests/twitter.sh
@@ -2,12 +2,14 @@
 
 # Check Twitter handle
 check_twitter () {
-	handles="$(git --no-pager diff origin/master..HEAD ../_data | grep ^+[[:space:]] | grep twitter | cut -c15-)"
+	handles="$(git log -p origin/master..HEAD ../_data | grep ^+[[:space:]] | grep twitter | cut -c15-)"
 
   if [ -z "$handles" ]; then
     echo "No Twitter handles found."
     exit 0
   fi
+
+  gem i twitter --no-post-install-message --no-suggestions --minimal-deps --no-verbose -N -q
 
   # Loop through all Twitter handles
   echo "${handles}" | while IFS= read -r handle; do


### PR DESCRIPTION
Amazon has a 10K API request per month limit on the Alexa API. We haven't reached that limit any month yet but its likely we will sometime in the future. By adding a cache for the `alexa.rb` script we can be reasonably sure that we won't reach that limit.

I also made the following changes:
* Removed `twitter.sh` as it can be merged with `twitter.rb`.
* Check git diff for Twitter handle changes before installing Twitter gem in CircleCI.
* Cleaned up `alexa.rb` and fixed Rubycop errors/warnings inside the file.
* Implemented @phallobst's suggestion on Alexa rank formatting.
* Fixed Rubocop warning in `verify.rb`.