### PR TITLE
Update Microsoft sites

### DIFF
--- a/_data/backup.yml
+++ b/_data/backup.yml
@@ -155,7 +155,6 @@ websites:
       - totp
       - u2f
     doc: https://support.microsoft.com/en-us/help/12408/
-    exception: "Hardware token supporting FIDO2/WebAuthn can only be used in Windows 10 version 1809 and above."
 
   - name: PCloud
     url: https://www.pcloud.com

--- a/_data/backup.yml
+++ b/_data/backup.yml
@@ -150,11 +150,12 @@ websites:
     img: onedrive.png
     tfa:
       - sms
+      - email
       - proprietary
       - totp
       - u2f
     doc: https://support.microsoft.com/en-us/help/12408/
-    exception: "Hardware token supporting FIDO2/WebAuthn can only be used in Windows 10 version 1809 and above using Edge browser."
+    exception: "Hardware token supporting FIDO2/WebAuthn can only be used in Windows 10 version 1809 and above."
 
   - name: PCloud
     url: https://www.pcloud.com

--- a/_data/communication.yml
+++ b/_data/communication.yml
@@ -283,12 +283,12 @@ websites:
     img: skype.png
     tfa:
       - sms
+      - email
       - proprietary
       - totp
       - u2f
-      - phone
     doc: https://support.microsoft.com/en-us/help/12408/
-    exception: "Must be associated with a Microsoft Account. U2F authentication only available on Edge browser."
+    exception: "Must be associated with a Microsoft Account."
 
   - name: Slack
     url: https://slack.com/

--- a/_data/developer.yml
+++ b/_data/developer.yml
@@ -613,12 +613,15 @@ websites:
       - totp
     doc: https://blog.uptimerobot.com/introducing-two-factor-authentication-2fa/
 
-  - name: Visual Studio Online
+  - name: Visual Studio Codespaces
     url: https://www.visualstudio.com/
     img: visualstudio.png
     tfa:
       - sms
+      - email
+      - proprietary
       - totp
+      - u2f
     doc: https://support.microsoft.com/en-us/help/12408/
 
   - name: Zapier

--- a/_data/email.yml
+++ b/_data/email.yml
@@ -132,10 +132,12 @@ websites:
     img: outlook.png
     tfa:
       - sms
+      - email
+      - proprietary
       - totp
-      - hardware
+      - u2f
     doc: https://support.microsoft.com/en-us/help/12408/
-    exception: "Hardware token supporting FIDO2/WebAuthn can only be used in Windows 10 version 1809 and above using Edge browser."
+    exception: "Hardware token supporting FIDO2/WebAuthn can only be used in Windows 10 version 1809 and above."
 
   - name: Pobox
     url: https://www.pobox.com/

--- a/_data/email.yml
+++ b/_data/email.yml
@@ -137,7 +137,6 @@ websites:
       - totp
       - u2f
     doc: https://support.microsoft.com/en-us/help/12408/
-    exception: "Hardware token supporting FIDO2/WebAuthn can only be used in Windows 10 version 1809 and above."
 
   - name: Pobox
     url: https://www.pobox.com/

--- a/_data/gaming.yml
+++ b/_data/gaming.yml
@@ -393,7 +393,9 @@ websites:
     tfa:
       - sms
       - email
+      - proprietary
       - totp
+      - u2f
     doc: https://support.microsoft.com/en-us/help/12408/
 
   - name: YoYo Games

--- a/_data/other.yml
+++ b/_data/other.yml
@@ -424,7 +424,6 @@ websites:
       - totp
       - u2f
     doc: https://support.office.com/en-US/article/Set-up-multi-factor-authentication-for-Office-365-8f0454b2-f51a-4d9c-bcde-2c48e41621c6
-    exception: "Hardware token supporting FIDO2/WebAuthn can only be used in Windows 10 version 1809 and above."
 
   - name: Onshape
     url: https://www.onshape.com/

--- a/_data/other.yml
+++ b/_data/other.yml
@@ -419,10 +419,12 @@ websites:
     tfa:
       - sms
       - phone
+      - email
+      - proprietary
       - totp
-      - hardware
+      - u2f
     doc: https://support.office.com/en-US/article/Set-up-multi-factor-authentication-for-Office-365-8f0454b2-f51a-4d9c-bcde-2c48e41621c6
-    exception: "Hardware token supporting FIDO2/WebAuthn can only be used in Windows 10 version 1809 and above using Edge browser."
+    exception: "Hardware token supporting FIDO2/WebAuthn can only be used in Windows 10 version 1809 and above."
 
   - name: Onshape
     url: https://www.onshape.com/

--- a/_data/task.yml
+++ b/_data/task.yml
@@ -71,7 +71,9 @@ websites:
     tfa:
       - sms
       - email
+      - proprietary
       - totp
+      - u2f
     doc: https://support.microsoft.com/en-us/help/12408/
 
   - name: Planio


### PR DESCRIPTION
Updated Microsoft sites to reflect latest MFA options. Also renamed Visual Studio Online to Visual Studio Codespaces to reflect naming change (https://visualstudio.microsoft.com/services/visual-studio-codespaces/).

 Available 2FA options for Microsoft accounts are sms, email, proprietary, totp (https://support.microsoft.com/en-us/help/12408/) and u2f (https://support.microsoft.com/en-us/help/4463210/windows-10-sign-in-microsoft-account-windows-hello-security-key). 

Office365 also supports phone (https://support.microsoft.com/en-us/office/set-up-your-microsoft-365-sign-in-for-multi-factor-authentication-ace1d096-61e5-449b-a875-58eb3d74de14?ui=en-US&rs=en-US&ad=US).
