### PR TITLE
Fix margin on social buttons

### DIFF
--- a/_includes/scss/social-media.scss
+++ b/_includes/scss/social-media.scss
@@ -29,4 +29,7 @@
     margin: .2em;
     max-width: 50%;
   }
+  .social-button:first-child:nth-last-child(1){
+    margin-left: 0 !important;
+  }
 }


### PR DESCRIPTION
Currently, on the tablet viewport, when there is a single social contact button, it is right-aligned and looks slightly out of place
![image](https://user-images.githubusercontent.com/20560218/121742895-63ccd300-caf8-11eb-8ec6-be9866297850.png)

This PR moves the button to the center on tablet viewports. 
![image](https://user-images.githubusercontent.com/20560218/121742963-7cd58400-caf8-11eb-8c1f-20c58a9d413f.png)
