### PR TITLE
Fix active category button on mobile

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -38,7 +38,7 @@ $('.cat').click(function () {
 function showCategory(category) {
   $(`#${category}-table`).collapse("show");
   $(`#${category}-mobile-table`).collapse("show");
-  $(`#${category}`).addClass('active');
+  $(`[id=${category}]`).addClass('active');
 }
 
 let resizeObserver = new ResizeObserver(() => {


### PR DESCRIPTION
The `active` class is not applied to the category button on the mobile table.

![image](https://user-images.githubusercontent.com/20560218/120923693-bf95f700-c6c7-11eb-9e03-27c66f7e81a9.png)
![image](https://user-images.githubusercontent.com/20560218/120923696-c91f5f00-c6c7-11eb-8e48-9c503e46593a.png)

Occurs because there are multiple divs with the same id, so the js code only applies it to the first instance (the desktop table). 