### PR TITLE
Add U2F to Outlook.com

### DIFF
--- a/entries/o/outlook.com.json
+++ b/entries/o/outlook.com.json
@@ -6,7 +6,8 @@
       "call",
       "email",
       "custom-software",
-      "totp"
+      "totp",
+      "u2f"
     ],
     "documentation": "https://support.microsoft.com/en-us/help/12408/",
     "notes": "2FA phone calls may not be available in all regions",


### PR DESCRIPTION
Outlook.com uses Microsoft Accounts which do support hardware tokens