### PR TITLE
Update playstation.com.json Documentation Link

### DIFF
--- a/entries/p/playstation.com.json
+++ b/entries/p/playstation.com.json
@@ -6,7 +6,7 @@
       "sms",
       "totp"
     ],
-    "documentation": "https://playstation.com/support/2sv/",
+    "documentation": "https://www.playstation.com/support/account/2sv-psn-login/",
     "keywords": [
       "gaming"
     ]


### PR DESCRIPTION
Previous documentation link resulted in HTTP 404 error