### PR TITLE
Update AOL Mail

### DIFF
--- a/_data/email.yml
+++ b/_data/email.yml
@@ -6,6 +6,7 @@ websites:
       - sms
       - phone
       - email
+      - hardware
     doc: https://help.aol.com/articles/2-step-verification-stronger-than-your-password-alone
 
   - name: FastMail


### PR DESCRIPTION
Added 'hardware' for AOL Mail. While they KB article is still not updated, users can go to https://login.aol.com/account/security/security-key for instructions after login.

