### PR TITLE
Use absolute paths for notes

### DIFF
--- a/entries/c/chase.com.json
+++ b/entries/c/chase.com.json
@@ -7,7 +7,7 @@
       "call",
       "email"
     ],
-    "documentation": "/notes/chase/",
+    "documentation": "https://2fa.directory/notes/chase/",
     "keywords": [
       "banking"
     ],

--- a/entries/i/internetbs.net.json
+++ b/entries/i/internetbs.net.json
@@ -4,7 +4,7 @@
     "tfa": [
       "totp"
     ],
-    "documentation": "/notes/internetbs/",
+    "documentation": "https://2fa.directory/notes/internetbs/",
     "keywords": [
       "domains"
     ]

--- a/entries/i/internetbs.net.json
+++ b/entries/i/internetbs.net.json
@@ -1,6 +1,7 @@
 {
   "Internet.bs": {
     "domain": "internetbs.net",
+    "url": "http://internetbs.net",
     "tfa": [
       "totp"
     ],

--- a/entries/i/internetbs.net.json
+++ b/entries/i/internetbs.net.json
@@ -1,7 +1,6 @@
 {
   "Internet.bs": {
     "domain": "internetbs.net",
-    "url": "http://internetbs.net",
     "tfa": [
       "totp"
     ],

--- a/tests/schema.json
+++ b/tests/schema.json
@@ -35,7 +35,7 @@
         "documentation": {
           "type": "string",
           "format": "uri-reference",
-          "pattern": "^(https:|http:|\/notes\/)"
+          "pattern": "^(https:|http:)"
         },
         "recovery": {
           "type": "string",

--- a/tests/validate-urls.rb
+++ b/tests/validate-urls.rb
@@ -29,7 +29,7 @@ diff&.each do |path|
   entry['additional-domains']&.each { |domain| curl("https://#{domain}/") }
 
   # Process documentation and recovery URLs
-  curl(entry['documentation']) if entry.key?('documentation') && !entry['documentation'].start_with?('/notes/')
+  curl(entry['documentation']) if entry.key?('documentation')
   curl(entry['recovery']) if entry.key? 'recovery'
 end
 exit(@status)


### PR DESCRIPTION
Currently, any entries with a `/notes` page for their documentation use the relative path. From what I can tell (#894), this was to help test locally. However, currently, these relative paths are appearing in the API files, which is probably not the desired behaviour. 