### PR TITLE
Add more regions

### DIFF
--- a/_data/regions.yml
+++ b/_data/regions.yml
@@ -4,6 +4,12 @@
 - id: au
   name: Australia
 
+- id: be
+  name: Belgium
+
+- id: br
+  name: Brazil
+
 - id: ca
   name: Canada
 
@@ -14,20 +20,50 @@
 - id: de
   name: Germany
 
+- id: dk
+  name: Denmark
+
+- id: es
+  name: Spain
+
+- id: fi
+  name: Finland
+
 - id: fr
   name: France
+
+- id: ie
+  name: Ireland
+
+- id: in
+  name: India
 
 - id: it
   name: Italy
 
+- id: jp
+  name: Japan
+
 - id: nl
   name: Netherlands
+
+- id: "no"
+  name: Norway
 
 - id: nz
   name: New Zealand
 
+- id: mx
+  name: Mexico
+
+- id: pl
+  name: Poland
+
 - id: se
   name: Sweden
+
+- id: sg
+  name: Singapore
 
 - id: gb
   name: United Kingdom

--- a/css/navbar.scss
+++ b/css/navbar.scss
@@ -22,6 +22,8 @@
 
   .dropdown-menu {
     position: absolute !important; // Bootstrap normally sets position static for dropdowns in mobile views
+    background: #eeeeee;
+    z-index: 1100; // higher than ".cat"
 
     .dropdown-item {
       .flag-icon, .fas {


### PR DESCRIPTION
These regions have 10 or more entries associated with them.

The menu background is now opaque grey to make the white flag parts stand out more.

Also, the menu is now so tall that it runs into the categories, so the `z-index` had to be adjusted.