### PR TITLE
Fix git diff bug

### DIFF
--- a/tests/alexa.rb
+++ b/tests/alexa.rb
@@ -42,15 +42,13 @@ end
 status = 0
 # Fetch changes
 # rubocop:disable Layout/LineLength
-diff = `git diff origin/master...HEAD entries/ | grep "^+[[:space:]]*\\"domain\\":" | sed -e 's/ //g;s/"//g;s/+domain://g'`
+diff = `git diff origin/master...HEAD entries/ | grep "^+[[:space:]]*\\"domain\\":" | sed -n 's/.*"domain"[^"]*"\\(.*\\)".*/\\1/p'`
 # rubocop:enable Layout/LineLength
 # Strip and loop through diff
 diff.gsub("\n", '').split('",').each do |site|
-  begin
-    fetch_from_api(site) unless fetch_from_cache(site)
-  rescue StandardError => e
-    puts "\e[31m#{e.message}\e[39m"
-    status = 1
-  end
+  fetch_from_api(site) unless fetch_from_cache(site)
+rescue StandardError => e
+  puts "\e[31m#{e.message}\e[39m"
+  status = 1
 end
 exit(status)

--- a/tests/alexa.rb
+++ b/tests/alexa.rb
@@ -41,7 +41,9 @@ end
 
 status = 0
 # Fetch changes
-diff = `git diff origin/master...HEAD entries/ | grep "^+[[:space:]]*\\"domain\\":" | cut -c17-`
+# rubocop:disable Layout/LineLength
+diff = `git diff origin/master...HEAD entries/ | grep "^+[[:space:]]*\\"domain\\":" | sed -e 's/ //g;s/"//g;s/+domain://g'`
+# rubocop:enable Layout/LineLength
 # Strip and loop through diff
 diff.gsub("\n", '').split('",').each do |site|
   begin

--- a/tests/alexa.rb
+++ b/tests/alexa.rb
@@ -41,14 +41,14 @@ end
 
 status = 0
 # Fetch changes
-# rubocop:disable Layout/LineLength
-diff = `git diff origin/master...HEAD entries/ | grep "^+[[:space:]]*\\"domain\\":" | sed -n 's/.*"domain"[^"]*"\\(.*\\)".*/\\1/p'`
-# rubocop:enable Layout/LineLength
+diff = `git diff origin/master...HEAD entries/ | sed -n 's/^+.*"domain"[^"]*"\\(.*\\)".*/\\1/p'`
 # Strip and loop through diff
-diff.gsub("\n", '').split('",').each do |site|
-  fetch_from_api(site) unless fetch_from_cache(site)
-rescue StandardError => e
-  puts "\e[31m#{e.message}\e[39m"
-  status = 1
+diff.split('\n').each do |site|
+  begin
+    fetch_from_api(site) unless fetch_from_cache(site)
+  rescue StandardError => e
+    puts "\e[31m#{e.message}\e[39m"
+    status = 1
+  end
 end
 exit(status)

--- a/tests/alexa.rb
+++ b/tests/alexa.rb
@@ -43,7 +43,7 @@ status = 0
 # Fetch changes
 diff = `git diff origin/master...HEAD entries/ | sed -n 's/^+.*"domain"[^"]*"\\(.*\\)".*/\\1/p'`
 # Strip and loop through diff
-diff.split('\n').each do |site|
+diff.split("\n").each do |site|
   begin
     fetch_from_api(site) unless fetch_from_cache(site)
   rescue StandardError => e

--- a/tests/facebook.rb
+++ b/tests/facebook.rb
@@ -6,7 +6,7 @@ require 'uri'
 
 status = 0
 # rubocop:disable Layout/LineLength
-diff = `git diff upstream/master...HEAD entries/ | grep "^+[[:space:]]*\\"facebook\\":" | sed -e 's/ //g;s/"//g;s/+facebook://g'`
+diff = `git diff origin/master...HEAD entries/ | grep "^+[[:space:]]*\\"facebook\\":" | sed -n 's/.*"facebook"[^"]*"\\(.*\\)".*/\\1/p'`
 # rubocop:enable Layout/LineLength
 diff.gsub("\n", '').gsub(',', '').split('"').each do |page|
   url = URI("https://www.facebook.com/pg/#{page}")

--- a/tests/facebook.rb
+++ b/tests/facebook.rb
@@ -5,7 +5,9 @@ require 'net/http'
 require 'uri'
 
 status = 0
-diff = `git diff origin/master...HEAD entries/ | grep "^+[[:space:]]*\\"facebook\\":" | cut -c21-`
+# rubocop:disable Layout/LineLength
+diff = `git diff upstream/master...HEAD entries/ | grep "^+[[:space:]]*\\"facebook\\":" | sed -e 's/ //g;s/"//g;s/+facebook://g'`
+# rubocop:enable Layout/LineLength
 diff.gsub("\n", '').gsub(',', '').split('"').each do |page|
   url = URI("https://www.facebook.com/pg/#{page}")
   http = Net::HTTP.new(url.host, url.port)
@@ -16,6 +18,8 @@ diff.gsub("\n", '').gsub(',', '').split('"').each do |page|
 
     fb_page = response.header['location'].split('/').last
     raise("\"#{page}\" should be \"#{fb_page}\".") unless fb_page.eql? page
+
+    puts("#{page} is valid.")
   rescue StandardError => e
     puts "\e[31m#{e.message}\e[39m"
     status = 1

--- a/tests/facebook.rb
+++ b/tests/facebook.rb
@@ -5,10 +5,8 @@ require 'net/http'
 require 'uri'
 
 status = 0
-# rubocop:disable Layout/LineLength
-diff = `git diff origin/master...HEAD entries/ | grep "^+[[:space:]]*\\"facebook\\":" | sed -n 's/.*"facebook"[^"]*"\\(.*\\)".*/\\1/p'`
-# rubocop:enable Layout/LineLength
-diff.gsub("\n", '').gsub(',', '').split('"').each do |page|
+diff = `git diff origin/master...HEAD entries/ | sed -n 's/^+.*"facebook"[^"]*"\\(.*\\)".*/\\1/p'`
+diff.split('\n').each do |page|
   url = URI("https://www.facebook.com/pg/#{page}")
   http = Net::HTTP.new(url.host, url.port)
   http.use_ssl = true

--- a/tests/facebook.rb
+++ b/tests/facebook.rb
@@ -6,7 +6,7 @@ require 'uri'
 
 status = 0
 diff = `git diff origin/master...HEAD entries/ | sed -n 's/^+.*"facebook"[^"]*"\\(.*\\)".*/\\1/p'`
-diff.split('\n').each do |page|
+diff.split(' ').each do |page|
   url = URI("https://www.facebook.com/pg/#{page}")
   http = Net::HTTP.new(url.host, url.port)
   http.use_ssl = true

--- a/tests/facebook.rb
+++ b/tests/facebook.rb
@@ -6,7 +6,7 @@ require 'uri'
 
 status = 0
 diff = `git diff origin/master...HEAD entries/ | sed -n 's/^+.*"facebook"[^"]*"\\(.*\\)".*/\\1/p'`
-diff.split(' ').each do |page|
+diff.split("\n").each do |page|
   url = URI("https://www.facebook.com/pg/#{page}")
   http = Net::HTTP.new(url.host, url.port)
   http.use_ssl = true

--- a/tests/twitter.rb
+++ b/tests/twitter.rb
@@ -11,20 +11,20 @@ client = Twitter::REST::Client.new do |config|
 end
 
 status = 0
-diff = `git diff origin/master...HEAD entries/ | grep "^+[[:space:]]*\\"twitter\\":" | cut -c20-`
+# rubocop:disable Layout/LineLength
+diff = `git diff origin/master...HEAD entries/ | grep "^+[[:space:]]*\\"twitter\\":" | sed -e 's/ //g;s/"//g;s/+twitter:// g'`
+# rubocop:enable Layout/LineLength
 diff.gsub("\n", '').split('"').each do |handle|
   begin
-    begin
-      name = client.user(handle).screen_name
-      raise("Twitter handle \"#{handle}\" should be \"#{name}\".") unless handle.eql? name
-    rescue Twitter::Error => e
-      raise('Twitter API keys not found or invalid.') if e.instance_of? Twitter::Error::BadRequest
-      raise('Too many requests to Twitter.') if e.instance_of? Twitter::Error::TooManyRequests
-      raise("Twitter handle \"#{handle}\" not found.") if e.instance_of? Twitter::Error::NotFound
-    end
-  rescue StandardError => e
-    puts "\e[31m#{e.message}\e[39m"
-    status = 1
+    name = client.user(handle).screen_name
+    raise("Twitter handle \"#{handle}\" should be \"#{name}\".") unless handle.eql? name
+  rescue Twitter::Error => e
+    raise('Twitter API keys not found or invalid.') if e.instance_of? Twitter::Error::BadRequest
+    raise('Too many requests to Twitter.') if e.instance_of? Twitter::Error::TooManyRequests
+    raise("Twitter handle \"#{handle}\" not found.") if e.instance_of? Twitter::Error::NotFound
   end
+rescue StandardError => e
+  puts "\e[31m#{e.message}\e[39m"
+  status = 1
 end
 exit status

--- a/tests/twitter.rb
+++ b/tests/twitter.rb
@@ -11,20 +11,20 @@ client = Twitter::REST::Client.new do |config|
 end
 
 status = 0
-# rubocop:disable Layout/LineLength
-diff = `git diff origin/master...HEAD entries/ | grep "^+[[:space:]]*\\"twitter\\":" | sed -n 's/.*"twitter"[^"]*"\\(.*\\)".*/\\1/p'`
-# rubocop:enable Layout/LineLength
-diff.gsub("\n", '').split('"').each do |handle|
+diff = `git diff origin/master...HEAD entries/ | ed -n 's/^+.*"twitter"[^"]*"\\(.*\\)".*/\\1/p'`
+diff.split('\n').each do |handle|
   begin
-    name = client.user(handle).screen_name
-    raise("Twitter handle \"#{handle}\" should be \"#{name}\".") unless handle.eql? name
-  rescue Twitter::Error => e
-    raise('Twitter API keys not found or invalid.') if e.instance_of? Twitter::Error::BadRequest
-    raise('Too many requests to Twitter.') if e.instance_of? Twitter::Error::TooManyRequests
-    raise("Twitter handle \"#{handle}\" not found.") if e.instance_of? Twitter::Error::NotFound
+    begin
+      name = client.user(handle).screen_name
+      raise("Twitter handle \"#{handle}\" should be \"#{name}\".") unless handle.eql? name
+    rescue Twitter::Error => e
+      raise('Twitter API keys not found or invalid.') if e.instance_of? Twitter::Error::BadRequest
+      raise('Too many requests to Twitter.') if e.instance_of? Twitter::Error::TooManyRequests
+      raise("Twitter handle \"#{handle}\" not found.") if e.instance_of? Twitter::Error::NotFound
+    end
+  rescue StandardError => e
+    puts "\e[31m#{e.message}\e[39m"
+    status = 1
   end
-rescue StandardError => e
-  puts "\e[31m#{e.message}\e[39m"
-  status = 1
 end
 exit status

--- a/tests/twitter.rb
+++ b/tests/twitter.rb
@@ -11,12 +11,14 @@ client = Twitter::REST::Client.new do |config|
 end
 
 status = 0
-diff = `git diff origin/master...HEAD entries/ | ed -n 's/^+.*"twitter"[^"]*"\\(.*\\)".*/\\1/p'`
+diff = `git diff origin/master...HEAD entries/ | sed -n 's/^+.*"twitter"[^"]*"\\(.*\\)".*/\\1/p'`
 diff.split('\n').each do |handle|
   begin
     begin
       name = client.user(handle).screen_name
       raise("Twitter handle \"#{handle}\" should be \"#{name}\".") unless handle.eql? name
+
+      puts("#{name} is valid")
     rescue Twitter::Error => e
       raise('Twitter API keys not found or invalid.') if e.instance_of? Twitter::Error::BadRequest
       raise('Too many requests to Twitter.') if e.instance_of? Twitter::Error::TooManyRequests

--- a/tests/twitter.rb
+++ b/tests/twitter.rb
@@ -12,7 +12,7 @@ end
 
 status = 0
 # rubocop:disable Layout/LineLength
-diff = `git diff origin/master...HEAD entries/ | grep "^+[[:space:]]*\\"twitter\\":" | sed -e 's/ //g;s/"//g;s/+twitter:// g'`
+diff = `git diff origin/master...HEAD entries/ | grep "^+[[:space:]]*\\"twitter\\":" | sed -n 's/.*"twitter"[^"]*"\\(.*\\)".*/\\1/p'`
 # rubocop:enable Layout/LineLength
 diff.gsub("\n", '').split('"').each do |handle|
   begin

--- a/tests/twitter.rb
+++ b/tests/twitter.rb
@@ -12,7 +12,7 @@ end
 
 status = 0
 diff = `git diff origin/master...HEAD entries/ | sed -n 's/^+.*"twitter"[^"]*"\\(.*\\)".*/\\1/p'`
-diff.split('\n').each do |handle|
+diff.split("\n").each do |handle|
   begin
     begin
       name = client.user(handle).screen_name


### PR DESCRIPTION
This PR removes the white space on git diff lines. This in turn fixes recent build failures that where due to `cut` being incorrectly used to remove white space.

I also reformatted  twitter.rb.