### PR TITLE
Docker workflow fix v3

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,7 +34,7 @@ jobs:
         uses: docker/build-push-action@v2.7.0
         with:
           context: .
-          platforms: linux/amd64,linux/arm/v7,linux/arm64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ${{ GITHUB.REPOSITORY }}:latest


### PR DESCRIPTION
At least the workflow ran this time...

[ruby:2.7-alpine](https://hub.docker.com/layers/ruby/library/ruby/2.7-alpine/images/sha256-04e3608e72a2cd4a7ebe140da5620ee4bfa98190641bd02867fd599bb64e49fb?context=explore) doesn't support arm/v7