### PR TITLE
Add padding to category icons

### DIFF
--- a/_includes/scss/desktop-table.scss
+++ b/_includes/scss/desktop-table.scss
@@ -1,4 +1,10 @@
 @media screen and (min-width: 993px) {
+
+  /* Category icons */
+  .col .cat-icon-inner {
+    padding: 1em;
+  }
+
   /* Desktop table */
   .category-table {
     width: 100%;


### PR DESCRIPTION
#5760 removed the padding around category icons/buttons.
This PR brings back the padding in a way that preserves the bugfix of #5760.

No padding:
![2fa.directory](https://user-images.githubusercontent.com/3535780/122282489-c1439400-ceeb-11eb-8eac-596f96bee8e2.png)

Padding:
![2fa.carlgo11.com](https://user-images.githubusercontent.com/3535780/122282542-cf91b000-ceeb-11eb-814b-d58368ce7f0b.png)
