### PR TITLE
Switch from cURL validation to httpclient

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ruby:2.7-alpine
 WORKDIR /app
 COPY Gemfile .
 COPY ./scripts/entrypoint.sh .
-RUN apk add --no-cache build-base git bash dos2unix npm gnupg curl
+RUN apk add --no-cache build-base git bash dos2unix npm gnupg
 RUN bundle config set path '/app/vendor/cache'
 RUN bundle install
 RUN npm i -g babel-minify

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ group :jekyll_plugins do
 end
 
 group :test do
+  gem 'httpclient'
   gem 'json_schemer'
   gem 'rubocop'
   gem 'twitter'

--- a/tests/validate-urls.rb
+++ b/tests/validate-urls.rb
@@ -13,12 +13,11 @@ def curl(url)
   headers = { 'User-Agent' => 'Mozilla/5.0 (compatible;  MSIE 7.01; Windows NT 5.0)', 'FROM' => '2fa.directory' }
   req = HTTPClient.new
   req.receive_timeout = 8
-  return 0 if (res = req.get(url, nil, headers, follow_redirect: true).status == 200)
-
-  raise(nil) unless res.status.match?('/50\d/')
+  res = req.get(url, nil, headers, follow_redirect: true)
+  return if res.status == 200
+  raise(nil) unless res.status.to_s.match(/50\d|403/)
 
   puts "::warning file=#{@path}:: Unexpected response from #{url} (#{res.status})"
-  0
 rescue StandardError => _e
   puts "::error file=#{@path}:: Unable to reach #{url} #{res.respond_to?('status') ? res.status : nil}"
   1
@@ -30,11 +29,11 @@ diff&.each do |path|
   entry = JSON.parse(File.read(@path)).values[0]
 
   # Process the url,domain & additional-domains
-  status += curl((entry.key?('url') ? entry['url'] : "https://#{entry['domain']}/"))
-  entry['additional-domains']&.each { |domain| status += curl("https://#{domain}/") }
+  status += curl((entry.key?('url') ? entry['url'] : "https://#{entry['domain']}/")).to_i
+  entry['additional-domains']&.each { |domain| status += curl("https://#{domain}/").to_i }
 
   # Process documentation and recovery URLs
-  status += curl(entry['documentation']) if entry.key?('documentation')
-  status += curl(entry['recovery']) if entry.key? 'recovery'
+  status += curl(entry['documentation']).to_i if entry.key? 'documentation'
+  status += curl(entry['recovery']).to_i if entry.key? 'recovery'
 end
 exit(status)

--- a/tests/validate-urls.rb
+++ b/tests/validate-urls.rb
@@ -7,7 +7,7 @@ require 'httpclient'
 status = 0
 
 # Fetch created/modified files in entries/**
-diff = `git diff --name-only --diff-filter=AM entries/`.split("\n")
+diff = `git diff --name-only --diff-filter=AM origin/master...HEAD entries/`.split("\n")
 
 def curl(url)
   headers = { 'User-Agent' => 'Mozilla/5.0 (compatible;  MSIE 7.01; Windows NT 5.0)', 'FROM' => '2fa.directory' }


### PR DESCRIPTION
Using [nahi/httpclient](https://github.com/nahi/httpclient.git) allows for more fine tuned handling of failed HTTP requests.
Here I have made 50x responses fail without failing the entire build. This allows us to list sites that are blocking scripts from accessing their site (like sierra.com, alaskanair.com, #6123, #6119)