### PR TITLE
Update Twitter script to comply with new Twitter API auth changes

### DIFF
--- a/_deployment/tests/twitter.rb
+++ b/_deployment/tests/twitter.rb
@@ -7,6 +7,8 @@ require 'twitter'
 client = Twitter::REST::Client.new do |config|
   config.consumer_key = ENV['twitter_consumer_key']
   config.consumer_secret = ENV['twitter_consumer_secret']
+  config.access_token = ENV['TWITTER_TOKEN']
+  config.access_token_secret = ENV['TWITTER_TOKEN_SECRET']
 end
 
 # Check that an argument has been sent


### PR DESCRIPTION
Apparently Twitter changed who and what can get data about users. They now require access tokens from a user (in this case @2faorg) to work.
The keys have already been added to CircleCI. This PR adds it to the script as well.