### PR TITLE
Update bitwarden

### DIFF
--- a/_data/identity.yml
+++ b/_data/identity.yml
@@ -24,6 +24,8 @@ websites:
       - email
       - totp
       - u2f
+      - hardware
+      - proprietary
     doc: https://help.bitwarden.com/article/setup-two-step-login/
     exception: "Premium account required for Duo, YubiKey and FIDO U2F."
 


### PR DESCRIPTION
Doc page mentions Duo push notifications (proprietary) and YubiKey OTP (hardware) in addition to the methods currently listed