### PR TITLE
Add Lenovo

### DIFF
--- a/_data/retail.yml
+++ b/_data/retail.yml
@@ -339,7 +339,7 @@ websites:
     url: https://lenovo.com
     img: lenovo.svg
     twitter: Lenovo
-    facebook: Lenovo
+    facebook: lenovo
 
   - name: Lowes
     url: https://www.lowes.com

--- a/_data/retail.yml
+++ b/_data/retail.yml
@@ -335,6 +335,12 @@ websites:
     twitter: asklazadasg
     img: lazada.png
 
+  - name: Lenovo
+    url: https://lenovo.com
+    img: lenovo.svg
+    twitter: Lenovo
+    facebook: Lenovo
+
   - name: Lowes
     url: https://www.lowes.com
     img: lowes.png

--- a/_data/retail.yml
+++ b/_data/retail.yml
@@ -338,7 +338,7 @@ websites:
   - name: Lenovo
     url: https://lenovo.com
     img: lenovo.svg
-    twitter: Lenovo
+    twitter: LenovoSupport
     facebook: lenovo
 
   - name: Lowes

--- a/img/retail/lenovo.svg
+++ b/img/retail/lenovo.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 180"><path d="M0 0h180v180H0z" fill="#e60012"/><path d="M129.48 126.43H72.936V31.58H47.719v117.69h81.761z" fill="#fff"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 180" style="background: #e60012;fill:#fff"><path d="M129.48 126.43H72.936V31.58H47.719v117.69h81.761z"/></svg>

--- a/img/retail/lenovo.svg
+++ b/img/retail/lenovo.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 180"><path d="M0 0h180v180H0z" fill="#e60012"/><path d="M129.48 126.43H72.936V31.58H47.719v117.69h81.761z" fill="#fff"/></svg>


### PR DESCRIPTION
Closes #5606 

Decided to use `@Lenovo` for twitter instead of `@LenovoSupport` as mentioned in issue, as they do seem to reply to queries on their main account.