### PR TITLE
Update Bitwarden

### DIFF
--- a/entries/b/bitwarden.com.json
+++ b/entries/b/bitwarden.com.json
@@ -11,7 +11,7 @@
       "custom-software"
     ],
     "documentation": "https://help.bitwarden.com/article/setup-two-step-login/",
-    "notes": "Premium account required for Duo, YubiKey and FIDO U2F.",
+    "notes": "Premium account required for Duo, YubiKey and FIDO U2F. Teams or Enterprise account required for SMS and phone call",
     "keywords": [
       "identity"
     ]

--- a/entries/b/bitwarden.com.json
+++ b/entries/b/bitwarden.com.json
@@ -11,7 +11,7 @@
       "custom-software"
     ],
     "documentation": "https://help.bitwarden.com/article/setup-two-step-login/",
-    "notes": "Premium account required for Duo, YubiKey and FIDO U2F. Teams or Enterprise account required for SMS and phone call",
+    "notes": "2FA options offered differ depending on subscription plan.",
     "keywords": [
       "identity"
     ]


### PR DESCRIPTION
added additional notes to explain that a team or enterprise account is required to use sms  or phone call for 2nd factor