### PR TITLE
Update Wyze

### DIFF
--- a/_data/iot.yml
+++ b/_data/iot.yml
@@ -93,9 +93,10 @@ websites:
     img: totalconnect.png
 
   - name: Wyze
-    url: https://www.wyzecam.com
+    url: https://www.wyze.com
     img: wyze.png
     tfa:
       - sms
+      - totp
     doc: https://support.wyzecam.com/hc/en-us/articles/360024402052
     exception: "2FA via SMS is only available for USA and Canada."


### PR DESCRIPTION
* Wyze now supports TOTP
* Canonical domain has changed from `wyzecam.com` to `wyze.com`