### PR TITLE
Update namecheap

### DIFF
--- a/_data/domains.yml
+++ b/_data/domains.yml
@@ -327,7 +327,6 @@ websites:
     img: namecheap.png
     tfa:
       - sms
-      - proprietary
       - totp
       - u2f
     doc: https://www.namecheap.com/security/2fa-two-factor-authentication/


### PR DESCRIPTION
Namecheap now uses standard TOTP 2FA, not proprietary. See: [article](https://www.namecheap.com/support/knowledgebase/article.aspx/10073/45/how-can-i-use-the-totp-method-for-twofactor-authentication/)