### PR TITLE
Merge Discover listings

### DIFF
--- a/_data/banking.yml
+++ b/_data/banking.yml
@@ -581,13 +581,7 @@ websites:
     img: idb.png
     lang: he
 
-  - name: Discover (Banking)
-    url: https://www.discover.com/online-banking/
-    img: discover.png
-    twitter: Discover
-    facebook: discover
-
-  - name: Discover (Credit Cards)
+  - name: Discover
     url: https://www.discover.com/
     img: discover.png
     tfa:


### PR DESCRIPTION
Discover (Banking) now supports the same 2FA as (Credit Card). https://www.discover.com/online-banking/security-center/
Merging the two entries allows us to create a duplicate checking script :eyes: