### PR TITLE
Update Microsoft Services

### DIFF
--- a/entries/o/onedrive.live.com.json
+++ b/entries/o/onedrive.live.com.json
@@ -6,8 +6,7 @@
       "call",
       "email",
       "custom-software",
-      "totp",
-      "u2f"
+      "totp"
     ],
     "documentation": "https://support.microsoft.com/en-us/help/12408/",
     "notes": "2FA phone calls may not be available in all regions",

--- a/entries/o/outlook.com.json
+++ b/entries/o/outlook.com.json
@@ -6,8 +6,7 @@
       "call",
       "email",
       "custom-software",
-      "totp",
-      "u2f"
+      "totp"
     ],
     "documentation": "https://support.microsoft.com/en-us/help/12408/",
     "notes": "2FA phone calls may not be available in all regions",

--- a/entries/s/skype.com.json
+++ b/entries/s/skype.com.json
@@ -6,8 +6,7 @@
       "sms",
       "email",
       "custom-software",
-      "totp",
-      "u2f"
+      "totp"
     ],
     "documentation": "https://support.microsoft.com/en-us/help/12408/",
     "notes": "Must be associated with a Microsoft Account.",

--- a/entries/t/todo.microsoft.com.json
+++ b/entries/t/todo.microsoft.com.json
@@ -6,8 +6,7 @@
       "call",
       "email",
       "custom-software",
-      "totp",
-      "u2f"
+      "totp"
     ],
     "documentation": "https://support.microsoft.com/en-us/help/12408/",
     "notes": "2FA phone calls may not be available in all regions",

--- a/entries/v/visualstudio.microsoft.com.json
+++ b/entries/v/visualstudio.microsoft.com.json
@@ -5,8 +5,7 @@
       "sms",
       "email",
       "custom-software",
-      "totp",
-      "u2f"
+      "totp"
     ],
     "documentation": "https://support.microsoft.com/en-us/help/12408/",
     "keywords": [

--- a/entries/x/xbox.com.json
+++ b/entries/x/xbox.com.json
@@ -7,8 +7,7 @@
       "email",
       "custom-software",
       "call",
-      "totp",
-      "u2f"
+      "totp"
     ],
     "documentation": "https://support.microsoft.com/en-us/help/12408/",
     "notes": "2FA phone calls may not be available in all regions",


### PR DESCRIPTION
Security keys can only be used as a paswordless login method, not as a second factor. This esentially makes the first factor "something you have", rather than "something you know", but does not constitute 2FA, as there is no second factor involved.