### PR TITLE
Replace custom-hardware references with U2F

### DIFF
--- a/entries/b/boxcryptor.com.json
+++ b/entries/b/boxcryptor.com.json
@@ -4,7 +4,7 @@
     "url": "https://www.boxcryptor.com",
     "tfa": [
       "totp",
-      "custom-hardware"
+      "u2f"
     ],
     "documentation": "https://www.boxcryptor.com/help/boxcryptor-account/#two-factor-authentication",
     "keywords": [

--- a/entries/b/braintreepayments.com.json
+++ b/entries/b/braintreepayments.com.json
@@ -5,7 +5,7 @@
     "tfa": [
       "sms",
       "totp",
-      "custom-hardware"
+      "u2f"
     ],
     "documentation": "https://articles.braintreepayments.com/reference/security/two-factor-authentication",
     "keywords": [

--- a/entries/d/dmarcian.com.json
+++ b/entries/d/dmarcian.com.json
@@ -3,7 +3,7 @@
     "domain": "dmarcian.com",
     "tfa": [
       "totp",
-      "custom-hardware"
+      "u2f"
     ],
     "documentation": "https://dmarcian.com/secure-dmarcian-2fa/",
     "keywords": [

--- a/entries/o/onelogin.com.json
+++ b/entries/o/onelogin.com.json
@@ -6,7 +6,8 @@
       "custom-software",
       "sms",
       "totp",
-      "custom-hardware"
+      "custom-hardware",
+      "u2f"
     ],
     "documentation": "https://onelogin.service-now.com/support?id=kb_article&sys_id=43d99143db109700d5505eea4b96197a",
     "keywords": [

--- a/entries/p/porkbun.com.json
+++ b/entries/p/porkbun.com.json
@@ -3,7 +3,7 @@
     "domain": "porkbun.com",
     "tfa": [
       "totp",
-      "custom-hardware"
+      "u2f"
     ],
     "documentation": "https://kb.porkbun.com/category/20--",
     "keywords": [

--- a/entries/s/stripe.com.json
+++ b/entries/s/stripe.com.json
@@ -5,7 +5,7 @@
     "tfa": [
       "sms",
       "totp",
-      "custom-hardware"
+      "u2f"
     ],
     "documentation": "https://support.stripe.com/questions/how-do-i-enable-two-step-verification",
     "keywords": [

--- a/entries/s/stripe.com.json
+++ b/entries/s/stripe.com.json
@@ -5,7 +5,11 @@
     "tfa": [
       "sms",
       "totp",
-      "u2f"
+      "u2f",
+      "custom-hardware"
+    ],
+    "custom-hardware": [
+      "Biometrics - Windows Hello / Apple Touch ID"
     ],
     "documentation": "https://support.stripe.com/questions/how-do-i-enable-two-step-verification",
     "keywords": [

--- a/entries/v/vanguard.com.json
+++ b/entries/v/vanguard.com.json
@@ -6,10 +6,10 @@
     "tfa": [
       "sms",
       "call",
-      "custom-hardware"
+      "u2f"
     ],
     "documentation": "https://investor.vanguard.com/security/security-keys",
-    "notes": "Hardware based 2FA requires SMS / Phone call 2FA as a backup. Hardware 2FA only works with the following hardware keys: Yubikey 4 Series, YubiKey 5 Series, Yubikey Security Key Series.",
+    "notes": "Hardware based 2FA requires SMS / Phone call 2FA as a backup.",
     "keywords": [
       "investing"
     ]

--- a/entries/v/vanguard.com.json
+++ b/entries/v/vanguard.com.json
@@ -6,7 +6,11 @@
     "tfa": [
       "sms",
       "call",
-      "u2f"
+      "u2f",
+      "custom-hardware"
+    ],
+    "custom-hardware": [
+      "Voice Verification"
     ],
     "documentation": "https://investor.vanguard.com/security/security-keys",
     "notes": "Hardware based 2FA requires SMS / Phone call 2FA as a backup.",

--- a/entries/w/weclapp.com.json
+++ b/entries/w/weclapp.com.json
@@ -4,9 +4,9 @@
     "img": "weclapp.com.png",
     "tfa": [
       "totp",
-      "custom-hardware"
+      "u2f"
     ],
-    "documentation": "https://doc.weclapp.com/knowledgebase/zwei-wege-authentifizierung-2fa/",
+    "documentation": "https://doc.weclapp.com/en/documentation/dein-start-mit-weclapp/2-my-weclapp-personal-master-and-contact-data/2-4-security/2-factor-authentication/",
     "keywords": [
       "other"
     ]


### PR DESCRIPTION
There were a couple entries that support U2F/WebAuthn, but were labelled as `custom-hardware`.