### PR TITLE
Update Geforce

### DIFF
--- a/entries/g/geforce.com.json
+++ b/entries/g/geforce.com.json
@@ -1,11 +1,16 @@
 {
   "GeForce (Nvidia)": {
     "domain": "geforce.com",
-    "url": "https://www.geforce.com/",
-    "contact": {
-      "facebook": "NVIDIAGeForce",
-      "twitter": "NVIDIAGeForce"
-    },
+    "additional-domains": [
+      "nvidia.com",
+      "login.nvgs.nvidia.com"
+    ],
+    "tfa": [
+      "email",
+      "totp",
+      "u2f"
+    ],
+    "documentation": "https://login.nvgs.nvidia.com/v1/help/nfactor",
     "keywords": [
       "gaming"
     ]

--- a/entries/g/geforce.com.json
+++ b/entries/g/geforce.com.json
@@ -11,7 +11,7 @@
       "u2f"
     ],
     "documentation": "https://login.nvgs.nvidia.com/v1/help/nfactor",
-    "notes": "Email 2FA is always enabled."
+    "notes": "Email 2FA is always enabled.",
     "keywords": [
       "gaming"
     ]

--- a/entries/g/geforce.com.json
+++ b/entries/g/geforce.com.json
@@ -11,6 +11,7 @@
       "u2f"
     ],
     "documentation": "https://login.nvgs.nvidia.com/v1/help/nfactor",
+    "notes": "Email 2FA is always enabled."
     "keywords": [
       "gaming"
     ]


### PR DESCRIPTION
Although the default is authorisation when adding a 2FA method, settings can be changed to force 2 factor authentication rather than authorisation.
![image](https://user-images.githubusercontent.com/20560218/126873974-ddb3caed-9e2a-47ed-8a1a-c5d2bff5ecb5.png)
