### PR TITLE
Check for superfluous url entry

### DIFF
--- a/entries/u/usefathom.com.json
+++ b/entries/u/usefathom.com.json
@@ -1,7 +1,6 @@
 {
     "Fathom Analytics" : {
         "domain": "usefathom.com",
-        "url": "https://usefathom.com",
         "tfa":[
             "totp"
         ],

--- a/tests/validate-json.rb
+++ b/tests/validate-json.rb
@@ -33,6 +33,14 @@ Dir.glob('entries/*/*.json') do |file|
     status = 1
   end
 
+  domain = document.values[0]['domain']
+  url = document.values[0]['url']
+  default_url = "https://#{domain}"
+  if !url.nil? && ( url.eql?(default_url) || url.eql?(default_url+"/") )
+    puts "::error file=#{file}:: Defining the url property for #{domain} is not necessary - '#{default_url}' is the default value"
+    status = 1
+  end
+  
   keywords = document.values[0]['keywords']
   keywords.each do |kw|
     unless categories.include? kw


### PR DESCRIPTION
Similar to #6029, this checks for default `url` values

(usefathom.com.json was the sole offender)