### PR TITLE
Update TD Bank Canadian Branding

### DIFF
--- a/_data/banking.yml
+++ b/_data/banking.yml
@@ -1401,20 +1401,15 @@ websites:
     doc: https://www.tbcbank.ge/web/en/web/guest/tbc-digipass
 
   - name: TD Bank
-    url: https://www.tdbank.com
+    url: https://www.td.com/
     img: tdbank.png
     tfa:
       - sms
       - phone
     doc: https://www.td.com/privacy-and-security/privacy-and-security/how-we-protect-you/online-security/2fa.jsp
-
-  - name: TD Canada Trust
-    url: https://www.tdcanadatrust.com
-    img: tdbank.png
-    tfa:
-      - sms
-      - phone
-    doc: https://www.td.com/privacy-and-security/privacy-and-security/how-we-protect-you/online-security/2fa.jsp
+    regions:
+      - us
+      - ca
 
   - name: Tesco Bank
     url: https://www.tescobank.com/

--- a/_data/investing.yml
+++ b/_data/investing.yml
@@ -236,11 +236,8 @@ websites:
     img: tdameritrade.png
     tfa:
       - sms
-
-  - name: TD Waterhouse
-    url: https://www.tdwaterhouse.ca
-    twitter: TD_Canada
-    img: tdameritrade.png
+    regions:
+      - us
 
   - name: TIAA-CREF
     url: https://www.tiaa-cref.org

--- a/_data/investing.yml
+++ b/_data/investing.yml
@@ -232,7 +232,7 @@ websites:
     img: sunsuper.png
 
   - name: TD Ameritrade
-    url: https://www.tdameritrade.com
+    url: https://www.tdameritrade.com/
     img: tdameritrade.png
     tfa:
       - sms


### PR DESCRIPTION
TD Waterhouse and Canada Direct domains now redirect to td.com. Updating and added regions