### PR TITLE
Update Amazon Web Services

### DIFF
--- a/_data/cloud.yml
+++ b/_data/cloud.yml
@@ -3,11 +3,10 @@ websites:
     url: https://aws.amazon.com
     img: aws.png
     tfa:
-      - sms
       - totp
       - hardware
       - u2f
-    doc: https://aws.amazon.com/iam/details/mfa/
+    doc: https://aws.amazon.com/iam/features/mfa/
 
   - name: appFog
     url: https://www.ctl.io/appfog/


### PR DESCRIPTION
Removed 'sms' and updated doc url for Amazon Web Services.

They're dropping support for sms: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_mfa_enable_sms.html

![Screen Shot 2020-04-24 at 09 36 30-2](https://user-images.githubusercontent.com/17606465/80213169-25800600-860f-11ea-9547-559eb2440a96.png)
