### PR TITLE
Update AOL Mail

### DIFF
--- a/_data/email.yml
+++ b/_data/email.yml
@@ -6,7 +6,7 @@ websites:
       - sms
       - phone
       - email
-      - hardware
+      - u2f
     doc: https://help.aol.com/articles/2-step-verification-stronger-than-your-password-alone
 
   - name: FastMail

--- a/_data/email.yml
+++ b/_data/email.yml
@@ -6,6 +6,7 @@ websites:
       - sms
       - phone
       - email
+      - hardware
     doc: https://help.aol.com/articles/2-step-verification-stronger-than-your-password-alone
 
   - name: FastMail


### PR DESCRIPTION
Added 'hardware' for AOL Mail. While they KB article is still not updated, users can go to https://login.aol.com/account/security/security-key for instructions after login.

![Screen Shot 2020-09-14 at 09 14 29](https://user-images.githubusercontent.com/17606465/93085755-6afba900-f66c-11ea-8b21-e12b4f07b03a.png)

![Screen Shot 2020-09-14 at 09 20 50](https://user-images.githubusercontent.com/17606465/93085748-68994f00-f66c-11ea-801c-460f8ef6dba9.png)