### PR TITLE
Update Ubiquiti to use correct domain

### DIFF
--- a/_data/other.yml
+++ b/_data/other.yml
@@ -505,8 +505,8 @@ websites:
     facebook: spare5app
     email_address: feedback@spare5.com
 
-  - name: Ubiquiti Networks
-    url: https://www.ubnt.com
+  - name: Ubiquiti Inc
+    url: https://www.ui.com
     img: ubiquiti.png
     tfa:
       - totp


### PR DESCRIPTION
Ubiquiti updated domain to ui.com and changed name from Ubiquiti Networks to Ubiquiti Inc