### PR TITLE
Update Discord's URL

### DIFF
--- a/_data/communication.yml
+++ b/_data/communication.yml
@@ -134,13 +134,13 @@ websites:
     doc: https://directmailmac.com/support/article/507
 
   - name: Discord
-    url: https://discordapp.com/
+    url: https://discord.com/
     img: discord.png
     tfa:
       - sms
       - email
       - totp
-    doc: https://support.discordapp.com/hc/en-us/articles/219576828
+    doc: https://support.discord.com/hc/en-us/articles/219576828
 
   - name: Disqus
     url: https://disqus.com


### PR DESCRIPTION
Discord has changed its URL from discordapp.com to discord.com. This updated the info to represent this.