### PR TITLE
Use relative /notes/ path for website

### DIFF
--- a/_includes/html/desktop-table.html
+++ b/_includes/html/desktop-table.html
@@ -48,7 +48,7 @@
             <td class="icon-cell">
               <div class="row">
               {% if website.documentation %}
-                <a href="{{ website.documentation }}" class="col">
+                <a href="{{ website.documentation | remove: 'https://2fa.directory' }}" class="col">
                   <i class="fas fa-book"></i>
                 </a>
               {% endif %}

--- a/_includes/html/mobile-table.html
+++ b/_includes/html/mobile-table.html
@@ -47,7 +47,7 @@
 
         {% if website.documentation %}
           <div class="btn doc-btn col-11 col-sm-8 d-flex justify-content-center website-doc">
-            <a href="{{ website.documentation }}">
+            <a href="{{ website.documentation | remove: 'https://2fa.directory' }}">
               <i class="fas fa-book"></i>
               Read more
             </a>


### PR DESCRIPTION
Follow-up to #6107

Strip base URL for /notes/ paths on the website only to enable local testing.