### PR TITLE
Update Kinsta

### DIFF
--- a/_data/hosting.yml
+++ b/_data/hosting.yml
@@ -306,9 +306,8 @@ websites:
     url: https://kinsta.com
     img: kinsta.png
     tfa:
-      - sms
-      - proprietary
-    doc: https://kinsta.com/blog/wordpress-two-factor-authentication/
+      - totp
+    doc: https://kinsta.com/knowledgebase/two-factor-authentication/
 
   - name: KnownHost
     url: https://www.knownhost.com


### PR DESCRIPTION
- SMS 2FA is no longer supported for new users - it is only available as a legacy option for those with it available
- Authy 2FA is no longer offered
- TOTP 2FA is now available
- Updated doc link to more useful page.