### PR TITLE
Remove empty twitter:creator meta tag

### DIFF
--- a/_includes/html/seo.html
+++ b/_includes/html/seo.html
@@ -9,7 +9,6 @@
 <meta property="og:type" content="website">
 <meta property="twitter:card" content="summary_large_image">
 <meta property="twitter:title" content="{{ site.title }}">
-<meta property="twitter:creator" content="{{ site.author }}">
 <meta property="twitter:site" content="{{ site.twitter }}">
 <meta property="twitter:image" content="https://repository-images.githubusercontent.com/17724730/63495880-b408-11e9-8cc4-03451aa4cc14">
 <meta property="twitter:description" content="{{ site.description }}">


### PR DESCRIPTION
`site.author` currently has no value. 

`twitter:creator` is described as @username of content creator which I don't believe is necessary given that we have `twitter:site` set to 2faorg already.