### PR TITLE
Add color codes to Circle CI outputs

### DIFF
--- a/_deployment/tests/alexa.rb
+++ b/_deployment/tests/alexa.rb
@@ -49,14 +49,12 @@ else
   file.close
 end
 
-# rubocop:disable Layout/LineLength
 if max_ranking < rank_i
   puts("\e[31m#{site} has an Alexa ranking above #{max_ranking_string}. (Currently: #{rank})\e[39m")
-	exit(1)
+  exit(1)
 elsif rank_i.zero?
   puts("\e[31m#{site} doesn't have an Alexa rank. #{max_ranking_string} or less required.\e[39m")
-	exit(1)
+  exit(1)
 end
-# rubocop:enable Layout/LineLength
 
 puts("\e[32m#{site} has an Alexa ranking of #{rank}.\e[39m")

--- a/_deployment/tests/alexa.rb
+++ b/_deployment/tests/alexa.rb
@@ -50,10 +50,13 @@ else
 end
 
 # rubocop:disable Layout/LineLength
-raise("\e[31m#{site} has an Alexa ranking above #{max_ranking_string}. (Currently: #{rank})\e[0m") if max_ranking < rank_i
-
-raise("\e[31m#{site} doesn't have an Alexa rank. #{max_ranking_string} or less required.\e[0m") if rank_i.zero?
-
+if max_ranking < rank_i
+  puts("\e[31m#{site} has an Alexa ranking above #{max_ranking_string}. (Currently: #{rank})\e[39m")
+	exit(1)
+elsif rank_i.zero?
+  puts("\e[31m#{site} doesn't have an Alexa rank. #{max_ranking_string} or less required.\e[39m")
+	exit(1)
+end
 # rubocop:enable Layout/LineLength
 
-puts("\e[32m#{site} has an Alexa ranking of #{rank}.\e[0m")
+puts("\e[32m#{site} has an Alexa ranking of #{rank}.\e[39m")

--- a/_deployment/tests/facebook.sh
+++ b/_deployment/tests/facebook.sh
@@ -20,12 +20,12 @@ check_facebook () {
 
     # Compare 302 location with the handle
     if [ "$fb_handle" == "$handle" ]; then
-      echo "Facebook page \"${handle}\" is valid."
+      echo -e "\e[32mFacebook page \"${handle}\" is valid.\e[39m"
     elif [ -z "$fb_handle" ]; then
-      echo "::error:: Facebook page \"${handle}\" not found."
+      echo -e "\e[31mFacebook page \"${handle}\" not found.\e[39m"
       exit 1
     else
-      echo "::error:: Facebook handle \"${handle}\" should be \"${fb_handle}\"."
+      echo -e "\e[31mFacebook handle \"${handle}\" should be \"${fb_handle}\".\e[39m"
       exit 1
     fi
 

--- a/_deployment/tests/twitter.rb
+++ b/_deployment/tests/twitter.rb
@@ -23,13 +23,13 @@ begin
 # Catch any exceptions
 rescue Twitter::Error => e
   if e.class == Twitter::Error::NotFound
-    puts "Twitter user #{ARGV[0]} not found."
+    puts "\e[31mTwitter user #{ARGV[0]} not found.\e[39m"
     exit 2
   elsif e.class == Twitter::Error::TooManyRequests
-    puts 'Disregarding Twitter checks due to too many requests.'
+    puts '\e[31mDisregarding Twitter checks due to too many requests.\e[39m'
     exit 0 # Soft fail if unable to access twitter api
   elsif e.class == Twitter::Error::BadRequest
-    puts 'Invalid authentication. Check Environment variables.'
+    puts '\e[31mInvalid authentication. Check Environment variables.\e[39m'
     exit 1
   else
     puts e.backtrace
@@ -40,6 +40,6 @@ end
 if user.eql? ARGV[0]
   exit 0
 else
-  puts "Twitter handle \"#{ARGV[0]}\" should be \"#{user}\"."
+  puts "\e[31mTwitter handle \"#{ARGV[0]}\" should be \"#{user}\".\e[39m"
   exit 3
 end

--- a/_deployment/tests/twitter.sh
+++ b/_deployment/tests/twitter.sh
@@ -9,7 +9,7 @@ check_twitter () {
     exit 0
   fi
 
-  gem i twitter --no-post-install-message --no-suggestions --minimal-deps --no-verbose -N -q
+  gem i twitter --no-post-install-message --no-suggestions --minimal-deps --no-verbose -N -q --silent
 
   # Loop through all Twitter handles
   echo "${handles}" | while IFS= read -r handle; do

--- a/_deployment/tests/twitter.sh
+++ b/_deployment/tests/twitter.sh
@@ -17,10 +17,10 @@ check_twitter () {
     twitter="$(ruby twitter.rb ${handle})"
 
     if [ "$twitter" ]; then
-      echo "::error:: $twitter"
+      echo -e "\e[31m$twitter\e[39m"
       exit 1
     else
-      echo "Twitter handle \"${handle}\" is valid."
+      echo -e "\e[32mTwitter handle \"${handle}\" is valid.\e[39m"
     fi
 
   done


### PR DESCRIPTION
* Added some color codes to make it easier to read the console output on the Circle CI tests.
* Switched to silently install gems for the Twitter test.
* Replaced the `raise` functions with `puts` & `exit` as raise doesn't support color codes.