### PR TITLE
Reactivate pushing to gh-pages

### DIFF
--- a/.github/workflows/repository.yml
+++ b/.github/workflows/repository.yml
@@ -114,7 +114,6 @@ jobs:
     name: Publish build
     needs: [complete_build]
     runs-on: ubuntu-latest
-    if: always() == false
     steps:
       - uses: actions/download-artifact@v2
         with:


### PR DESCRIPTION
This PR reactivates the pushing of new commits in master to gh-pages, updating 2fa.directory.