### PR TITLE
Update Zoom

### DIFF
--- a/_data/communication.yml
+++ b/_data/communication.yml
@@ -379,6 +379,6 @@ websites:
     url: https://www.zoom.us
     img: zoom.png
     tfa:
+      - sms
       - totp
     doc: https://support.zoom.us/hc/en-us/articles/360038247071
-    exception: "2FA is only available on paid plans and doesn't protect the desktop or mobile apps."


### PR DESCRIPTION
Zoom now supports TOTP and SMS for all users - see news https://www.engadget.com/zoom-rolls-out-twofactor-video-call-authentication-for-all-accounts-084536539.html and also on doc page https://support.zoom.us/hc/en-us/articles/360038247071