### PR TITLE
Update twofactorauth.org references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to TwoFactorAuth.org
+# Contributing to 2fa.directory
 
 All the data is managed through a series of [Yaml][yaml] files so it may be
 useful to read up on the Yaml syntax.

--- a/EXCLUSION.md
+++ b/EXCLUSION.md
@@ -1,6 +1,6 @@
-# TwoFactorAuth.org excluded categories and websites
+# 2fa.directory excluded categories and websites
 
-Below is a list of categories and websites that we, [the collaborators](https://github.com/orgs/2factorauth/teams/collaborators/members), have opted to not list on TwoFactorAuth.org.
+Below is a list of categories and websites that we, [the collaborators](https://github.com/orgs/2factorauth/teams/collaborators/members), have opted to not list on 2fa.directory.
 
 One of the primary concerns we seek to address with these exclusions is professional and academic web filters. We believe that the service that this site provides should be as accessible as possible, to help as many people as possible, in as many environments as possible. Dynamic web filters can block websites based solely on the existence of keywords which could lead to this service being filtered for mentioning or linking out to categories of websites that web admins have deemed unacceptable for their domain. While we believe that every site should make an effort to protect their users (which often includes enabling Two Factor Authentication), we also believe that accessibility to this list for all has more value than listing every possible site and service.
 
@@ -26,7 +26,7 @@ If you want to make a copy (fork) of our site to list any of these sites you're 
 
     There are several resons for why we've opted to not list such sites and services.
 
-    -   TwoFactorAuth.org is targeted towards consumers and not website administrators. As of right now, very few general internet users choose to host their own websites and services. Therefore we think that the effort on our part to maintain such a list of self hosted alternatives would outweigh the minimal theoretical change in the internet landscape by listing such services.
+    -   2fa.directory is targeted towards consumers and not website administrators. As of right now, very few general internet users choose to host their own websites and services. Therefore we think that the effort on our part to maintain such a list of self hosted alternatives would outweigh the minimal theoretical change in the internet landscape by listing such services.
 
     -   If the core project doesn't support two factor authentication but instead through plugins it would mean that we would have to list all plugins that enable two factor authentication for the service, something that is currently impossible with our website layout.
 
@@ -34,9 +34,9 @@ If you want to make a copy (fork) of our site to list any of these sites you're 
 
 *   #### Potential controversial sites 
 
-    Any site that could damage the reputation of TwoFactorAuth.org and/or lead to any controversy with either the maintainers or users, should not be listed.
+    Any site that could damage the reputation of 2fa.directory and/or lead to any controversy with either the maintainers or users, should not be listed.
     The group of active maintainers will decide on whether to include or exclude a site within a specific timeframe. Once an exclusion was decided upon, the site will be listed in the section below and any corresponding pull request will be closed.
 
 ## Sites
 
-Below is a list of specific sites/services excluded from TwoFactorAuth.org.
+Below is a list of specific sites/services excluded from 2fa.directory.


### PR DESCRIPTION
There were a couple of twofactorauth.org references that weren't fixed by #5248 so I have replaced them with 2fa.directory