### PR TITLE
SoFi (Social Finance) supports email and phone

### DIFF
--- a/_data/banking.yml
+++ b/_data/banking.yml
@@ -1312,6 +1312,8 @@ websites:
     img: sofi.png
     tfa:
       - sms
+      - phone
+      - email
     doc: https://www.sofi.com/blog/introducing-two-step-verification-sofi-next-level-account-protection/
 
   - name: Sparda Banken


### PR DESCRIPTION
SoFi supports delivery of 2FA codes via email and phone now. I've tested email personally, and it's documented in SoFi's help doc:
https://support.sofi.com/hc/en-us/articles/360044101551-Can-I-change-the-way-I-receive-my-verification-code-