### PR TITLE
Update Skrill

### DIFF
--- a/_data/payments.yml
+++ b/_data/payments.yml
@@ -188,7 +188,8 @@ websites:
     tfa:
       - email
       - sms
-    doc: http://www.skrill.com/en/support/#/path/905761532
+    doc: https://www.skrill.com/en/support#/path/SECURITY/1362150272/
+    exception: "Email method requires an additional PIN"
 
   - name: Square
     url: https://squareup.com

--- a/_data/payments.yml
+++ b/_data/payments.yml
@@ -186,9 +186,9 @@ websites:
     url: https://skrill.com/
     img: skrill.png
     tfa:
-      - totp
-      - hardware
-    doc: https://www.skrill.com/en/support#/path/ACCOUNT/Two-Factor-Authentication/905761532
+      - email
+      - sms
+    doc: http://www.skrill.com/en/support/#/path/905761532
 
   - name: Square
     url: https://squareup.com


### PR DESCRIPTION
Today I just noticed that Skrill has removed the ability to use both software and hardware tokens. When you login to your account, you'll be asked to setup and verify a mobile phone number and/or an email address. The 2FA section is no longer available and was replaced by the "Authentication methods" section, which has those two options.

<img width="869" alt="Screen Shot 2020-03-09 at 11 30 04" src="https://user-images.githubusercontent.com/17606465/76222833-e54cfb80-61f9-11ea-87c4-00cc9f1bcd8b.png">

As soon as you setup any of those methods, the previous 2FA method is completely disabled. The new login page looks as follows:

<img width="614" alt="Screen Shot 2020-03-09 at 11 30 29" src="https://user-images.githubusercontent.com/17606465/76223016-001f7000-61fa-11ea-8e38-f34c81226a45.png">

They confirmed this a couple weeks ago through their [Twitter account](https://twitter.com/skrill/status/1228706850868211715): "Hello! Unfortunately, the 2FA is no longer a valid additional authentication option in Skrill. You can learn more about it from here: http://www.skrill.com/en/support/#/path/1362150272"

Not a good move if you ask me.

I've added an exception because email authentication requires an additional PIN, not sure this is considered an exception or not.