### PR TITLE
Removed exception for Colorado School of Mines

### DIFF
--- a/_data/education.yml
+++ b/_data/education.yml
@@ -139,7 +139,6 @@ websites:
       - hardware
       - u2f
     doc: https://its.mines.edu/mfa/
-    exception: "Only available for employees"
     regions:
       - us
 


### PR DESCRIPTION
Colorado School of Mines previously had an exception of 2FA being "only available for employees," but 2FA is now available to all current Mines users.