### PR TITLE
Update N26

### DIFF
--- a/_data/banking.yml
+++ b/_data/banking.yml
@@ -955,7 +955,7 @@ websites:
     tfa:
       - sms
       - proprietary
-    doc: https://support.n26.com/en-gb/getting-started/psd2/how-to-log-in-with-two-factor-authentication
+    doc: https://support.n26.com/en-eu/security/passwords-and-codes/how-to-log-in-with-two-factor-authentication
 
   - name: NASA Federal Credit Union
     url: https://www.nasafcu.com/


### PR DESCRIPTION
It seems like https://support.n26.com/en-gb/getting-started/psd2/how-to-log-in-with-two-factor-authentication is not pointing to the desired documentation.