### PR TITLE
Update Login.gov

### DIFF
--- a/_data/government.yml
+++ b/_data/government.yml
@@ -116,7 +116,7 @@ websites:
       - sms
       - phone
       - totp
-      - hardware
+      - u2f
     doc: https://www.login.gov/help/creating-an-account/two-factor-authentication/
     regions:
       - us


### PR DESCRIPTION
Update Login.gov to reflect that it supports u2f security keys. The documentation page (https://www.login.gov/help/creating-an-account/security-key/) specifically calls out FIDO compliant security keys. 

Messed up the original PR https://github.com/2factorauth/twofactorauth/pull/4902 (that's what I get for working on master...)