### PR TITLE
Clean up docs

### DIFF
--- a/API.md
+++ b/API.md
@@ -9,7 +9,7 @@ If you're using our API to match client URLs with our dataset make sure you only
 
 ### Caching
 
-If you intent to query our JSON files often and with a lot of traffic, you may be blocked by Cloudflare, our reverse proxy provider. We therefore recommend that you cache the files locally for any large traffic cases.
+If you intend to query our JSON files often and with a lot of traffic, you may be blocked by Cloudflare, our reverse proxy provider. We therefore recommend that you cache the files locally for any large traffic cases.
 
 ### Avoid downloading unnecessary data
 

--- a/EXCLUSION.md
+++ b/EXCLUSION.md
@@ -1,22 +1,22 @@
 # 2fa.directory excluded categories and websites
 
-Below is a list of categories and websites that we, [the collaborators](https://github.com/orgs/2factorauth/teams/collaborators/members), have opted to not list on 2fa.directory.
+Below is a list of categories and websites that we, [the collaborators][collaborators], have opted to not list on 2fa.directory.
 
 One of the primary concerns we seek to address with these exclusions is professional and academic web filters. We believe that the service that this site provides should be as accessible as possible, to help as many people as possible, in as many environments as possible. Dynamic web filters can block websites based solely on the existence of keywords which could lead to this service being filtered for mentioning or linking out to categories of websites that web admins have deemed unacceptable for their domain. While we believe that every site should make an effort to protect their users (which often includes enabling Two Factor Authentication), we also believe that accessibility to this list for all has more value than listing every possible site and service.
 
-If you want to make a copy (fork) of our site to list any of these sites you're welcome to do so as long as you comply with our [license](LICENSE).
+If you want to make a copy (fork) of our site to list any of these sites you're welcome to do so as long as you comply with our [license][license].
 
 ## Categories
 
 *   #### Pornographic sites
 
-    As the volunteers of [2factorauth](https://github.com/2factorauth) need to review all submissions to validate that the site/service provides 2FA to its users in addition to verifying that the pull request meets our style guidelines, we've chosen to not list sites that primarily host and serve pornographic content. Given the volunteer driven nature of this project, there is no guarantee that there will always be a collaborator available to review a submission that also does not have an  objection to reviewing such material. Special consideration must also be given due to the potential for content in this category to quickly cross subjective personal boundaries that vary widely from person to person.
+    As the volunteers of [2factorauth][org_link] need to review all submissions to validate that the site/service provides 2FA to its users in addition to verifying that the pull request meets our style guidelines, we've chosen to not list sites that primarily host and serve pornographic content. Given the volunteer driven nature of this project, there is no guarantee that there will always be a collaborator available to review a submission that also does not have an objection to reviewing such material. Special consideration must also be given due to the potential for content in this category to quickly cross subjective personal boundaries that vary widely from person to person.
 
 *   #### Self-hosted services
 
     The category "self-hosted services/sites" includes all types of software that's designed to be hosted by the end user. These are excluded from listing unless all these points are met:
 
-    1. All [Site Criteria](CONTRIBUTING.md#site-criteria) and [Guidelines](CONTRIBUTING.md#guidelines) are met
+    1. All [Site Criteria][site_criteria] and [Guidelines][guidelines] are met
 
     2. Public interest and public accessibility are given  
 
@@ -40,3 +40,9 @@ If you want to make a copy (fork) of our site to list any of these sites you're 
 ## Sites
 
 Below is a list of specific sites/services excluded from 2fa.directory.
+
+[collaborators]: https://github.com/orgs/2factorauth/teams/collaborators/members
+[license]: /LICENSE
+[org_link]: https://github.com/2factorauth
+[site_criteria]: CONTRIBUTING.md#site-criteria
+[guidelines]: CONTRIBUTING.md#guidelines

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ If you would like to contribute, please read the entire guidelines here in
 In order to run the site locally, bundler, and all other dependencies will need to be installed, and afterwards Jekyll can serve
 the site.
 
-Ubuntu
+Ubuntu:
 
 ```bash
 sudo snap install ruby --classic
@@ -35,7 +35,7 @@ npm i babel-minify
 bundle install --path vendor/bundle
 ```
 
-Windows Subsystem for Linux (WSL)
+Windows Subsystem for Linux (WSL):
 
 ```bash
 sudo apt install build-essential ruby-bundler ruby-dev make gcc g++ zlib1g-dev npm webp
@@ -43,7 +43,7 @@ npm i babel-minify
 bundle install --path vendor/bundle
 ```
 
-MacOS (_Requires Xcode_)
+MacOS (_Requires Xcode_):
 
 ```bash
 # Install homebrew

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # 2fa.directory
 
-[![Build Status](https://img.shields.io/github/workflow/status/2factorauth/twofactorauth/Jekyll%20Tests?style=for-the-badge)](https://github.com/2factorauth/twofactorauth/actions)
-[![License](https://img.shields.io/badge/license-mit-9A0F2D.svg?style=for-the-badge)](/LICENSE)
-[![Gitter](https://img.shields.io/gitter/room/2factorauth/twofactorauth.svg?style=for-the-badge&logo=gitter&color=ED1965)](https://gitter.im/2factorauth/twofactorauth)
-[![Twitter](https://img.shields.io/badge/Twitter-@2faorg-1DA1F2.svg?style=for-the-badge&logo=twitter)](https://twitter.com/2faorg)
+[![Build Status](https://img.shields.io/github/workflow/status/2factorauth/twofactorauth/Jekyll%20Tests?style=for-the-badge)][build_status]
+[![License](https://img.shields.io/badge/license-mit-9A0F2D.svg?style=for-the-badge)][license]
+[![Gitter](https://img.shields.io/gitter/room/2factorauth/twofactorauth.svg?style=for-the-badge&logo=gitter&color=ED1965)][gitter]
+[![Twitter](https://img.shields.io/badge/Twitter-@2faorg-1DA1F2.svg?style=for-the-badge&logo=twitter)][twitter]
 
 A list of popular sites and whether or not they accept two factor auth.
 
-## The Goal
+## The Goal :goal_net:
 
-The goal of this project is to build a website ([2fa.directory](https://2fa.directory)) with a list of popular sites that support
+The goal of this project is to build a website ([2fa.directory][site_url]) with a list of popular sites that support
 Two Factor Authentication, as well as the methods that they provide.
 
 Our hope is to aid consumers who are deciding between alternative services based on the security they
@@ -22,9 +22,11 @@ If you would like to contribute, please read the entire guidelines here in
 
 ## Local installation :hammer_and_wrench:
 
-2fa.directory is built upon [Jekyll](https://jekyllrb.com/), using the [github-pages](https://github.com/github/pages-gem) gem.
+2fa.directory is built upon [Jekyll][jekyll], using the [github-pages][pages-gem] gem.
 In order to run the site locally, bundler, and all other dependencies will need to be installed, and afterwards Jekyll can serve
-the site. Ubuntu:
+the site.
+
+Ubuntu
 
 ```bash
 sudo snap install ruby --classic
@@ -83,12 +85,20 @@ bundle exec jekyll serve --watch
 
 The TwoFactorAuth website should now be accessible from `http://localhost:4000`.
 
-Another option is to run Jekyll inside a [Docker](https://www.docker.com/) container. Please read the [Jekyll Docker Documentation](https://github.com/envygeeks/jekyll-docker/blob/master/README.md) on how to use Jekyll.
+Another option is to run Jekyll inside a [Docker][docker] container. Please read the [Jekyll Docker Documentation][jekyll_docker] on how to use Jekyll.
 
 ## License :balance_scale:
 
 This code is distributed under the MIT license. For more info, read the
 [LICENSE][license] file distributed with the source code.
 
-[contrib]: /CONTRIBUTING.md
+[build_status]: https://github.com/2factorauth/twofactorauth/actions
 [license]: /LICENSE
+[gitter]: https://gitter.im/2factorauth/twofactorauth
+[twitter]: https://twitter.com/2faorg
+[site_url]: https://2fa.directory
+[contrib]: /CONTRIBUTING.md
+[jekyll]: https://jekyllrb.com/
+[pages-gem]: https://github.com/github/pages-gem
+[docker]: https://www.docker.com/
+[jekyll_docker]: https://github.com/envygeeks/jekyll-docker/blob/master/README.md


### PR DESCRIPTION
- fix typos (double spaces between words, spelling)
- Increase consistency of links (`[name][link]` format)
- Clean up "Local Installation" instructions (colons, like in "running locally" section and new line before 'Ubuntu')
- Add emoji for "The goal" to make headings more consistent