### PR TITLE
Multiple tweet messages

### DIFF
--- a/_data/languages.yml
+++ b/_data/languages.yml
@@ -38,3 +38,4 @@ pt:
 sv:
   tweets:
     - Säkerhet är viktigt, @TWITTERHANDLE. Vänligen lägg till two factor authentication på er hemsida.
+    - @TWITTERHANDLE snälla lägg till tvåfaktorsautentisering för användare.

--- a/_data/languages.yml
+++ b/_data/languages.yml
@@ -38,4 +38,4 @@ pt:
 sv:
   tweets:
     - Säkerhet är viktigt, @TWITTERHANDLE. Vänligen lägg till two factor authentication på er hemsida.
-    - @TWITTERHANDLE snälla lägg till tvåfaktorsautentisering för användare.
+    - "@TWITTERHANDLE snälla lägg till tvåfaktorsautentisering för användare."

--- a/_data/languages.yml
+++ b/_data/languages.yml
@@ -7,6 +7,8 @@ de:
   email_subject: Unterstützung von Zwei-Faktor-Authentifizierung
   tweets: 
     - Sicherheit ist wichtig, @TWITTERHANDLE. Bitte aktiviert Zwei-Faktor-Authentifizierung auf eurer Webseite.
+    - Zwei-Faktor-Authentifizierung ist ein wichtiges Sicherheitsmerkmal. Bitte unterstützt dies doch auch, @TWITTERHANDLE.
+    - Wir würden es sehr begrüßen, wenn ihr Zwei-Faktor-Authentifizierung unterstützen würdet, @TWITTERHANDLE. Die Sicherheit der Accounts wird dadurch wesentlich erhöht.
 en:
   email_subject: Support Two Factor Authentication
   tweets: 

--- a/_data/languages.yml
+++ b/_data/languages.yml
@@ -1,28 +1,40 @@
 # Languages should be categorized according to ISO 639-1
 # Language codes (including within data files) should be in lowercase
 cs:
-  tweet: Bezpečnost je důležitá, @TWITTERHANDLE. Byli bychom rádi, kdybyste podporovali dvoufaktorové ověření.
+  tweets: 
+    - Bezpečnost je důležitá, @TWITTERHANDLE. Byli bychom rádi, kdybyste podporovali dvoufaktorové ověření.
 de:
   email_subject: Unterstützung von Zwei-Faktor-Authentifizierung
-  tweet: Sicherheit ist wichtig, @TWITTERHANDLE. Bitte aktiviert Zwei-Faktor-Authentifizierung auf eurer Webseite.
+  tweets: 
+    - Sicherheit ist wichtig, @TWITTERHANDLE. Bitte aktiviert Zwei-Faktor-Authentifizierung auf eurer Webseite.
 en:
   email_subject: Support Two Factor Authentication
-  tweet: Security is important, @TWITTERHANDLE. We'd like it if you supported two factor authentication.
+  tweets: 
+    - Security is important, @TWITTERHANDLE. We'd like it if you supported two factor authentication.
+    - Two factor authentication is an important security feature. We'd like to see it supported @TWITTERHANDLE.
+    - We'd appreciate it if you could support two factor authentication @TWITTERHANDLE. It greatly improves account security.
 es:
   email_subject: Considere implementar autenticación de doble factor
-  tweet: La seguridad es importante, @TWITTERHANDLE. Nos gustaría que consideren implementar autenticación de doble factor (2FA).
+  tweets: 
+    - La seguridad es importante, @TWITTERHANDLE. Nos gustaría que consideren implementar autenticación de doble factor (2FA).
 fr:
-  tweet: La sécurité est importante @TWITTERHANDLE. C'est pour quand la double authentification (2FA)?
+  tweets: 
+    - La sécurité est importante @TWITTERHANDLE. C'est pour quand la double authentification (2FA)?
 he:
   email_subject: תמיכה באימות דו-שלבי
-  tweet: אבטחת מידע היא דבר חשוב, @TWITTERHANDLE. מתי תתמכו באימות דו-שלבי?
+  tweets:
+    - אבטחת מידע היא דבר חשוב, @TWITTERHANDLE. מתי תתמכו באימות דו-שלבי?
 it:
   email_subject: Suportare l'autenticazione a due fattori
-  tweet: La sicurezza è importante, @TWITTERHANDLE. Ci piacerebbe che supportaste l'autenticazione a due fattori (2FA).
+  tweets: 
+    - La sicurezza è importante, @TWITTERHANDLE. Ci piacerebbe che supportaste l'autenticazione a due fattori (2FA).
 ko:
   email_subject: "2단계 인증 지원을 요청합니다"
-  tweet: "@TWITTERHANDLE, 보안은 중요합니다. 웹 사이트에 2단계 인증(2FA)을 추가해 주세요."
+  tweets: 
+    - "@TWITTERHANDLE, 보안은 중요합니다. 웹 사이트에 2단계 인증(2FA)을 추가해 주세요."
 pt:
-  tweet: A segurança é importante, @TWITTERHANDLE. Agradecemos que suportasse a autenticação de dois fatores (2FA).
+  tweets: 
+    - A segurança é importante, @TWITTERHANDLE. Agradecemos que suportasse a autenticação de dois fatores (2FA).
 sv:
-  tweet: Säkerhet är viktigt, @TWITTERHANDLE. Vänligen lägg till two factor authentication på er hemsida.
+  tweets:
+    - Säkerhet är viktigt, @TWITTERHANDLE. Vänligen lägg till two factor authentication på er hemsida.

--- a/js/social-media.js
+++ b/js/social-media.js
@@ -34,7 +34,7 @@ let lang = $(this).data('lang')
   const handle = $(this).data('twitter')
 
   if (!langs.has(lang) || lang == null) lang = "en"
-  const index = Math.floor(Math.random() * ((langs.get(lang).length-1) - 0 + 1) + 0);
+  const index = Math.floor(Math.random() * langs.get(lang).length);
   const text = langs.get(lang)[index].replace('TWITTERHANDLE', handle)
 
   window.open('https://twitter.com/share?hashtags=SupportTwoFactorAuth&text=' + text, '_blank');

--- a/js/social-media.js
+++ b/js/social-media.js
@@ -19,9 +19,14 @@ let lang = $(this).data('lang')
 
 $('.twitter-button').click(function () {
   let langs = new Map();
+  let tweets = [];
 {% for lang in site.data.languages %}
-  {% if lang[1].tweet %}
-  langs.set("{{ lang[0] }}", "{{ lang[1].tweet |cgi_escape }}");
+  {% if lang[1].tweets %}
+    tweets = [];
+    {% for tweet in lang[1].tweets %}
+      tweets.push("{{ tweet |cgi_escape }}")
+    {% endfor %}
+    langs.set("{{ lang[0] }}", tweets);
   {% endif %}
 {% endfor %}
 
@@ -29,7 +34,8 @@ let lang = $(this).data('lang')
   const handle = $(this).data('twitter')
 
   if (!langs.has(lang) || lang == null) lang = "en"
-  const text = langs.get(lang).replace('TWITTERHANDLE', handle)
+  const index = Math.floor(Math.random() * ((langs.get(lang).length-1) - 0 + 1) + 0);
+  const text = langs.get(lang)[index].replace('TWITTERHANDLE', handle)
 
   window.open('https://twitter.com/share?hashtags=SupportTwoFactorAuth&text=' + text, '_blank');
 })


### PR DESCRIPTION
Partially fixes #1813

This PR allows for multiple tweet messages to be added and picks a random tweet message when the twitter button is clicked. Although this doesn't completely fix the issues mentioned in that issue, it does start to make the 2FA tweets a bit less spammy.