### PR TITLE
Update twitter.com.json

### DIFF
--- a/entries/t/twitter.com.json
+++ b/entries/t/twitter.com.json
@@ -7,7 +7,6 @@
       "u2f"
     ],
     "documentation": "https://support.twitter.com/articles/20170388",
-    "notes": "Hardware 2FA requires enabling back-up method. SMS only available on select providers.",
     "keywords": [
       "social"
     ]


### PR DESCRIPTION
hardware keys no longer require another backup 2fa method https://twitter.com/TwitterSupport/status/1410343864431374340?s=20