### PR TITLE
Update Wordpress.com

### DIFF
--- a/entries/w/wordpress.com.json
+++ b/entries/w/wordpress.com.json
@@ -5,7 +5,7 @@
       "sms",
       "totp",
        "custom-hardware": [
-      "WebAuthn"
+      "WebAuthn" ]
    
     ],
     "documentation": "https://en.support.wordpress.com/security/two-step-authentication/",

--- a/entries/w/wordpress.com.json
+++ b/entries/w/wordpress.com.json
@@ -3,7 +3,10 @@
     "domain": "wordpress.com",
     "tfa": [
       "sms",
-      "totp"
+      "totp",
+       "custom-hardware": [
+      "WebAuthn"
+    ],
     ],
     "documentation": "https://en.support.wordpress.com/security/two-step-authentication/",
     "notes": "SMS required for 2FA.",

--- a/entries/w/wordpress.com.json
+++ b/entries/w/wordpress.com.json
@@ -6,7 +6,7 @@
       "totp",
        "custom-hardware": [
       "WebAuthn"
-    ],
+   
     ],
     "documentation": "https://en.support.wordpress.com/security/two-step-authentication/",
     "notes": "SMS required for 2FA.",

--- a/entries/w/wordpress.com.json
+++ b/entries/w/wordpress.com.json
@@ -4,9 +4,7 @@
     "tfa": [
       "sms",
       "totp",
-       "custom-hardware": [
-      "WebAuthn" ]
-   
+      "custom-software"
     ],
     "documentation": "https://en.support.wordpress.com/security/two-step-authentication/",
     "notes": "SMS required for 2FA.",

--- a/entries/w/wordpress.com.json
+++ b/entries/w/wordpress.com.json
@@ -7,7 +7,6 @@
       "custom-software"
     ],
     "documentation": "https://en.support.wordpress.com/security/two-step-authentication/",
-    "notes": "SMS required for 2FA.",
     "keywords": [
       "social"
     ]

--- a/entries/w/wordpress.com.json
+++ b/entries/w/wordpress.com.json
@@ -4,7 +4,7 @@
     "tfa": [
       "sms",
       "totp",
-      "custom-software"
+      "u2f"
     ],
     "documentation": "https://en.support.wordpress.com/security/two-step-authentication/",
     "keywords": [


### PR DESCRIPTION
updated wordpress to include the fact that a hardware key with webauth is now an option for 2fa