### PR TITLE
Fix Bug: Broken Link in noscript tag

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -68,7 +68,7 @@
           <p>Without JavaScript, this page probably won't work very well.
                   For more information, or if you would like to talk to us about this,
                   please take a look at our
-            <b><a href="{{ site.repo }}" style="color: whitesmoke;">
+            <b><a href="{{ site.github.repository_url }}" style="color: whitesmoke;">
               GitHub repository</a></b>.</p>
         </div>
       </noscript>


### PR DESCRIPTION
At the moment, the link to the GH repo in the noscript tag doesn't do anything and when the page is built, this is the HTML produced:
`<a href="" style="color:#f5f5f5"> GitHub repository</a>` 

as `site.repo` doesn't seem to be defined. Changing it to `site.github.repository_url` like in the GitHub icon in the corner should fix this.