### PR TITLE
Add recovery links

### DIFF
--- a/_includes/html/desktop-table.html
+++ b/_includes/html/desktop-table.html
@@ -46,11 +46,18 @@
             {% assign tfa = website.tfa %}
 
             <td class="icon-cell">
+              <div class="row">
               {% if website.documentation %}
-                <a href="{{ website.documentation }}">
+                <a href="{{ website.documentation }}" class="col">
                   <i class="fas fa-book"></i>
                 </a>
               {% endif %}
+              {% if website.recovery %}
+                <a href="{{ website.recovery }}" class="col">
+                  <i class="fas fa-redo"></i>
+                </a>
+              {% endif %}
+              </div>
             </td>
 
             <td class="icon-cell">

--- a/_includes/scss/desktop-table.scss
+++ b/_includes/scss/desktop-table.scss
@@ -83,7 +83,8 @@
           }
 
           .fa-book,
-          .tfa-icon {
+          .tfa-icon,
+          .fa-redo {
             font-size: 27px;
             line-height: 35px;
           }


### PR DESCRIPTION
Resolves #1348 and the new issue #5892.
This also applies to the desktop view. I'm uncertain if adding recovery links to the mobile view would help more than it would clutter the limited space available.

The updated view looks like this:
![screenshot](https://user-images.githubusercontent.com/3535780/124003181-ef8a9e80-d9d6-11eb-9f1c-714b1e44cdda.png)

