### PR TITLE
Change twofactorauth.org references to 2fa.directory

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-add-site-with-2fa.md
+++ b/.github/ISSUE_TEMPLATE/1-add-site-with-2fa.md
@@ -48,14 +48,14 @@ See our [wiki](https://github.com/2factorauth/twofactorauth/wiki/FAQ-2FA-Types) 
 - [ ] SMS tokens
 - [ ] Email tokens
 
-### Information about the site's eligibility to be added to twofactorauth.org: ###
+### Information about the site's eligibility to be added to 2fa.directory: ###
 <!-- Check each box below to verify that the site meets our requirements for being listed.
 If a site does not meet all of these requirements, feel free to continue your issue submission.
 Leave any unmet requirements unchecked, and add any additional information or questions in the "Additional information" section below. -->
 
-- [ ] I have checked that the site meets twofactorauth.org's [contributing guidelines and site criteria](https://github.com/2factorauth/twofactorauth/blob/master/CONTRIBUTING.md).
+- [ ] I have checked that the site meets 2fa.directory's [contributing guidelines and site criteria](https://github.com/2factorauth/twofactorauth/blob/master/CONTRIBUTING.md).
 - [ ] The site is ranked within the top 200,000 sites on [Alexa](https://www.alexa.com/siteinfo/) or has a substantial social media following.
-- [ ] The site does not contain or promote content that violates twofactorauth.org's [excluded categories and websites guidelines](https://github.com/2factorauth/twofactorauth/blob/master/EXCLUSION.md), including pornographic, discriminatory, or unlawful content.
+- [ ] The site does not contain or promote content that violates 2fa.directory's [excluded categories and websites guidelines](https://github.com/2factorauth/twofactorauth/blob/master/EXCLUSION.md), including pornographic, discriminatory, or unlawful content.
 
 ### Additional information: ###
 <!-- If you have any additional information to provide, please do so below. -->

--- a/.github/ISSUE_TEMPLATE/2-add-site-without-2fa.md
+++ b/.github/ISSUE_TEMPLATE/2-add-site-without-2fa.md
@@ -29,7 +29,7 @@ Check both boxes below before submitting your issue to verify that you have alre
 * Does the site support 2FA? - `No`
 
 ### Information about the site's contact information: ###
-<!-- This information is used to allow those visiting twofactorauth.org to contact the owner of the site and request that 2FA be supported.
+<!-- This information is used to allow those visiting 2fa.directory to contact the owner of the site and request that 2FA be supported.
 Leave any fields that do not have contact information blank. -->
 
 <!-- Language of the site.
@@ -47,14 +47,14 @@ List the language used for the site's Twitter and support email address. -->
 <!-- Support email address for the site -->
 * Email address - ``
 
-### Information about the site's eligibility to be added to twofactorauth.org: ###
+### Information about the site's eligibility to be added to 2fa.directory: ###
 <!-- Check each box below to verify that the site meets our requirements for being listed.
 If a site does not meet all of these requirements, feel free to continue your issue submission.
 Leave any unmet requirements unchecked, and add any additional information or questions in the "Additional information" section below. -->
 
-- [ ] I have checked that the site meets twofactorauth.org's [contributing guidelines and site criteria](https://github.com/2factorauth/twofactorauth/blob/master/CONTRIBUTING.md).
+- [ ] I have checked that the site meets 2fa.directory's [contributing guidelines and site criteria](https://github.com/2factorauth/twofactorauth/blob/master/CONTRIBUTING.md).
 - [ ] The site is ranked within the top 200,000 sites on [Alexa](https://www.alexa.com/siteinfo/) or has a substantial social media following.
-- [ ] The site does not contain or promote content that violates twofactorauth.org's [excluded categories and websites guidelines](https://github.com/2factorauth/twofactorauth/blob/master/EXCLUSION.md), including pornographic, discriminatory, or unlawful content.
+- [ ] The site does not contain or promote content that violates 2fa.directory's [excluded categories and websites guidelines](https://github.com/2factorauth/twofactorauth/blob/master/EXCLUSION.md), including pornographic, discriminatory, or unlawful content.
 
 ### Additional information: ###
 <!-- If you have any additional information to provide, please do so below. -->

--- a/.github/ISSUE_TEMPLATE/3-update-existing-site.md
+++ b/.github/ISSUE_TEMPLATE/3-update-existing-site.md
@@ -19,13 +19,13 @@ Check the box below before submitting your issue to verify that you have already
 - [ ] I have searched [open issues and pull requests](https://github.com/2factorauth/twofactorauth/issues?q=is%3Aopen). The issue I'm creating is not a duplicate of an existing open issue or pull request.
 
 ### Information about the site entry to be updated: ###
-<!-- Name of the site, as currently listed on twofactorauth.org -->
+<!-- Name of the site, as currently listed on 2fa.directory -->
 * Site name - ``
 
-<!-- Link to the main page of the site, as currently listed on twofactorauth.org -->
+<!-- Link to the main page of the site, as currently listed on 2fa.directory -->
 * Site URL - ``
 
-<!-- Category of the site, as currently listed on twofactorauth.org -->
+<!-- Category of the site, as currently listed on 2fa.directory -->
 * Site category - ``
 
 ### Information about why the site entry should be updated: ###
@@ -39,7 +39,7 @@ Check the box below before submitting your issue to verify that you have already
 - [ ] Its Twitter username, Facebook page, and/or email address have changed.
 - [ ] It fits better in a different category.
 - [ ] Its logo has changed.
-- [ ] It has been acquired or absorbed by another site, and the new site is eligible to be listed on twofactorauth.org.
+- [ ] It has been acquired or absorbed by another site, and the new site is eligible to be listed on 2fa.directory.
 - [ ] Other (please describe below).
 
 ### Information about how the site entry should be updated: ###

--- a/.github/ISSUE_TEMPLATE/4-remove-existing-site.md
+++ b/.github/ISSUE_TEMPLATE/4-remove-existing-site.md
@@ -19,13 +19,13 @@ Check the box below before submitting your issue to verify that you have already
 - [ ] I have searched [open issues and pull requests](https://github.com/2factorauth/twofactorauth/issues?q=is%3Aopen). The issue I'm creating is not a duplicate of an existing open issue or pull request.
 
 ### Information about the site entry to be removed: ###
-<!-- Name of the site, as currently listed on twofactorauth.org -->
+<!-- Name of the site, as currently listed on 2fa.directory -->
 * Site name - ``
 
-<!-- Link to the main page of the site, as currently listed on twofactorauth.org -->
+<!-- Link to the main page of the site, as currently listed on 2fa.directory -->
 * Site URL - ``
 
-<!-- Category of the site, as currently listed on twofactorauth.org -->
+<!-- Category of the site, as currently listed on 2fa.directory -->
 * Site category - ``
 
 ### Information about why the site entry should be removed: ###
@@ -33,10 +33,10 @@ Check the box below before submitting your issue to verify that you have already
 - [ ] It is a duplicate of an existing site entry.
 - [ ] It will be discontinued in the near future.
 - [ ] It has been shut down by the owner and is no longer accessible.
-- [ ] It has been acquired or absorbed by another site, and the new site is already listed on twofactorauth.org.
+- [ ] It has been acquired or absorbed by another site, and the new site is already listed on 2fa.directory.
 - [ ] It no longer has verifiable 2FA documentation and is no longer ranked within the top 200,000 sites on [Alexa](https://www.alexa.com/siteinfo/).
-- [ ] It no longer meets twofactorauth.org's [contributing guidelines and site criteria](https://github.com/2factorauth/twofactorauth/blob/master/CONTRIBUTING.md).
-- [ ] It contains content that violates twofactorauth.org's [excluded categories and websites guidelines](https://github.com/2factorauth/twofactorauth/blob/master/EXCLUSION.md).
+- [ ] It no longer meets 2fa.directory's [contributing guidelines and site criteria](https://github.com/2factorauth/twofactorauth/blob/master/CONTRIBUTING.md).
+- [ ] It contains content that violates 2fa.directory's [excluded categories and websites guidelines](https://github.com/2factorauth/twofactorauth/blob/master/EXCLUSION.md).
 - [ ] Other (please describe below).
 
 **Additional information about why this site entry should be removed:**

--- a/API.md
+++ b/API.md
@@ -1,7 +1,7 @@
 # API usage
 ## Introduction
 
-The data collected for the twofactorauth.org website is also available as JSON files in order to enable developers to use it in their own programs. It is recommended to use the API with the highest version number, since older versions might not include all available information.
+The data collected for the 2fa.directory website is also available as JSON files in order to enable developers to use it in their own programs. It is recommended to use the API with the highest version number, since older versions might not include all available information.
 
 ### URL & Domain matching
 
@@ -21,15 +21,15 @@ If you only intent on using a specific dataset, like all sites supporting RFC-62
 
 |URI|Coverage|
 |---|--------|
-|https://twofactorauth.org/api/v2/all.json|All sites|
-|https://twofactorauth.org/api/v2/tfa.json|All 2FA-supporting sites|
-|https://twofactorauth.org/api/v2/sms.json|SMS|
-|https://twofactorauth.org/api/v2/phone.json|Phone calls|
-|https://twofactorauth.org/api/v2/email.json|Email 2FA|
-|https://twofactorauth.org/api/v2/hardware.json|non-U2F hardware 2FA tokens|
-|https://twofactorauth.org/api/v2/u2f.json|U2F hardware tokens|
-|https://twofactorauth.org/api/v2/totp.json|RFC-6238|
-|https://twofactorauth.org/api/v2/proprietary.json|non-RFC-6238 software 2FA|
+|https://2fa.directory/api/v2/all.json|All sites|
+|https://2fa.directory/api/v2/tfa.json|All 2FA-supporting sites|
+|https://2fa.directory/api/v2/sms.json|SMS|
+|https://2fa.directory/api/v2/phone.json|Phone calls|
+|https://2fa.directory/api/v2/email.json|Email 2FA|
+|https://2fa.directory/api/v2/hardware.json|non-U2F hardware 2FA tokens|
+|https://2fa.directory/api/v2/u2f.json|U2F hardware tokens|
+|https://2fa.directory/api/v2/totp.json|RFC-6238|
+|https://2fa.directory/api/v2/proprietary.json|non-RFC-6238 software 2FA|
 
 
 ### Elements
@@ -90,7 +90,7 @@ If you only intent on using a specific dataset, like all sites supporting RFC-62
 
 |URI|Coverage|
 |---|--------|
-|https://twofactorauth.org/api/v1/data.json|All sites|
+|https://2fa.directory/api/v1/data.json|All sites|
 
 ### Elements
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at contact@twofactorauth.org. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at contact@2fa.directory. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,8 +62,8 @@ $ bundle exec rake verify
 ## Site Criteria
 
 The following section contains rough criteria and explanations regarding
-what websites should be listed on twofactorauth.org. If one of the following
-criteria is met, it belongs on twofactorauth.org:
+what websites should be listed on 2fa.directory. If one of the following
+criteria is met, it belongs on 2fa.directory:
 
 1. **Personal Info/Image**: Any site that deals with personal info or a person's
    image. An example of a site with **Personal Info** would be their Amazon

--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,7 @@ author: Josh Davis
 description:
   List of sites with Two Factor Auth support which includes SMS, email,
   phone calls, hardware, and software.
-url: https://twofactorauth.org
+url: https://2fa.directory
 repository: 2factorauth/twofactorauth
 img: /img/logo.png
 env: development

--- a/_deployment/apiv1.rb
+++ b/_deployment/apiv1.rb
@@ -38,7 +38,7 @@ YAML.load_file("#{data_dir}/sections.yml").each do |section|
       website_data['exceptions'] = { 'text' => website['exception'] } unless website['exception'].nil?
       unless website['doc'].nil?
         website_data['doc'] =
-          website['doc'].start_with?('/notes/') ? "https://twofactorauth.org#{website['doc']}" : website['doc']
+          website['doc'].start_with?('/notes/') ? "https://2fa.directory#{website['doc']}" : website['doc']
       end
     end
     section_data[website['name']] = website_data

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,7 +15,7 @@
     <meta property="og:title" content="{{ site.title }}">
     <meta property="og:url" content="{{ site.url }}">
     <meta property="og:description" content="{{ site.description }}">
-    <meta content="https://twofactorauth.org/img/logo.png" property="og:image">
+    <meta content="https://2fa.directory/img/logo.png" property="og:image">
     <meta content="website" property="og:type">
     <meta content="summary_large_image" property="twitter:card">
     <meta property="twitter:title" content="{{ site.title }}">


### PR DESCRIPTION
The mail address contact@2fa.directory currently forwards to me, as long as no proper mail handling is set up.
I can change the forward if there is a better alternative.