### PR TITLE
Add Sparbankerna to Swedbank

### DIFF
--- a/_data/banking.yml
+++ b/_data/banking.yml
@@ -1197,7 +1197,7 @@ websites:
     facebook: suntrust
     img: suntrust.png
 
-  - name: Swedbank
+  - name: Swedbank & Sparbankerna
     url: https://www.swedbank.se/
     img: swedbank.png
     tfa:


### PR DESCRIPTION
Lots of smaller banks calling themselves "sparbanker" use Swedbank's services for their own customers.