### PR TITLE
Update afip.gob.ar

### DIFF
--- a/entries/a/afip.gob.ar.json
+++ b/entries/a/afip.gob.ar.json
@@ -6,8 +6,7 @@
       "custom-hardware",
       "custom-software"
     ],
-    "documentation": "https://serviciosweb.afip.gob.ar/genericos/GuiaDeTramites/VerGuia.aspx?tr=38",
-    "notes": "2FA is only available for users with security level (Clave Fiscal) 4",
+    "documentation": "https://www.afip.gob.ar/claveFiscal/informacion-basica/solicitud.asp",
     "keywords": [
       "government"
     ],


### PR DESCRIPTION
Updated link to documentation. Removed notes as the website removed the limitations around which accounts could enable MFA.