### PR TITLE
Adds Credit Karma UK

### DIFF
--- a/_data/finance.yml
+++ b/_data/finance.yml
@@ -81,7 +81,7 @@ websites:
     facebook: SAPConcur
     img: concur.png
 
-  - name: Credit Karma (UK), formally Noddle
+  - name: Credit Karma (UK), formerly Noddle
     url: https://www.creditkarma.co.uk
     img: creditkarma.png
     twitter: useyournoddle

--- a/_data/finance.yml
+++ b/_data/finance.yml
@@ -81,6 +81,12 @@ websites:
     facebook: SAPConcur
     img: concur.png
 
+  - name: Credit Karma (UK), formally Noddle
+    url: https://www.creditkarma.co.uk
+    img: creditkarma.png
+    twitter: useyournoddle
+    facebook: noddleuk
+
   - name: Credit Karma (US)
     url: https://www.creditkarma.com
     img: creditkarma.png
@@ -88,12 +94,6 @@ websites:
       - sms
       - phone
     doc: https://help.creditkarma.com/hc/en-us/articles/360001472366
-
-  - name: Credit Karma (UK), formally Noddle
-    url: https://www.creditkarma.co.uk
-    img: creditkarma.png
-    twitter: useyournoddle
-    facebook: noddleuk
 
   - name: DEGIRO
     url: https://www.degiro.nl

--- a/_data/finance.yml
+++ b/_data/finance.yml
@@ -81,13 +81,19 @@ websites:
     facebook: SAPConcur
     img: concur.png
 
-  - name: Credit Karma
+  - name: Credit Karma (US)
     url: https://www.creditkarma.com
     img: creditkarma.png
     tfa:
       - sms
       - phone
     doc: https://help.creditkarma.com/hc/en-us/articles/360001472366
+
+  - name: Credit Karma (UK), formally Noddle
+    url: https://www.creditkarma.co.uk
+    img: creditkarma.png
+    twitter: useyournoddle
+    facebook: noddleuk
 
   - name: DEGIRO
     url: https://www.degiro.nl


### PR DESCRIPTION
Credit Karma bought Noddle in the UK, and although the site has been rebranded it does not support 2FA. Updated the YAML to reflect this.