### PR TITLE
LastPass does not support U2F.

### DIFF
--- a/_data/identity.yml
+++ b/_data/identity.yml
@@ -87,7 +87,6 @@ websites:
       - totp
       - hardware
       - proprietary
-      - u2f
     doc: https://support.logmeininc.com/lastpass/help/enable-multifactor-authentication-lp010002
     exception: "Availability of 2FA options depends on your account type."
 


### PR DESCRIPTION
Hello!

LastPass does not support U2F. It only supports the OTP function of YubiKeys, which is significantly weaker than U2F.

From https://www.lastpass.com/yubico:
> The YubiKey offers flexibility for LastPass users looking to deploy Yubico One Time Password to access their password vault [...]

There's a good [demonstration of phishing LastPass](https://pberba.github.io/security/2020/05/28/lastpass-phishing/) which shows the difference.

Thanks for twofactorauth.org! It's an awesome reference!
