### PR TITLE
Add exception to AWS

### DIFF
--- a/_data/cloud.yml
+++ b/_data/cloud.yml
@@ -7,6 +7,7 @@ websites:
       - hardware
       - u2f
     doc: https://aws.amazon.com/iam/features/mfa/
+    exception: "Limited to one software token OR one hardware token."
 
   - name: appFog
     url: https://www.ctl.io/appfog/


### PR DESCRIPTION
AWS currently does not support more than one 2FA method at once: you cannot set multiple virtual 2FA devices or U2F keys, or even set a virtual 2FA alongside a U2F key.

Source: https://forums.aws.amazon.com/thread.jspa?threadID=137055