### PR TITLE
Update GoCardless

### DIFF
--- a/_data/payments.yml
+++ b/_data/payments.yml
@@ -69,6 +69,7 @@ websites:
     url: https://gocardless.com/
     tfa:
       - sms
+      - totp
     doc: https://support.gocardless.com/hc/en-gb/articles/360001164385
 
   - name: Google Pay


### PR DESCRIPTION
GoCardless now supports 2FA via TOTP

https://support.gocardless.com/hc/en-gb/articles/360001164385#how_to_enable_two_step_sign_in