### PR TITLE
Update Epic Games doc URL

### DIFF
--- a/_data/gaming.yml
+++ b/_data/gaming.yml
@@ -81,7 +81,7 @@ websites:
     tfa:
       - email
       - totp
-    doc: https://www.epicgames.com/help/en-US/epic-accounts-c74/account-security-c112/twofactor-authentication-and-how-to-enable-it-a3218
+    doc: https://www.epicgames.com/help/en-US/c74/c112/a3218
 
   - name: EVE Online
     url: https://www.eveonline.com/

--- a/_data/gaming.yml
+++ b/_data/gaming.yml
@@ -81,7 +81,7 @@ websites:
     tfa:
       - email
       - totp
-    doc: https://epicgames.helpshift.com/a/epic-accounts/?s=epic-accounts&f=what-is-two-factor-authentication-2fa-and-how-do-i-opt-in
+    doc: https://www.epicgames.com/help/en-US/epic-accounts-c74/account-security-c112/twofactor-authentication-and-how-to-enable-it-a3218
 
   - name: EVE Online
     url: https://www.eveonline.com/


### PR DESCRIPTION
Current doc URL returns 404, this changes the URL to the most recent help document.