### PR TITLE
Add exception for LinkedIn

### DIFF
--- a/_data/social.yml
+++ b/_data/social.yml
@@ -141,6 +141,7 @@ websites:
       - sms
       - totp
     doc: https://www.linkedin.com/help/linkedin/answer/531
+    exception: "Only one 2FA method is allowed at a time."
 
   - name: LiveJournal
     url: https://www.livejournal.com


### PR DESCRIPTION
LinkedIn does not allow more than one method of 2FA at once.