### PR TITLE
Update Ring.

### DIFF
--- a/entries/r/ring.com.json
+++ b/entries/r/ring.com.json
@@ -3,7 +3,7 @@
     "domain": "ring.com",
     "tfa": [
       "sms",
-      "email"
+      "totp"
     ],
     "documentation": "https://support.ring.com/hc/en-us/articles/360039693891",
     "keywords": [


### PR DESCRIPTION
Ring deprecated email as a form of 2FA and now supports authenticator apps.

Closes https://github.com/2factorauth/twofactorauth/issues/6024