### PR TITLE
Update test dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   tests:
 
     docker:
-      - image: ruby:2.5.3
+      - image: ruby:latest
     steps:
       - checkout
 

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -10,11 +10,9 @@ jobs:
     if: github.repository == '2factorauth/twofactorauth'
 
     steps:
-      - uses: actions/checkout@v2.1.0
+      - uses: actions/checkout@v2
 
-      - name: Get Cache
-        id: cache
-        uses: actions/cache@v1.1.2
+      - uses: actions/cache@v2
         with:
           path: vendor/cache
           key: ${{ runner.os }}-bundle-${{ hashFiles('**/Gemfile.lock') }}
@@ -27,7 +25,7 @@ jobs:
           bundle config set cache_all true
           bundle install --jobs 4 --retry 3
           npm i babel-minify
-          sudo apt install webp -y
+          sudo apt install webp -y &
           [ -d "vendor/cache" ] || { bundle package; }
 
       - name: Check file extensions
@@ -61,7 +59,7 @@ jobs:
 
       - name: Deploy to GH Pages
         if: success()
-        uses: crazy-max/ghaction-github-pages@v2.0.0
+        uses: crazy-max/ghaction-github-pages@v2
         with:
           target_branch: gh-pages
           build_dir: _site

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -22,7 +22,6 @@ jobs:
         bundle config set path 'vendor/cache'
         bundle config set cache_all true
         bundle install --jobs 4 --retry 3
-        sudo npm i babel-minify -g
         [ -d "vendor/cache" ] || { bundle package; }
 
     - name: Check file extensions

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -21,9 +21,8 @@ jobs:
       run: |
         bundle config set path 'vendor/cache'
         bundle config set cache_all true
-        bundle install --jobs 4 --retry 3 &
+        bundle install --jobs 4 --retry 3
         sudo npm i babel-minify -g
-        sudo apt install webp -y &
         [ -d "vendor/cache" ] || { bundle package; }
 
     - name: Check file extensions

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     name: Test Jekyll
     steps:
-    - uses: actions/checkout@v2.1.0
+    - uses: actions/checkout@v2
 
-    - uses: actions/cache@v1.1.2
+    - uses: actions/cache@v2
       with:
         path: vendor/cache
         key: ${{ runner.os }}-bundle-${{ hashFiles('**/Gemfile.lock') }}
@@ -21,9 +21,9 @@ jobs:
       run: |
         bundle config set path 'vendor/cache'
         bundle config set cache_all true
-        bundle install --jobs 4 --retry 3
+        bundle install --jobs 4 --retry 3 &
         sudo npm i babel-minify -g
-        sudo apt install webp -y
+        sudo apt install webp -y &
         [ -d "vendor/cache" ] || { bundle package; }
 
     - name: Check file extensions

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     name: Rubocop
     steps:
-      - uses: actions/checkout@v2.1.0
+      - uses: actions/checkout@v2
 
-      - uses: actions/cache@v1.1.2
+      - uses: actions/cache@v2
         with:
           path: vendor/cache
           key: ${{ runner.os }}-bundle-${{ hashFiles('**/Gemfile.lock') }}

--- a/_deployment/tests/facebook.sh
+++ b/_deployment/tests/facebook.sh
@@ -2,7 +2,7 @@
 
 # Check Facebook handle
 check_facebook () {
-  handles="$(git log -p origin/master..HEAD ../_data | grep ^+[[:space:]] | grep facebook | cut -c16-)"
+  handles="$(git log -p origin/master..HEAD ../../_data | grep ^+[[:space:]] | grep facebook | cut -c16-)"
 
   if [ -z "$handles" ]; then
     echo "No Facebook handles found."

--- a/_deployment/tests/twitter.sh
+++ b/_deployment/tests/twitter.sh
@@ -2,7 +2,7 @@
 
 # Check Twitter handle
 check_twitter () {
-	handles="$(git log -p origin/master..HEAD ../_data | grep ^+[[:space:]] | grep twitter | cut -c15-)"
+	handles="$(git log -p origin/master..HEAD ../../_data | grep ^+[[:space:]] | grep twitter | cut -c15-)"
 
   if [ -z "$handles" ]; then
     echo "No Twitter handles found."


### PR DESCRIPTION
CircleCI:
* Change to always use the latest stable Ruby version
* Fix directory paths for Twitter/Facebook tests

Gh-pages workflow:
* Update checkout, cache & gh-pages action versions
* Install webp in the background

Jekyll workflow:
* Update checkout & cache action versions
* Remove unused dependencies

Rubocop workflow:
* Update checkout & cache action versions

Runtime:
circleci ~7s
jekyll.yml ~20s
ruby.yml  ~28s
gh-pages.yml _unknown_