### PR TITLE
Add static timezone suffix

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -84,7 +84,7 @@
       </div>
       <div id="buildNumber" class="desktop-only" title="{{ site.github.build_revision }}">
         Build #: {{ site.github.build_revision | slice: 0,7 }}<br>
-        Build Date: {{ site.time | slice: 0,10}}Z
+        Build Date: {{ site.time | slice: 0,10}} UTC
       </div>
     </div>
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -84,7 +84,7 @@
       </div>
       <div id="buildNumber" class="desktop-only" title="{{ site.github.build_revision }}">
         Build #: {{ site.github.build_revision | slice: 0,7 }}<br>
-        Build Date: {{ site.time | slice: 0,10}}
+        Build Date: {{ site.time | slice: 0,10}}Z
       </div>
     </div>
 


### PR DESCRIPTION
The build date is always displayed in UTC/ZULU and so adding the timezone as a suffix would clear up any date confusion.