### PR TITLE
Update Yahoo Mail

### DIFF
--- a/_data/email.yml
+++ b/_data/email.yml
@@ -255,6 +255,7 @@ websites:
       - phone
       - email
       - proprietary
+      - hardware
     doc: https://help.yahoo.com/kb/SLN5013.html
     exception: "Linked phone number required for 2FA."
 

--- a/_data/email.yml
+++ b/_data/email.yml
@@ -255,7 +255,7 @@ websites:
       - phone
       - email
       - proprietary
-      - hardware
+      - u2f
     doc: https://help.yahoo.com/kb/SLN5013.html
     exception: "Linked phone number required for 2FA."
 


### PR DESCRIPTION
Added 'hardware' for Yahoo Mail. While they KB article is still not updated, users can go to https://login.yahoo.com/account/security/security-key for instructions after login.

Similar to #4952


![Screen Shot 2020-09-14 at 09 47 56](https://user-images.githubusercontent.com/17606465/93087798-743a4500-f66f-11ea-9fd1-854244c6ba8c.png)
