### PR TITLE
Update Discord

### DIFF
--- a/entries/d/discord.com.json
+++ b/entries/d/discord.com.json
@@ -3,7 +3,6 @@
     "domain": "discord.com",
     "tfa": [
       "sms",
-      "email",
       "totp"
     ],
     "documentation": "https://support.discord.com/hc/en-us/articles/219576828",


### PR DESCRIPTION
updates to not include email as a supported form of 2fa. Resolves #5749 