### PR TITLE
Add PGP signed API files at deployment

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -5,7 +5,7 @@ on:
     branches: master
 
 jobs:
-  build:
+  deploy:
     runs-on: ubuntu-latest
     if: github.repository == '2factorauth/twofactorauth'
 
@@ -52,6 +52,16 @@ jobs:
         run: |
           ./_deployment/apiv1.rb
           ./_deployment/apiv2.rb
+
+      - name: Import PGP key
+        id: pgp
+        uses: crazy-max/ghaction-import-gpg@v3
+        with:
+          gpg-private-key: ${{ secrets.pgp_key }}
+          passphrase: ${{ secrets.pgp_passphrase }}
+
+      - name: Sign API files
+        run: ./_deployment/sign.sh ${{ secrets.pgp_passphrase }} ${{ steps.pgp.outputs.keyid }}
 
       - name: Build the site
         run: bundle exec jekyll build --config _config.yml,_deployment/config-production.yml

--- a/_deployment/sign.sh
+++ b/_deployment/sign.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+for file in api/v*/*.json; do
+echo "$file.sig"
+echo $1 | gpg --yes --passphrase --local-user $2 --output "$file.sig" --sign "$file"
+done

--- a/_deployment/sign.sh
+++ b/_deployment/sign.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/bin/sh
 
 for file in api/v*/*.json; do
 echo "$file.sig"

--- a/_deployment/sign.sh
+++ b/_deployment/sign.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 for file in api/v*/*.json; do
 echo "$file.sig"


### PR DESCRIPTION
The script goes through all JSON files in the /api folder at deployment and creates seperate .sig files that can be used to verify the integrity of the API files.

The PGP key is already stored as a "secret" environment variable in the repository.