### PR TITLE
feat: check for superfluous img properties in validate-images.rb

### DIFF
--- a/tests/validate-images.rb
+++ b/tests/validate-images.rb
@@ -23,6 +23,11 @@ Dir.glob('entries/*/*.json') do |file|
     status = 1
   end
 
+  if !website['img'].nil? && website['img'].eql?("#{website['domain']}.svg")
+    puts "::error file=#{file}:: Defining the img property for #{website['domain']} is not necessary - '#{website['img']}' is the default value"
+    status = 1
+  end
+
   seen_sites.push(path)
 end
 


### PR DESCRIPTION
This PR adds an additional automated check to identify unneeded `img` fields. @ApCoder123 mentioned this on a recent PR of mine (https://github.com/2factorauth/twofactorauth/pull/6023#discussion_r680555415) and, to save you all time, I thought it would be nice if the automated test suites captured this state.

Here's a local test/validation:

<img width="1387" alt="Screen Shot 2021-08-03 at 5 14 22 PM" src="https://user-images.githubusercontent.com/630449/128097955-264cf0ac-f861-4dac-9e6b-d3e4cf2e2d0a.png">
