### PR TITLE
Rework join-entries.rb

### DIFF
--- a/entries/m/myemma.com.json
+++ b/entries/m/myemma.com.json
@@ -7,7 +7,7 @@
     ],
     "documentation": "https://support.e2ma.net/s/article/Two-factor-authentication",
     "keywords": [
-      "communication"
+      "marketing"
     ]
   }
 }

--- a/scripts/join-entries.rb
+++ b/scripts/join-entries.rb
@@ -5,10 +5,11 @@
 
 require 'json'
 
-entries = {}
+entries = []
+
 Dir.glob('entries/*/*.json') do |file|
-  name = JSON.parse(File.read(file))
-  name.each { |k, v| entries[k] = v }
+  entry = JSON.parse(File.read(file))
+  entries.push([entry.keys[0], entry.values[0]])
 end
 
-puts JSON.generate(entries.sort_by{ |k,v| k.downcase })
+puts JSON.generate(entries.sort_by { |a| a[0].downcase })


### PR DESCRIPTION
I've reworked the join-entries.rb script to allow for entries with the same name. 

The only test case I can see is Emma (emma.ca/myemma.com).

Before:
![image](https://user-images.githubusercontent.com/20560218/130455672-894f1ffc-6e04-4f64-b71b-666eeb142f30.png)

After:
![image](https://user-images.githubusercontent.com/20560218/130455644-1cc2607b-5913-44b9-9d33-4b18b2d3fe54.png)
