### PR TITLE
Add email 2fa for ring

### DIFF
--- a/_data/iot.yml
+++ b/_data/iot.yml
@@ -55,6 +55,7 @@ websites:
     img: ringcom.png
     tfa:
       - sms
+      - email
     doc: https://support.ring.com/hc/en-us/articles/360024818291
 
   - name: Samsung SmartThings

--- a/_data/iot.yml
+++ b/_data/iot.yml
@@ -56,7 +56,7 @@ websites:
     tfa:
       - sms
       - email
-    doc: https://support.ring.com/hc/en-us/articles/360024818291
+    doc: https://support.ring.com/hc/en-us/articles/360039693891
 
   - name: Samsung SmartThings
     url: https://www.smartthings.com/


### PR DESCRIPTION
Read that they offer email 2fa on https://eu.ring.com/blogs/alwayshome/extra-layers-of-security-and-control

Funny that they sell to countries where it's illegal to put up these kinds of cameras 😒 
