### PR TITLE
Remove exception from Backblaze

### DIFF
--- a/_data/backup.yml
+++ b/_data/backup.yml
@@ -15,7 +15,6 @@ websites:
       - sms
       - totp
     doc: https://help.backblaze.com/hc/en-us/articles/217666588
-    exception: "SMS-capable phone required for initial setup."
 
   - name: Box
     url: https://www.box.com/


### PR DESCRIPTION
Original exception stated that an "SMS-capable phone required for initial setup." According to [Backblaze's 2FA docs](https://help.backblaze.com/hc/en-us/articles/217666588), initial setup now allows an authentication app to be used.