### PR TITLE
Add '--production' flag to region.rb

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Build region sites
         run: |
           ruby ./_deployment/used_regions.rb > api/v2/regions.json
-          ruby ./_deployment/regions.rb
+          ruby ./_deployment/regions.rb --production
 
       - name: Generate webp images
         run: ./_deployment/webp.sh

--- a/_deployment/regions.rb
+++ b/_deployment/regions.rb
@@ -42,8 +42,10 @@ regions.each do |region|
 
   out_dir = "#{Dir.pwd}/#{region['id']}"
   puts "Building #{region['id']}..."
+  configs = ['_config.yml']
+  configs.push('_deployment/config-production.yml') if ARGV.include?('--production')
   # rubocop:disable Layout/LineLength
-  puts `bundle exec jekyll build -s #{dest_dir} -d #{out_dir} --config _config.yml,_deployment/config-production.yml --baseurl #{region['id']}` # Add -V for debugging
+  puts `bundle exec jekyll build -s #{dest_dir} -d #{out_dir} --config #{configs.join(',')} --baseurl #{region['id']}` # Add -V for debugging
   # rubocop:enable Layout/LineLength
   puts "#{region['id']} built!"
 end


### PR DESCRIPTION
Feature request from @phallobst

Default, will run without the production flag resulting in a quicker build.
```bash
ruby _deployment/region.rb
```

Running:
```bash
ruby _deployment/region.rb --production
```
Takes a longer time but results in a minnified HTML code. (Which is desired for production environments) 