### PR TITLE
add note that fastmail requires SMS as a backup

### DIFF
--- a/entries/f/fastmail.com.json
+++ b/entries/f/fastmail.com.json
@@ -9,6 +9,7 @@
       "u2f"
     ],
     "documentation": "https://www.fastmail.com/help/account/2fa.html",
+    "notes": "SMS must be set up as a backup method.",
     "keywords": [
       "email"
     ]

--- a/entries/f/fastmail.com.json
+++ b/entries/f/fastmail.com.json
@@ -9,7 +9,7 @@
       "u2f"
     ],
     "documentation": "https://www.fastmail.com/help/account/2fa.html",
-    "notes": "SMS must be set up as a backup method.",
+    "notes": "Setup requires SMS verification.",
     "keywords": [
       "email"
     ]


### PR DESCRIPTION
Documented here: https://www.fastmail.com/help/account/2fa.html


> To help make sure that you are not locked out of your own account, before you can enable two-step verification, you must add a recovery phone to your account. If you ever lose access to your primary form of two-step verification, your recovery phone can be used to prevent you from being locked out of your account. You get a code sent to your phone instead to complete your second step when you log in.
