### PR TITLE
Optimise gem installs

### DIFF
--- a/.github/workflows/repository.yml
+++ b/.github/workflows/repository.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Bundle install
         run: |
-          bundle set without jekyll_plugins
+          bundle config set without jekyll_plugins
           bundle install
       - uses: actions/cache@v2
         with:
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Bundle install
         run: | 
-          bundle set without test
+          bundle config set without test
           bundle install
       - name: Generate API files
         run: |
@@ -86,7 +86,7 @@ jobs:
         run: tar -xzf build.tar.gz
       - name: Bundle install
         run: |
-          bundle set without test
+          bundle config set without test
           bundle install
       - name: Install GnuPG
         run: apk add --no-cache gnupg

--- a/.github/workflows/repository.yml
+++ b/.github/workflows/repository.yml
@@ -9,7 +9,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Bundle install
-        run: bundle install
+        run: |
+          bundle set without jekyll_plugins
+          bundle install
       - uses: actions/cache@v2
         with:
           path: |
@@ -34,7 +36,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Bundle install
-        run: bundle install
+        run: | 
+          bundle set without test
+          bundle install
       - name: Generate API files
         run: |
           mkdir -p api/v1
@@ -81,7 +85,9 @@ jobs:
       - name: Extract artifact
         run: tar -xzf build.tar.gz
       - name: Bundle install
-        run: bundle install
+        run: |
+          bundle set without test
+          bundle install
       - name: Install GnuPG
         run: apk add --no-cache gnupg
       - uses: crazy-max/ghaction-import-gpg@v3

--- a/Gemfile
+++ b/Gemfile
@@ -9,12 +9,7 @@ group :jekyll_plugins do
 end
 
 group :test do
-  gem 'diffy'
-  gem 'fastimage'
-  gem 'html-proofer'
-  gem 'jsonlint'
   gem 'json_schemer'
-  gem 'kwalify'
   gem 'rubocop'
   gem 'twitter'
 end


### PR DESCRIPTION
I've removed some unused dependencies from the `Gemfile` that used to be used in the old Rakefile and `verify.rb` test. I've also modified some of the installs in the GitHub Actions workflow to avoid installing unnecessary dependencies (i.e. ignore `jekyll_plugins` group for Tests, which should speed up execution time.