### PR TITLE
Add Keybase lockdown mode

### DIFF
--- a/_data/identity.yml
+++ b/_data/identity.yml
@@ -77,8 +77,10 @@ websites:
 
   - name: Keybase
     url: https://keybase.io
-    twitter: KeybaseIO
     img: keybase.png
+    tfa:
+      - proprietary
+    doc: https://book.keybase.io/docs/lockdown
 
   - name: LastPass
     url: https://lastpass.com/


### PR DESCRIPTION
[Lockdown mode](https://book.keybase.io/docs/lockdown) prevents anyone from using a Keybase account without access to a registered device.