### PR TITLE
Force site names to be one line

### DIFF
--- a/css/mobile-table.scss
+++ b/css/mobile-table.scss
@@ -18,6 +18,10 @@
       .site-title {
         font-size: 18px;
         line-height: 53px;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+        overflow: hidden;
+        color: #3596ff;
 
         .fa-exclamation-triangle {
           float: right;


### PR DESCRIPTION
The mobile table looks weird right now when looking at sites with long names. This PR makes sure that the site names only can use 1 line.

Before:
![](https://user-images.githubusercontent.com/3535780/87368723-c29f6a80-c57e-11ea-8150-503747223652.png)

After:
![](https://user-images.githubusercontent.com/3535780/87368734-c7fcb500-c57e-11ea-9911-be6d740eae02.png)