### PR TITLE
Update Yahoo Mail

### DIFF
--- a/_data/email.yml
+++ b/_data/email.yml
@@ -245,6 +245,7 @@ websites:
       - sms
       - phone
       - email
+      - proprietary
     doc: https://help.yahoo.com/kb/SLN5013.html
 
   - name: Yandex.Mail

--- a/_data/email.yml
+++ b/_data/email.yml
@@ -244,6 +244,7 @@ websites:
     tfa:
       - sms
       - phone
+      - email
     doc: https://help.yahoo.com/kb/SLN5013.html
 
   - name: Yandex.Mail

--- a/_data/email.yml
+++ b/_data/email.yml
@@ -247,6 +247,7 @@ websites:
       - email
       - proprietary
     doc: https://help.yahoo.com/kb/SLN5013.html
+    exception: "Linked phone number required for 2FA."
 
   - name: Yandex.Mail
     url: https://mail.yandex.com/


### PR DESCRIPTION
Added 'email' for Yahoo Mail

I can no longer see the 'phone' option. Can anyone confirm if it's still there? Maybe it's just related to my country code (+54).

<img width="420" alt="Screen Shot 2020-04-24 at 09 42 07" src="https://user-images.githubusercontent.com/17606465/80214838-e1dacb80-8611-11ea-9e97-8d516d63bb8e.png">
