### PR TITLE
Updating backup.yml with Mega docs link

### DIFF
--- a/_data/backup.yml
+++ b/_data/backup.yml
@@ -128,7 +128,7 @@ websites:
     img: mega.png
     tfa:
       - totp
-    doc: https://mega.nz/help/client/webclient/security-and-privacy/5bb5436cf1b70966038b456b
+    doc: https://mega.nz/help/client/ios/accounts-and-pro-accounts#how-do-i-enable-two-factor-authentication-on-my-account-5bb542b3f1b70961038b4571
 
   - name: MultCloud
     url: https://www.multcloud.com/home.html


### PR DESCRIPTION
# Summary

Mega docs link was updated with their FAQ site update, this changes the doc link to the correct link, https://mega.nz/help/client/ios/accounts-and-pro-accounts#how-do-i-enable-two-factor-authentication-on-my-account-5bb542b3f1b70961038b4571

## Files Changed

- [_data/backup.yml](https://github.com/2factorauth/twofactorauth/compare/master...arcsector:master#diff-9e3a2343e901b5658b456e00087e5e1a)