### PR TITLE
Fix social button backgrounds

### DIFF
--- a/_includes/scss/social-media.scss
+++ b/_includes/scss/social-media.scss
@@ -11,15 +11,15 @@
   color: white;
   margin: 0 6px;
 
-  .twitter-button {
+  &.twitter-button {
     background-color: #1DA1F2;
   }
 
-  .facebook-button {
+  &.facebook-button {
     background-color: #3b5998;
   }
 
-  .email-button {
+  &.email-button {
     background-color: #ea4235;
   }
 }


### PR DESCRIPTION
Currently targeting 
`.social-button .twitter-button`

![image](https://user-images.githubusercontent.com/20560218/120473788-4e8cd180-c39f-11eb-939e-1694ffcfabfe.png)

but should be targeting `.social-button.twitter-button`