### PR TITLE
Change Centrify "doc" URL

### DIFF
--- a/_data/identity.yml
+++ b/_data/identity.yml
@@ -36,7 +36,7 @@ websites:
       - proprietary
       - hardware
       - u2f
-    doc: https://www.centrify.com/privileged-access-management/authentication-service/mfa/
+    doc: https://www.centrify.com/pam/authentication-service/mfa/
 
   - name: Dashlane
     url: https://www.dashlane.com


### PR DESCRIPTION
Recently, we changed our URL for the page you are linking to. When we changed the URL, we put in a proper 301 redirect, but we'd like it if the URL on your site can be updated so it can go directly to the new URL. Thanks!