### PR TITLE
Update Depop

### DIFF
--- a/entries/d/depop.com.json
+++ b/entries/d/depop.com.json
@@ -1,11 +1,12 @@
 {
   "Depop": {
     "domain": "depop.com",
-    "url": "https://www.depop.com",
-    "contact": {
-      "facebook": "depop",
-      "twitter": "depop"
-    },
+    "tfa": [
+      "sms"
+    ],
+    "documentation": "https://depophelp.zendesk.com/hc/en-gb/articles/360017103878",
+    "notes": "2FA can only be enabled via the app. Recovery codes can only be used via the app.",
+    "recovery": "https://depophelp.zendesk.com/hc/en-gb/articles/360017003737",
     "keywords": [
       "retail"
     ],


### PR DESCRIPTION
See [this page](https://depophelp.zendesk.com/hc/en-gb/articles/360017003737) for the exceptions:

> On web/Depop.com, you can’t:
> Set up two-factor authentication for the first time.
> Turn off two-factor authentication.
> Turn two-factor authentication back on if you turned it off in the app.
> Use your recovery code to log in.