### PR TITLE
Show custom-software/hardware values

### DIFF
--- a/_includes/html/desktop-table.html
+++ b/_includes/html/desktop-table.html
@@ -81,11 +81,19 @@
             <td class="icon-cell">
               <div class="row">
                 {% if tfa contains "custom-hardware" %}
-                  <i class="tfa-icon fas fa-check col"></i>
+                  <i class="tfa-icon fas fa-info col"
+                     title="{%- if website.custom-hardware -%}
+                     Required hardware token: {{ website.custom-hardware }}
+                     {%- else -%}
+                     Requires custom hardware token
+                     {%- endif -%}
+                     "
+
+                  ></i>
                 {% endif %}
 
                 {% if tfa contains "u2f" %}
-                  <i class="tfa-icon u2f-icon col" title="U2F">
+                  <i class="tfa-icon u2f-icon col" title="U2F/WebAuthn support">
                     <img alt="U2F" height="20" src="/img/u2f.svg" loading="lazy" type="image/svg">
                   </i>
                 {% endif %}
@@ -98,7 +106,14 @@
                   <i class="tfa-icon fas fa-check col"></i>
                 {% endif %}
                 {% if tfa contains "custom-software" %}
-                  <i class="tfa-icon fas fa-info col" title="Proprietary software based 2FA"></i>
+                  <i class="tfa-icon fas fa-info col"
+                     title="{%- if website.custom-software -%}
+                     Required app: {{ website.custom-software }}
+                     {%- else -%}
+                     Requires proprietary app/software
+                     {%- endif -%}
+                     "
+                  ></i>
                 {% endif %}
               </div>
             </td>

--- a/_includes/html/desktop-table.html
+++ b/_includes/html/desktop-table.html
@@ -20,7 +20,7 @@
         <tr class="table-{% if website.tfa %}success{% else %}danger{% endif %}">
 
           <td>
-            <div class="searchWords" style="display: none;">{{ name }} {{ website.domain }}{% for item in website.tfa %} 2fa:{{ item }}{% endfor %}{% for item in website.custom-hardware %} custom-hardware:{{item}}{% endfor %}{% for item in website.custom-software %} custom-software:{{item}}{% endfor %} {% for domain in website.additional-domains %} {{ domain }} {% endfor %}</div>
+            <div class="searchWords" style="display: none;">{{ name }} {{ website.domain }}{% for item in website.tfa %} 2fa:{{ item }}{% endfor %}{% for item in website.custom-hardware %} 2fa:{{item}}{% endfor %}{% for item in website.custom-software %} 2fa:{{item}}{% endfor %} {% for domain in website.additional-domains %} {{ domain }} {% endfor %}</div>
             <div class="row no-gutters">
               <a class="site-name {% if website.notes %}exception-site{% endif %}" href="{% if website.url %}{{ website.url }}{% else %}https://{{ website.domain }}{% endif %}">
               <!-- Image -->

--- a/_includes/html/desktop-table.html
+++ b/_includes/html/desktop-table.html
@@ -83,7 +83,7 @@
                 {% if tfa contains "custom-hardware" %}
                   <i class="tfa-icon fas fa-info col"
                      title="{%- if website.custom-hardware -%}
-                     Required hardware token: {{ website.custom-hardware }}
+                     Required hardware token:&#013;{%- for item in website.custom-hardware -%} {{ item }}&#013; {%- endfor -%}
                      {%- else -%}
                      Requires custom hardware token
                      {%- endif -%}

--- a/_includes/html/desktop-table.html
+++ b/_includes/html/desktop-table.html
@@ -83,7 +83,12 @@
                 {% if tfa contains "custom-hardware" %}
                   <i class="tfa-icon fas fa-info col"
                      title="{%- if website.custom-hardware -%}
-                     Required hardware token:{%- for item in website.custom-hardware -%}&#013; {{ item }} {%- endfor -%}
+                     {%- if website.custom-hardware.size > 1 -%}
+                     Requires one of:
+                     {%- else -%}
+                     Required hardware token:
+                     {%- endif-%}
+                     {%- for item in website.custom-hardware -%}&#013; {{ item }} {%- endfor -%}
                      {%- else -%}
                      Requires custom hardware token
                      {%- endif -%}
@@ -108,7 +113,12 @@
                 {% if tfa contains "custom-software" %}
                   <i class="tfa-icon fas fa-info col"
                      title="{%- if website.custom-software -%}
-                     Required app:{%- for item in website.custom-software -%}&#013; {{ item }} {%- endfor -%}
+                     {%- if website.custom-hardware.size > 1 -%}
+                     Requires one of:
+                     {%- else -%}
+                     Required app:
+                     {%- endif-%}
+                     {%- for item in website.custom-software -%}&#013; {{ item }} {%- endfor -%}
                      {%- else -%}
                      Requires proprietary app/software
                      {%- endif -%}

--- a/_includes/html/desktop-table.html
+++ b/_includes/html/desktop-table.html
@@ -108,7 +108,7 @@
                 {% if tfa contains "custom-software" %}
                   <i class="tfa-icon fas fa-info col"
                      title="{%- if website.custom-software -%}
-                     Required app: {{ website.custom-software }}
+                     Required app:&#013;{%- for item in website.custom-software -%} {{ item }}&#013; {%- endfor -%}
                      {%- else -%}
                      Requires proprietary app/software
                      {%- endif -%}

--- a/_includes/html/desktop-table.html
+++ b/_includes/html/desktop-table.html
@@ -83,7 +83,7 @@
                 {% if tfa contains "custom-hardware" %}
                   <i class="tfa-icon fas fa-info col"
                      title="{%- if website.custom-hardware -%}
-                     Required hardware token:&#013;{%- for item in website.custom-hardware -%} {{ item }}&#013; {%- endfor -%}
+                     Required hardware token:{%- for item in website.custom-hardware -%}&#013; {{ item }} {%- endfor -%}
                      {%- else -%}
                      Requires custom hardware token
                      {%- endif -%}
@@ -108,7 +108,7 @@
                 {% if tfa contains "custom-software" %}
                   <i class="tfa-icon fas fa-info col"
                      title="{%- if website.custom-software -%}
-                     Required app:&#013;{%- for item in website.custom-software -%} {{ item }}&#013; {%- endfor -%}
+                     Required app:{%- for item in website.custom-software -%}&#013; {{ item }} {%- endfor -%}
                      {%- else -%}
                      Requires proprietary app/software
                      {%- endif -%}

--- a/_includes/html/desktop-table.html
+++ b/_includes/html/desktop-table.html
@@ -20,7 +20,7 @@
         <tr class="table-{% if website.tfa %}success{% else %}danger{% endif %}">
 
           <td>
-            <div class="searchWords" style="display: none;">{{ name }} {{ website.domain }}{% for item in website.tfa %} 2fa:{{ item }}{% endfor %} {% for domain in website.additional-domains %} {{ domain }} {% endfor %}</div>
+            <div class="searchWords" style="display: none;">{{ name }} {{ website.domain }}{% for item in website.tfa %} 2fa:{{ item }}{% endfor %}{% for item in website.custom-hardware %} custom-hardware:{{item}}{% endfor %}{% for item in website.custom-software %} custom-software:{{item}}{% endfor %} {% for domain in website.additional-domains %} {{ domain }} {% endfor %}</div>
             <div class="row no-gutters">
               <a class="site-name {% if website.notes %}exception-site{% endif %}" href="{% if website.url %}{{ website.url }}{% else %}https://{{ website.domain }}{% endif %}">
               <!-- Image -->


### PR DESCRIPTION
This PR takes advantage of the custom-* tags and displays which custom hardware/software that needs to be used for 2FA for the entries.

Screenshots:
![custom software](https://d.tempfiles.download/D614652A2BE589/?p=KSN4vAoyQkn3OX5P)
![custom software 2](https://d.tempfiles.download/D614652F8924DA/?p=7TYQKrNwuhZi6)
![u2f title](https://d.tempfiles.download/D6146525BC430C/?p=NYD8r9wQ1)
![custom hardware](https://d.tempfiles.download/D614652E6D73B3/?p=2CBTz6ZptPcxIDqR0wN)