### PR TITLE
Change Hosting Icon

### DIFF
--- a/_data/categories.json
+++ b/_data/categories.json
@@ -82,7 +82,7 @@
   {
     "name": "hosting",
     "title": "Hosting/VPS",
-    "icon": "fas fa-sitemap"
+    "icon": "fas fa-server"
   },
   {
     "name": "hotels",


### PR DESCRIPTION
I feel that the `fa-server` icon fits slightly better.
![image](https://user-images.githubusercontent.com/20560218/123482184-c21baa80-d5fc-11eb-8a52-9f4b950e2c17.png)