### PR TITLE
Fix contact email/tweet message

### DIFF
--- a/js/social-media.js
+++ b/js/social-media.js
@@ -7,9 +7,9 @@ $('.facebook-button').click(function () {
 $('.email-button').click(function () {
   let langs = new Map();
 {% for lang in site.data.languages %}
-  {% unless lang[1].email_subject == '' %}
+  {% if lang[1].email_subject %}
   langs.set("{{ lang[0] }}", "{{ lang[1].email_subject }}");
-  {% endunless %}
+  {% endif %}
 {% endfor %}
 let lang = $(this).data('lang')
 
@@ -20,9 +20,9 @@ let lang = $(this).data('lang')
 $('.twitter-button').click(function () {
   let langs = new Map();
 {% for lang in site.data.languages %}
-  {% unless lang[1].tweet == '' %}
+  {% if lang[1].tweet %}
   langs.set("{{ lang[0] }}", "{{ lang[1].tweet |cgi_escape }}");
-  {% endunless %}
+  {% endif %}
 {% endfor %}
 
 let lang = $(this).data('lang')


### PR DESCRIPTION
Currently when a language has a twitter message but not a email subject, email subjects are being overwritten with an empty string instead of using English as the default email subject language. This is due to incorrect null checking for email subjects and tweets.

E.g. when the site is built, this is what appears in `social-media.js`
```
a.set("cs","")
a.set("de","Unterst\xFCtzung von Zwei-Faktor-Authentifizierung")
a.set("en","Support Two Factor Authentication")
a.set("es","Considere implementar autenticaci\xF3n de doble factor")
a.set("fr","")
a.set("it","Suportare l'autenticazione a due fattori")
a.set("pt","")
a.set("sv","")
```