### PR TITLE
Update Facebook

### DIFF
--- a/_data/social.yml
+++ b/_data/social.yml
@@ -76,7 +76,7 @@ websites:
       - totp
       - u2f
     doc: https://www.facebook.com/help/148233965247823
-    exception: "Hardware 2FA requires also enabling a back-up method and is unsupported on mobile."
+    exception: "Hardware 2FA requires also enabling a back-up method"
 
   - name: Flickr
     url: https://www.flickr.com


### PR DESCRIPTION
According to https://about.fb.com/news/2021/03/expanding-support-for-security-keys-on-mobile-devices/, hardware 2FA is now supported on mobile