### PR TITLE
Update Compose

### DIFF
--- a/_data/developer.yml
+++ b/_data/developer.yml
@@ -188,6 +188,7 @@ websites:
     tfa:
       - sms
       - totp
+      - u2f
     doc: https://help.compose.com/docs/two-factor-authentication
 
   - name: Cookiebot

--- a/_data/developer.yml
+++ b/_data/developer.yml
@@ -189,7 +189,7 @@ websites:
       - sms
       - totp
       - u2f
-    doc: https://help.compose.com/docs/two-factor-authentication
+    doc: https://www.compose.com/articles/introducing-fido-universal-2nd-factor-authentication/
 
   - name: Cookiebot
     url: https://www.cookiebot.com/


### PR DESCRIPTION
According to this [blog post](https://www.compose.com/articles/introducing-fido-universal-2nd-factor-authentication/), u2f is supported in addition to sms and totp