### PR TITLE
Display Other category at the end

### DIFF
--- a/_data/sections.yml
+++ b/_data/sections.yml
@@ -86,10 +86,6 @@
   title: Legal
   icon: fas fa-balance-scale-left
 
-- id: other
-  title: Other
-  icon: fas fa-ellipsis-h
-
 - id: payments
   title: Payments
   icon: fas fa-credit-card
@@ -129,3 +125,7 @@
 - id: vpn
   title: VPN Providers
   icon: fas fa-shield-alt
+
+- id: other
+  title: Other
+  icon: fas fa-ellipsis-h


### PR DESCRIPTION
Since "Other" is not a very specific category, it makes sense to put this at the end (like any other list) instead of somewhere in the middle.