### PR TITLE
Update Bitbucket

### DIFF
--- a/_data/developer.yml
+++ b/_data/developer.yml
@@ -83,7 +83,7 @@ websites:
     img: bitbucket.png
     tfa:
       - totp
-      - hardware
+      - u2f
     doc: https://confluence.atlassian.com/x/425QLg
 
   - name: Buddy


### PR DESCRIPTION
Updated Bitbucket to reflect that it supports u2f security keys. https://support.atlassian.com/bitbucket-cloud/docs/enable-two-step-verification/