### PR TITLE
Fix padding on dark theme

### DIFF
--- a/_includes/html/category-button.html
+++ b/_includes/html/category-button.html
@@ -2,7 +2,7 @@
 {% assign title = include.category-param[1].title %}
 {% assign icon = include.category-param[1].icon %}
 
-<div class="col align-self-start category-icon-outer {{ include.viewport }}-only">
+<div class="col align-self-start {{ include.viewport }}-only">
   <div class="cat btn cat-icon-inner" data-toggle="collapse" data-target="#{{ name }}-table" aria-expanded="false" aria-controls="{{ name }}-table" id="{{ name }}">
         <div>
           <i class="{{ icon }} category-icon fa-fw"></i>

--- a/_includes/scss/categories.scss
+++ b/_includes/scss/categories.scss
@@ -3,9 +3,6 @@
   .category-title {
     color: #eee;
   }
-  .category-icon-outer {
-    padding: 1em;
-  }
   .category-icon {
     background-color: #eee !important;
   }


### PR DESCRIPTION
There is padding that is applied to the category buttons (only on the dark theme), which causes search results to be pushed far down the page. This padding is not applied to the light theme, so removing it doesn't really affect the spacing of the category buttons.

![image](https://user-images.githubusercontent.com/20560218/121516185-dac57700-c9e5-11eb-8d90-2d908b75838d.png)
![image](https://user-images.githubusercontent.com/20560218/121516212-e153ee80-c9e5-11eb-9a8a-c3c24f4a940c.png)

This is particularly problematic on the mobile table
![image](https://user-images.githubusercontent.com/20560218/121516333-ff215380-c9e5-11eb-9c02-1d9cfcecc1c1.png)
![image](https://user-images.githubusercontent.com/20560218/121516365-06e0f800-c9e6-11eb-91da-494ed5566506.png)

When the padding is removed, the search results look much better
![image](https://user-images.githubusercontent.com/20560218/121516752-7d7df580-c9e6-11eb-8e86-107c3436322d.png)
