### PR TITLE
TD Ameritrade offers proprietary two-factor auth solution now

### DIFF
--- a/_data/investing.yml
+++ b/_data/investing.yml
@@ -229,6 +229,8 @@ websites:
     img: tdameritrade.png
     tfa:
       - sms
+      - proprietary
+    doc: https://apps.apple.com/us/app/td-ameritrade-authenticator/id1449911854
 
   - name: TD Waterhouse
     url: https://www.tdwaterhouse.ca

--- a/_data/investing.yml
+++ b/_data/investing.yml
@@ -230,7 +230,6 @@ websites:
     tfa:
       - sms
       - proprietary
-    doc: https://apps.apple.com/us/app/td-ameritrade-authenticator/id1449911854
 
   - name: TD Waterhouse
     url: https://www.tdwaterhouse.ca


### PR DESCRIPTION
TD Ameritrade has a two factor auth application:
https://apps.apple.com/us/app/td-ameritrade-authenticator/id1449911854
https://play.google.com/store/apps/details?id=com.tdameritrade.authenticator&hl=en_US

This is not documented on their website but the solution has been available for about a year now in the app stores.