### PR TITLE
Update AngelList

### DIFF
--- a/_data/other.yml
+++ b/_data/other.yml
@@ -47,7 +47,6 @@ websites:
     tfa:
       - sms
       - totp
-    doc: https://angel.co/projects/106166
 
   - name: Audiense
     url: https://audiense.com/


### PR DESCRIPTION
Removed doc link as the current one seems to have nothing to do with AngelList's 2FA as it refers to enabling 2FA on Zoho?

> Two Factor Authentication acts as a second layer of protection for the Zoho account after the user signs in with username and password.

