### PR TITLE
Fix Docker Issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,10 @@
 FROM ruby:2.7-alpine
-WORKDIR /twofactorauth
+WORKDIR /app
 COPY Gemfile .
 COPY ./scripts/entrypoint.sh .
 RUN apk add --no-cache build-base git bash dos2unix npm gnupg
-RUN bundle config set path '/twofactorauth/vendor/cache'
+RUN bundle config set path './vendor/cache'
 RUN bundle install
 RUN npm i -g babel-minify
 RUN chmod +x entrypoint.sh
-WORKDIR /twofactorauth/site
-ENTRYPOINT ["/twofactorauth/entrypoint.sh"]
+ENTRYPOINT ["./entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 COPY Gemfile .
 COPY ./scripts/entrypoint.sh .
 RUN apk add --no-cache build-base git bash dos2unix npm gnupg
-RUN bundle config set path './vendor/cache'
+RUN bundle config set path '/app/vendor/cache'
 RUN bundle install
 RUN npm i -g babel-minify
 RUN chmod +x entrypoint.sh

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 cd /twofactorauth
-bundle config set path '/app/vendor/cache'
 
 if [ -z "${SKIP_DOS2UNIX}" ]; then
   echo "Converting scripts to Unix format:"

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
-cd /twofactorauth/site
-bundle config set path '/twofactorauth/vendor/cache'
+cd /twofactorauth
+bundle config set path '/app/vendor/cache'
 
 if [ -z "${SKIP_DOS2UNIX}" ]; then
   echo "Converting scripts to Unix format:"
@@ -19,6 +19,7 @@ fi
 
 if [ -z "${SKIP_BUILD}" ]; then
   echo "Building site:"
+  ruby ./scripts/join-entries.rb > _data/all.json
   bundle exec jekyll build
   if [ -z "${SKIP_REGIONS}" ]; then
     echo "Generating regions:"
@@ -30,3 +31,5 @@ if [ -z "${SKIP_MINIFY}" ]; then
   echo "Minifying JavaScript files:"
   ./scripts/minify-js.sh
 fi
+
+bundle exec jekyll serve --skip-initial-build --host=0.0.0.0

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -14,7 +14,9 @@ if [ -z "${SKIP_API}" ]; then
   mkdir -p api/v2
   mkdir -p api/v3
   echo "Generating API files:"
-  ruby ./scripts/APIv*.rb
+  ruby ./scripts/APIv1.rb
+  ruby ./scripts/APIv2.rb
+  ruby ./scripts/APIv3.rb
 fi
 
 if [ -z "${SKIP_BUILD}" ]; then

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -14,9 +14,9 @@ if [ -z "${SKIP_API}" ]; then
   mkdir -p api/v2
   mkdir -p api/v3
   echo "Generating API files:"
-  ruby ./scripts/APIv1.rb
-  ruby ./scripts/APIv2.rb
-  ruby ./scripts/APIv3.rb
+  for script in ./scripts/APIv*.rb; do
+    ruby "$script"
+  done
 fi
 
 if [ -z "${SKIP_BUILD}" ]; then


### PR DESCRIPTION
Currently when running the site in a docker container, an error is encountered where `./entrypoint.sh` cannot be found, as when mounting a volume to `/twofactorauth`, the existing content (e.g. entrypoint) is overwritten. Additionally, there were missing steps in the entrypoint.sh file, such as not joining entries to `_data/all.json`. 

This PR modifies the Dockerfile and entrypoint to (attempt to) fix all of these issues and allow the site to be run.

```bash
docker build -t twofactorauth .
docker run -p 4000:4000 -v $(pwd):/twofactorauth twofactorauth
```