### PR TITLE
Fix phone call checkmark on desktop table

### DIFF
--- a/_includes/html/desktop-table.html
+++ b/_includes/html/desktop-table.html
@@ -60,7 +60,7 @@
             </td>
 
             <td class="icon-cell">
-              {% if tfa contains "phone" %}
+              {% if tfa contains "call" %}
                 <i class="tfa-icon fas fa-check"></i>
                 {%endif%}
             </td>


### PR DESCRIPTION
Currently, checkmarks for phone call are not being displayed on the desktop table. The schema uses `call` not `phone` which is currently in use to display the checkmark.