### PR TITLE
Documentation Improvements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,7 +159,7 @@ The following is an example of a website that _supports_ TFA:
 If a site does not provide TFA, the `contact` field should be included.
 Inside of this object,
 * The `twitter` field should be included if the site uses Twitter. 
-* Facebook can also be included using the `facebook` field
+* Facebook can also be included using the `facebook` field.
 * Email can be included using the `email` field. 
 
 The `language` field inside `contact` can be included for websites that are not in English. The language
@@ -328,8 +328,7 @@ Then you can use the `category-id` as a keyword in the JSON file of your entry.
 - For the sake of organization and readability, it is appreciated if your site chunk
   follows the same order as the example earlier in the document.
 
-- If a site supports TFA, their contact information is not needed and should be left out
-  for cleanliness.
+- If a site supports TFA, their contact information is not needed and must be left out.
 
 ## A Note on Definitions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,8 +161,7 @@ Inside of this object,
 * The `twitter` field should be included if the site uses Twitter. 
 * Facebook can also be included using the `facebook` field.
 * Email can be included using the `email` field. 
-
-The `language` field inside `contact` can be included for websites that are not in English. The language
+* The `language` field inside `contact` can be included for websites whose social media pages/communication channels do not use English. The language
 codes should be lowercase [ISO 639-1][iso-lang-wikipedia] codes.
 
 The fields `tfa` and `documentation` are not necessary.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,27 +84,10 @@ its removal.
 
 View the complete list in the [EXCLUSION.md file][exclude].
 
-## New Categories
-
-To add a new category, modify the [categories file][categories] and follow the
-template below:
-
-```JSON
-  {
-    "name" : "category-id",
-    "title": "Category Title",
-    "icon": "icon-class"
-  },
-```
-
-The `icon-class` value needs to be chosen from [Font Awesome][font-awesome].
-
-Then you can use the `category-id` as a keyword in the JSON file of your entry.
-
 ## New Sites
 
 First and foremost, make sure the new site meets our [definition
-requirements][definitions] of Two Factor Auth.
+requirements][definitions] of two factor authentication.
 
 If you are adding multiple sites to the TwoFactorAuth list, please create a new
 git branch for each website, and submit a separate pull request for each branch.
@@ -145,9 +128,9 @@ field.
 
 #### Adding a site that _supports_ TFA
 
-If a site does provide TFA, it is strongly recommended that you add the `doc`
-field where public documentation is available. Other fields should be included
-if the website supports them. Any services that are not supported can be excluded.
+Sites that provide TFA can be noted with the `tfa` field and should contain the TFA methods supported.
+If a site does provide TFA, it is strongly recommended that you add the `documentation`
+field where public documentation is available.
 Sites supporting TFA must not have a `contact` property.
 
 The following is an example of a website that _supports_ TFA:
@@ -173,10 +156,16 @@ The following is an example of a website that _supports_ TFA:
 
 #### Adding a site that _does not_ support TFA
 
-If a site does not provide TFA, the `twitter` field should be included if the site uses
-Twitter. Facebook can also be included using the `facebook` field, as well as Email using
-the `email_address` field. If the website does not use the English language, the `lang`
-field should also be included. The fields `tfa` and `doc` can be completely removed.
+If a site does not provide TFA, the `contact` field should be included.
+Inside of this object,
+* The `twitter` field should be included if the site uses Twitter. 
+* Facebook can also be included using the `facebook` field
+* Email can be included using the `email` field. 
+
+The `language` field inside `contact` can be included for websites that are not in English. The language
+codes should be lowercase [ISO 639-1][iso-lang-wikipedia] codes.
+
+The fields `tfa` and `documentation` are not necessary.
 
 The following is an example of a website that _does not_ support TFA:
 
@@ -196,13 +185,10 @@ The following is an example of a website that _does not_ support TFA:
 }
 ```
 
-The `language` field inside `contact` can be included for non-English websites. The language
-codes should be lowercase [ISO 639-1][iso-lang-wikipedia] codes.
-
 ### Exceptions & Restrictions
 
 If a site requires the user to do something out of the ordinary to set up 2FA or if 2FA is
-only available in specific countries, you can note this on the website.
+only available in specific countries or to specific account types, you can document this using the `notes` field.
 
 ```JSON
 {
@@ -316,30 +302,48 @@ The country codes should be lowercase [ISO 3166-1][iso-country-wikipedia] codes.
 }
 ```
 
+## New Categories
+
+To add a new category, modify the [categories file][categories] and follow the
+template below:
+
+```JSON
+  {
+    "name" : "category-id",
+    "title": "Category Title",
+    "icon": "icon-class"
+  },
+```
+
+The `icon-class` value needs to be chosen from [Font Awesome][font-awesome].
+
+Then you can use the `category-id` as a keyword in the JSON file of your entry.
+
+
 ### Pro Tips
 
 - See Guideline #2 about icons. The SVG file should go in the corresponding
   `img/` folder.
 
 - For the sake of organization and readability, it is appreciated if your site chunk
-  follows the same order as the example above.
+  follows the same order as the example earlier in the document.
 
-- If a site supports TFA, their contact information is not needed and can be left out
+- If a site supports TFA, their contact information is not needed and should be left out
   for cleanliness.
 
 ## A Note on Definitions
 
-A lot of people have different ideas of what constitutes Two Factor Auth and
+There are lots of different ideas of what constitutes two factor authentication and
 what doesn't, so it stands to reason that we should clarify a bit. For the
-purposes of this site, Two Factor Auth is defined as any service provided as a
+purposes of this site, two factor authentication is defined as any service provided as a
 redundant layer for account _authentication_. Services that provide
 _authorization_ redundancy are certainly appreciated, but should not be
-considered Two Factor Auth.
+considered two factor authentication.
 
 As an example, a site that prompts you for an authentication token following
-user login would be considered Two Factor Auth. A site that does not prompt you
+user login would be considered two factor authentication. A site that does not prompt you
 for a token upon login, but prompts you for a token when you try to perform a
-sensitive action would not be considered Two Factor Authentication.
+sensitive action would not be considered two factor authentication.
 
 For context, check out the discussion in issue [#242][242].
 

--- a/EXCLUSION.md
+++ b/EXCLUSION.md
@@ -1,8 +1,8 @@
 # 2fa.directory excluded categories and websites
 
-Below is a list of categories and websites that we, [the collaborators][collaborators], have opted to not list on 2fa.directory.
+Below is a list of categories and websites that we, [the maintainers][maintainers], have opted to not list on 2fa.directory.
 
-One of the primary concerns we seek to address with these exclusions is professional and academic web filters. We believe that the service that this site provides should be as accessible as possible, to help as many people as possible, in as many environments as possible. Dynamic web filters can block websites based solely on the existence of keywords which could lead to this service being filtered for mentioning or linking out to categories of websites that web admins have deemed unacceptable for their domain. While we believe that every site should make an effort to protect their users (which often includes enabling Two Factor Authentication), we also believe that accessibility to this list for all has more value than listing every possible site and service.
+One of the primary concerns we seek to address with these exclusions is professional and academic web filters. We believe that the service that this site provides should be as accessible as possible, to help as many people as possible, in as many environments as possible. Dynamic web filters can block websites based solely on the existence of keywords which could lead to this service being filtered for mentioning or linking out to categories of websites that web admins have deemed unacceptable for their domain. While we believe that every site should make an effort to protect their users (which often includes enabling two factor authentication), we also believe that accessibility to this list for all has more value than listing every possible site and service.
 
 If you want to make a copy (fork) of our site to list any of these sites you're welcome to do so as long as you comply with our [license][license].
 
@@ -10,7 +10,7 @@ If you want to make a copy (fork) of our site to list any of these sites you're 
 
 *   #### Pornographic sites
 
-    As the volunteers of [2factorauth][org_link] need to review all submissions to validate that the site/service provides 2FA to its users in addition to verifying that the pull request meets our style guidelines, we've chosen to not list sites that primarily host and serve pornographic content. Given the volunteer driven nature of this project, there is no guarantee that there will always be a collaborator available to review a submission that also does not have an objection to reviewing such material. Special consideration must also be given due to the potential for content in this category to quickly cross subjective personal boundaries that vary widely from person to person.
+    As the volunteers of [2factorauth][org_link] need to review all submissions to validate that the site/service provides 2FA to its users in addition to verifying that the pull request meets our style guidelines, we've chosen to not list sites that primarily host and serve pornographic content. Given the volunteer driven nature of this project, there is no guarantee that there will always be a maintainer available to review a submission that also does not have an objection to reviewing such material. Special consideration must also be given due to the potential for content in this category to quickly cross subjective personal boundaries that vary widely from person to person.
 
 *   #### Self-hosted services
 
@@ -22,26 +22,26 @@ If you want to make a copy (fork) of our site to list any of these sites you're 
 
     3. The site has an independent authentication database
 
-    4. The underlying service supports 2FA natively or through a first-party (developer) plugin
+    4. The underlying service supports built-in 2FA or through a first-party (developer) plugin
 
     There are several resons for why we've opted to not list such sites and services.
 
-    -   2fa.directory is targeted towards consumers and not website administrators. As of right now, very few general internet users choose to host their own websites and services. Therefore we think that the effort on our part to maintain such a list of self hosted alternatives would outweigh the minimal theoretical change in the internet landscape by listing such services.
+    -   2fa.directory is targeted towards consumers and not website administrators. As of right now, very few general internet users choose to host their own websites and services. Therefore we think that the effort on our part to maintain such a list of self-hosted alternatives would outweigh the minimal theoretical change in the internet landscape by listing such services.
 
     -   If the core project doesn't support two factor authentication but instead through plugins it would mean that we would have to list all plugins that enable two factor authentication for the service, something that is currently impossible with our website layout.
 
     If you have any questions regarding whether or not a site qualifies for listing, simply open an issue and we'll take a look.
 
-*   #### Potential controversial sites 
+*   #### Potentially controversial sites 
 
     Any site that could damage the reputation of 2fa.directory and/or lead to any controversy with either the maintainers or users, should not be listed.
-    The group of active maintainers will decide on whether to include or exclude a site within a specific timeframe. Once an exclusion was decided upon, the site will be listed in the section below and any corresponding pull request will be closed.
+    The group of active maintainers will decide on whether to include or exclude a site within a specific timeframe. Once an exclusion was decided upon, the site will be listed in the section below and any corresponding pull requests will be closed.
 
 ## Sites
 
 Below is a list of specific sites/services excluded from 2fa.directory.
 
-[collaborators]: https://github.com/orgs/2factorauth/teams/collaborators/members
+[maintainers]: https://github.com/orgs/2factorauth/people
 [license]: /LICENSE
 [org_link]: https://github.com/2factorauth
 [site_criteria]: CONTRIBUTING.md#site-criteria

--- a/README.md
+++ b/README.md
@@ -1,23 +1,24 @@
 # 2fa.directory
 
-[![Build Status](https://img.shields.io/github/workflow/status/2factorauth/twofactorauth/Jekyll%20Tests?style=for-the-badge)][build_status]
+[![Build Status](https://img.shields.io/github/workflow/status/2factorauth/twofactorauth/Repository%20builds%20and%20tests?style=for-the-badge)][build_status]
 [![License](https://img.shields.io/badge/license-mit-9A0F2D.svg?style=for-the-badge)][license]
 [![Gitter](https://img.shields.io/gitter/room/2factorauth/twofactorauth.svg?style=for-the-badge&logo=gitter&color=ED1965)][gitter]
 [![Twitter](https://img.shields.io/badge/Twitter-@2faorg-1DA1F2.svg?style=for-the-badge&logo=twitter)][twitter]
 
-A list of popular sites and whether or not they accept two factor auth.
+A list of popular sites and whether or not they support two factor authentication.
 
 ## The Goal :goal_net:
 
 The goal of this project is to build a website ([2fa.directory][site_url]) with a list of popular sites that support
-Two Factor Authentication, as well as the methods that they provide.
+two factor authentication, as well as the methods that they provide.
 
 Our hope is to aid consumers who are deciding between alternative services based on the security they
 offer for their customers. This project also serves as an indicator of general security efforts used on a site.
 
 ## Contributing :pencil2:
 
-If you would like to contribute, please read the entire guidelines here in
+2fa.directory is only possible thanks to community contributions. We welcome all contributions to the project.
+If you would like to contribute, please read the entire guidelines in
 [CONTRIBUTING.md][contrib].
 
 ## Installing dependencies :hammer_and_wrench:
@@ -121,4 +122,3 @@ This code is distributed under the MIT license. For more info, read the
 [jekyll]: https://jekyllrb.com/
 [pages-gem]: https://github.com/github/pages-gem
 [docker]: https://www.docker.com/
-[jekyll_docker]: https://github.com/envygeeks/jekyll-docker/blob/master/README.md

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Build Status](https://img.shields.io/github/workflow/status/2factorauth/twofactorauth/Repository%20builds%20and%20tests?style=for-the-badge)][build_status]
 [![License](https://img.shields.io/badge/license-mit-9A0F2D.svg?style=for-the-badge)][license]
-[![Gitter](https://img.shields.io/gitter/room/2factorauth/twofactorauth.svg?style=for-the-badge&logo=gitter&color=ED1965)][gitter]
 [![Twitter](https://img.shields.io/badge/Twitter-@2faorg-1DA1F2.svg?style=for-the-badge&logo=twitter)][twitter]
 
 A list of popular sites and whether or not they support two factor authentication.

--- a/api.md
+++ b/api.md
@@ -3,17 +3,13 @@
 
 The data collected for the 2fa.directory website is also available as JSON files in order to enable developers to use it in their own programs. It is recommended to use the API with the highest version number, since older versions might not include all available information.
 
-### URL & Domain matching
-
-If you're using our API to match client URLs with our dataset make sure you only use the domain of the `url`-element, as a website commonly uses subdomains and subdirectories. Please note that there are exceptions like `.co.uk`, `.com.au` or `.co.nz` where the actual domain is found at a lower level.
-
 ### Caching
 
 If you intend to query our JSON files often and with a lot of traffic, you may be blocked by Cloudflare, our reverse proxy provider. We therefore recommend that you cache the files locally for any large traffic cases.
 
 ### Avoid downloading unnecessary data
 
-If you only intent on using a specific dataset, like all sites supporting RFC-6238, we recommend that you use the URI which lists just that. See [URIs](#uris-1) for a list of available paths. The smaller the better.
+If you only intent on using a specific dataset, like all sites supporting RFC-6238, we recommend that you use the URI which lists just that. See [URIs](#uris) for a list of available paths. The smaller the better.
 
 ## Version 3
 
@@ -28,7 +24,7 @@ If you only intent on using a specific dataset, like all sites supporting RFC-62
 |Email 2FA|https://2fa.directory/api/v3/email.json|https://2fa.directory/api/v3/email.json.sig|
 |non-U2F hardware 2FA tokens|https://2fa.directory/api/v3/custom-hardware.json|https://2fa.directory/api/v3/custom-hardware.json.sig|
 |U2F hardware tokens|https://2fa.directory/api/v3/u2f.json|https://2fa.directory/api/v3/u2f.json.sig|
-|RFC-6238|https://2fa.directory/api/v3/totp.json|https://2fa.directory/api/v3/totp.json.sig|
+|RFC-6238 (TOTP)|https://2fa.directory/api/v3/totp.json|https://2fa.directory/api/v3/totp.json.sig|
 |non-RFC-6238 software 2FA|https://2fa.directory/api/v3/custom-software.json|https://2fa.directory/api/v3/custom-software.json.sig|
 
 
@@ -113,7 +109,7 @@ If you only intent on using a specific dataset, like all sites supporting RFC-62
 ]
 ```
 
-## Version 2
+## Version 2 (Deprecated) :warning:
 
 ### URIs
 
@@ -126,7 +122,7 @@ If you only intent on using a specific dataset, like all sites supporting RFC-62
 |Email 2FA|https://2fa.directory/api/v2/email.json|https://2fa.directory/api/v2/email.json.sig|
 |non-U2F hardware 2FA tokens|https://2fa.directory/api/v2/hardware.json|https://2fa.directory/api/v2/hardware.json.sig|
 |U2F hardware tokens|https://2fa.directory/api/v2/u2f.json|https://2fa.directory/api/v2/u2f.json.sig|
-|RFC-6238|https://2fa.directory/api/v2/totp.json|https://2fa.directory/api/v2/totp.json.sig|
+|RFC-6238 (TOTP)|https://2fa.directory/api/v2/totp.json|https://2fa.directory/api/v2/totp.json.sig|
 |non-RFC-6238 software 2FA|https://2fa.directory/api/v2/proprietary.json|https://2fa.directory/api/v2/proprietary.json.sig|
 
 


### PR DESCRIPTION
I've made a couple of modifications to the documentation:

- Consistency (Phrase "two factor authentication", rather than a mixture of "two factor auth" and "Two Factor Authentication")
- Remove outdated references (there were a couple of references to the old YAML schema in CONTRIBUTING.md)
- Move new categories to end of contributing guidelines (the majority of contributors are looking to add sites)
- A couple of minor language changes & typo fixes 
- Mark v2 API as deprecated
- Remove Gitter link (it doesn't seem to have been used properly since 2019)