### PR TITLE
Standardize user agents

### DIFF
--- a/bot.md
+++ b/bot.md
@@ -15,4 +15,4 @@ As a result you will most likely only receive a couple of requests each year. We
 
 ## robots.txt
 
-Since each script only makes one request per website, the same number as if we would have fetched any robots.txt-file, we have opted to not comply with robots.txt-files.
+Since each script only makes one request per website, the same number as if we would have fetched any robots.txt file, we have opted to not comply with robots.txt files.

--- a/bot.md
+++ b/bot.md
@@ -1,0 +1,18 @@
+# 2FactorAuth Web bots
+
+In order to validate user contributions we use scripts or "bots".  
+These scripts only make requests to your website when someone tries to edit data about your site on 2fa.directory.   
+As a result you will most likely only receive a couple of requests each year. We would be very thankful if you didn't block these HTTP requests.
+
+## User agents:
+
+|User-Agent|Script source|
+|----------|-------------|
+|2FactorAuth/URLValidator|/tests/validate-urls.rb|
+|2FactorAuth/LanguageValidator|/tests/language-codes.rb|
+|2FactorAuth/RegionValidator|/tests/region-codes.rb|
+|2FactorAuth/FacebookValidator|/tests/facebook.rb|
+
+## robots.txt
+
+Since each script only makes one request per website, the same number as if we would have fetched any robots.txt-file, we have opted to not comply with robots.txt-files.

--- a/css/bot.md.scss
+++ b/css/bot.md.scss
@@ -1,0 +1,15 @@
+---
+---
+th, td {
+  padding: .7rem;
+  border: #ccc solid 1px;
+}
+
+th {
+  text-align: center;
+}
+
+h1, h2 {
+  line-height: 60px;
+  font-weight: 700;
+}

--- a/tests/facebook.rb
+++ b/tests/facebook.rb
@@ -6,11 +6,18 @@ require 'uri'
 
 status = 0
 diff = `git diff origin/master...HEAD entries/ | sed -n 's/^+.*"facebook"[^"]*"\\(.*\\)".*/\\1/p'`
+@headers = {
+  'User-Agent' => '2FactorAuth/FacebookValidator '\
+  "(Ruby/#{RUBY_VERSION}; +https://2fa.directory/bot)",
+  'From' => 'https://2fa.directory/'
+}
+
 diff.split("\n").each do |page|
   url = URI("https://www.facebook.com/pg/#{page}")
   http = Net::HTTP.new(url.host, url.port)
   http.use_ssl = true
-  response = http.request(Net::HTTP::Get.new(url))
+  request = Net::HTTP::Get.new(url, @headers)
+  response = http.request(request)
   begin
     raise("\"#{page}\" is either private or doesn't exist.") if response.code.eql? '404'
 

--- a/tests/language-codes.rb
+++ b/tests/language-codes.rb
@@ -15,7 +15,9 @@ else
   url = URI(@list_url)
   headers = {
     'Accept' => 'application/json',
-    'User-Agent' => 'twofactorauth (https://github.com/2factorauth/twofactorauth.git)'
+    'User-Agent' => '2FactorAuth/LanguageValidator '\
+    "(HTTPClient/#{Gem.loaded_specs['httpclient'].version} on Ruby/#{RUBY_VERSION}; +https://2fa.directory/bot)",
+    'From' => 'https://2fa.directory/'
   }
   https = Net::HTTP.new(url.host, url.port)
   https.use_ssl = true

--- a/tests/region-codes.rb
+++ b/tests/region-codes.rb
@@ -15,7 +15,9 @@ else
   url = URI(@list_url)
   headers = {
     'Accept' => 'application/json',
-    'User-Agent' => 'twofactorauth (https://github.com/2factorauth/twofactorauth.git)'
+    'User-Agent' => '2FactorAuth/RegionValidator' \
+    "(HTTPClient/#{Gem.loaded_specs['httpclient'].version} on Ruby/#{RUBY_VERSION}; +https://2fa.directory/bot)",
+    'From' => 'https://2fa.directory/'
   }
   https = Net::HTTP.new(url.host, url.port)
   https.use_ssl = true

--- a/tests/validate-urls.rb
+++ b/tests/validate-urls.rb
@@ -4,42 +4,46 @@
 require 'English'
 require 'json'
 require 'httpclient'
+
+# Exit code
 status = 0
 
 # Fetch created/modified files in entries/**
 diff = `git diff --name-only --diff-filter=AM origin/master...HEAD entries/`.split("\n")
 
-def new_http_client
-  agent_name = 'Mozilla/5.0 (compatible;  MSIE 7.01; Windows NT 5.0)'
+def http_client
+  agent_name = '2FactorAuth/URLValidator ' \
+  "(HTTPClient/#{Gem.loaded_specs['httpclient'].version} on Ruby/#{RUBY_VERSION}; +https://2fa.directory/bot)"
   from = '2fa.directory'
   client = HTTPClient.new(nil, agent_name, from)
   client.ssl_config.set_default_paths # ignore built-in CA and use system defaults
   client.receive_timeout = 8
+  client.redirect_uri_callback = ->(_, res) { res.header['location'][0] }
   client
 end
 
-def curl(url)
-  res = new_http_client.get(url, follow_redirect: true)
+# Check if the url supplied works
+def check_url(path, url)
+  res = http_client.get(url, follow_redirect: true)
   return if res.status == 200
   raise(nil) unless res.status.to_s.match(/50\d|403/)
 
-  puts "::warning file=#{@path}:: Unexpected response from #{url} (#{res.status})"
-rescue StandardError => _e
-  puts "::error file=#{@path}:: Unable to reach #{url} #{res.respond_to?('status') ? res.status : nil}"
+  puts "::warning file=#{path}:: Unexpected response from #{url} (#{res.status})"
+rescue StandardError => e
+  puts "::error file=#{path}:: Unable to reach #{url} #{res.respond_to?('status') ? res.status : nil}"
+  puts e.full_message unless e.instance_of?(TypeError)
   1
 end
 
 diff&.each do |path|
-  # Make path global for curl()
-  @path = path
-  entry = JSON.parse(File.read(@path)).values[0]
+  entry = JSON.parse(File.read(path)).values[0]
 
   # Process the url,domain & additional-domains
-  status += curl((entry.key?('url') ? entry['url'] : "https://#{entry['domain']}/")).to_i
-  entry['additional-domains']&.each { |domain| status += curl("https://#{domain}/").to_i }
+  status += check_url(path, (entry.key?('url') ? entry['url'] : "https://#{entry['domain']}/")).to_i
+  entry['additional-domains']&.each { |domain| status += check_url(path, "https://#{domain}/").to_i }
 
   # Process documentation and recovery URLs
-  status += curl(entry['documentation']).to_i if entry.key? 'documentation'
-  status += curl(entry['recovery']).to_i if entry.key? 'recovery'
+  status += check_url(path, entry['documentation']).to_i if entry.key? 'documentation'
+  status += check_url(path, entry['recovery']).to_i if entry.key? 'recovery'
 end
 exit(status)


### PR DESCRIPTION
This PR changes all user-agents used for tests to a more standardized user-agent containing the script name, HTTPClient version and Ruby version. I have tested this user-agent on sites known to block bots and it seems to work fine :thinking:

I also added a note about our bots for any webmasters.

(Also fixes #6139)

Here are screenshots of how bots.md would look like on 2fa.directory
![light bg](https://user-images.githubusercontent.com/3535780/135185603-d39bbab7-a778-4c89-8bae-e047db32f657.png)
![dark bg](https://user-images.githubusercontent.com/3535780/135185613-fa470df8-9180-4bdb-831d-60f5f1ba0cab.png)
