### PR TITLE
Add translation of some elements in Korean

### DIFF
--- a/_data/languages.yml
+++ b/_data/languages.yml
@@ -19,6 +19,9 @@ he:
 it:
   email_subject: Suportare l'autenticazione a due fattori
   tweet: La sicurezza è importante, @TWITTERHANDLE. Ci piacerebbe che supportaste l'autenticazione a due fattori (2FA).
+ko:
+  email_subject: 2단계 인증 지원을 요청합니다
+  tweet: @TWITTERHANDLE, 보안은 중요합니다. 웹 사이트에 2단계 인증(2FA)을 추가해 주세요.
 pt:
   tweet: A segurança é importante, @TWITTERHANDLE. Agradecemos que suportasse a autenticação de dois fatores (2FA).
 sv:

--- a/_data/languages.yml
+++ b/_data/languages.yml
@@ -20,8 +20,8 @@ it:
   email_subject: Suportare l'autenticazione a due fattori
   tweet: La sicurezza è importante, @TWITTERHANDLE. Ci piacerebbe che supportaste l'autenticazione a due fattori (2FA).
 ko:
-  email_subject: 2단계 인증 지원을 요청합니다
-  tweet: @TWITTERHANDLE, 보안은 중요합니다. 웹 사이트에 2단계 인증(2FA)을 추가해 주세요.
+  email_subject: "2단계 인증 지원을 요청합니다"
+  tweet: "@TWITTERHANDLE, 보안은 중요합니다. 웹 사이트에 2단계 인증(2FA)을 추가해 주세요."
 pt:
   tweet: A segurança é importante, @TWITTERHANDLE. Agradecemos que suportasse a autenticação de dois fatores (2FA).
 sv:

--- a/_data/regions.yml
+++ b/_data/regions.yml
@@ -20,6 +20,9 @@
 - id: it
   name: Italy
 
+- id: kr
+  name: South Korea
+
 - id: nl
   name: Netherlands
 

--- a/_data/regions.yml
+++ b/_data/regions.yml
@@ -20,9 +20,6 @@
 - id: it
   name: Italy
 
-- id: kr
-  name: South Korea
-
 - id: nl
   name: Netherlands
 


### PR DESCRIPTION
While it is a bit sad that the website itself is not available in other languages, I want to add Korean translation of e-mail titles and tweets. Also some websites indicate "kr" as available region, so I added that entity too.