### PR TITLE
Fix CircleCI Failures

### DIFF
--- a/tests/alexa.rb
+++ b/tests/alexa.rb
@@ -11,7 +11,7 @@ def fetch_from_api(site)
   url = URI("https://awis.api.alexa.com/api?Action=UrlInfo&ResponseGroup=Rank&Output=json&Url=#{site}")
   http = Net::HTTP.new(url.host, url.port)
   http.use_ssl = true
-  headers = { 'x-api-key' => ENV['ALEXA_API_KEY'], 'Accept' => 'application/json' }
+  headers = { 'x-api-key' => ENV['alexa_access_key'], 'Accept' => 'application/json' }
   response = http.request(Net::HTTP::Get.new(url, headers))
   raise("(#{response.code}) Request failed.") unless response.code == '200'
 

--- a/tests/twitter.rb
+++ b/tests/twitter.rb
@@ -4,8 +4,10 @@
 require 'twitter'
 
 client = Twitter::REST::Client.new do |config|
-  config.consumer_key = ENV['TWITTER_API_KEY']
-  config.consumer_secret = ENV['TWITTER_API_SECRET']
+  config.consumer_key = ENV['twitter_consumer_key']
+  config.consumer_secret = ENV['twitter_consumer_secret']
+  config.access_token = ENV['TWITTER_TOKEN']
+  config.access_token_secret = ENV['TWITTER_TOKEN_SECRET']
 end
 
 status = 0


### PR DESCRIPTION
Alexa tests are currently failing with 403 error (see #5819). The name of the environment variable in the CircleCI settings is `alexa_access_key` rather than `ALEXA_API_KEY`

Twitter tests are failing with error `Twitter API keys not found or invalid.` (see #5823), as the names of the environment variables are wrong and the changes from #5697 haven't been included.