### PR TITLE
Update Twitter

### DIFF
--- a/entries/t/twitter.com.json
+++ b/entries/t/twitter.com.json
@@ -6,8 +6,9 @@
       "totp",
       "u2f"
     ],
-    "documentation": "https://support.twitter.com/articles/20170388",
-    "notes": "Hardware 2FA requires enabling back-up method. SMS only available on select providers.",
+    "documentation": "https://help.twitter.com/en/managing-your-account/two-factor-authentication",
+    "recovery": "https://help.twitter.com/en/managing-your-account/issues-with-login-authentication",
+    "notes": "SMS only available on select providers.",
     "keywords": [
       "social"
     ]


### PR DESCRIPTION
Twitter now allows users to add a security key without enabling a backup method. 
See:
https://www.theverge.com/2021/6/30/22558238/twitter-physical-security-two-factor-authentication-2fa
and/or
https://blog.twitter.com/en_us/topics/product/2020/stronger-security-for-your-twitter-account