### PR TITLE
OVH: Add documentation and U2F support

### DIFF
--- a/_data/hosting.yml
+++ b/_data/hosting.yml
@@ -392,7 +392,8 @@ websites:
     tfa:
       - sms
       - totp
-      - hardware
+      - u2f
+    doc: https://docs.ovh.com/gb/en/customer/secure-account-with-2FA/
 
   - name: PlanetHoster
     url: https://www.planethoster.com/


### PR DESCRIPTION
Adding the documentation link for setting up 2FA on your account.
Also indicating U2F support, as listed in the documentation (I have been testing it myself, works with a Yubikey blue security key)