### PR TITLE
Remove border radius on logos

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -156,7 +156,6 @@ thead {
 
   /* Site name and logo */
   .logo {
-    border-radius: 50%;
     height: 32px;
     width: 32px;
     margin-right: .8em;


### PR DESCRIPTION
As @phallobst has pointed out, the logos look fine without the border radius and SVGs are often better without it.