### PR TITLE
Update LogicMonitor

### DIFF
--- a/entries/l/logicmonitor.com.json
+++ b/entries/l/logicmonitor.com.json
@@ -2,7 +2,7 @@
     "LogicMonitor": {
         "domain": "logicmonitor.com",
         "tfa": [
-            "phone",
+            "call",
             "sms",
             "custom-software"
         ],


### PR DESCRIPTION
Noticed in the test output:
```
Document not valid:
- file: entries/l/logicmonitor.com.json
  error : pattern
  data: phone
  path: /LogicMonitor/tfa/0
```
Tests were passing though, even though `call` is specified in the schema rather than `phone`.