### PR TITLE
Bump gh pages to 214 - fixing build

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,7 +41,7 @@ GEM
     ffi (1.15.0)
     forwardable-extended (2.6.0)
     gemoji (3.0.1)
-    github-pages (213)
+    github-pages (214)
       github-pages-health-check (= 1.17.0)
       jekyll (= 3.9.0)
       jekyll-avatar (= 0.7.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,7 +77,7 @@ GEM
       jekyll-theme-time-machine (= 0.1.1)
       jekyll-titles-from-headings (= 0.5.3)
       jemoji (= 0.12.0)
-      kramdown (>= 2.3.1)
+      kramdown (= 2.3.1)
       kramdown-parser-gfm (= 1.1.0)
       liquid (= 4.0.3)
       mercenary (~> 0.3)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 A list of popular sites and whether or not they accept two factor auth.
 
 ## The Goal
-
+ 
 The goal of this project is to build a website ([2fa.directory](https://2fa.directory)) with a list of popular sites that support
 Two Factor Authentication, as well as the methods that they provide.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 A list of popular sites and whether or not they accept two factor auth.
 
 ## The Goal
- 
+
 The goal of this project is to build a website ([2fa.directory](https://2fa.directory)) with a list of popular sites that support
 Two Factor Authentication, as well as the methods that they provide.
 


### PR DESCRIPTION
[github/github-pages#762](https://github.com/github/pages-gem/pull/762) was just merged, and the version has been bumped to 214 in commit [7f5dba4](https://github.com/github/pages-gem/commit/7f5dba47affd4f86e7d19287ded7f5a1ad98f8d4) which should fix the failing build at the moment that was caused by [35c92a2](https://github.com/2factorauth/twofactorauth/commit/35c92a215bf43b0ed450c7762d931f083178a80a)