### PR TITLE
Workaround for old CAs in httpclient

### DIFF
--- a/tests/validate-urls.rb
+++ b/tests/validate-urls.rb
@@ -12,6 +12,8 @@ diff = `git diff --name-only --diff-filter=AM origin/master...HEAD entries/`.spl
 def curl(url)
   headers = { 'User-Agent' => 'Mozilla/5.0 (compatible;  MSIE 7.01; Windows NT 5.0)', 'FROM' => '2fa.directory' }
   req = HTTPClient.new
+  # ignore built-in CA and use system defaults
+  req.ssl_config.set_default_paths
   req.receive_timeout = 8
   res = req.get(url, nil, headers, follow_redirect: true)
   return if res.status == 200

--- a/tests/validate-urls.rb
+++ b/tests/validate-urls.rb
@@ -12,7 +12,7 @@ diff = `git diff --name-only --diff-filter=AM origin/master...HEAD entries/`.spl
 def new_http_client
   agent_name = 'Mozilla/5.0 (compatible;  MSIE 7.01; Windows NT 5.0)'
   from = '2fa.directory'
-  client = HTTPClient.new(agent_name, from)
+  client = HTTPClient.new(nil, agent_name, from)
   client.ssl_config.set_default_paths # ignore built-in CA and use system defaults
   client.receive_timeout = 8
   client

--- a/tests/validate-urls.rb
+++ b/tests/validate-urls.rb
@@ -9,13 +9,17 @@ status = 0
 # Fetch created/modified files in entries/**
 diff = `git diff --name-only --diff-filter=AM origin/master...HEAD entries/`.split("\n")
 
+def new_http_client
+  agent_name = 'Mozilla/5.0 (compatible;  MSIE 7.01; Windows NT 5.0)'
+  from = '2fa.directory'
+  client = HTTPClient.new(agent_name, from)
+  client.ssl_config.set_default_paths # ignore built-in CA and use system defaults
+  client.receive_timeout = 8
+  client
+end
+
 def curl(url)
-  headers = { 'User-Agent' => 'Mozilla/5.0 (compatible;  MSIE 7.01; Windows NT 5.0)', 'FROM' => '2fa.directory' }
-  req = HTTPClient.new
-  # ignore built-in CA and use system defaults
-  req.ssl_config.set_default_paths
-  req.receive_timeout = 8
-  res = req.get(url, nil, headers, follow_redirect: true)
+  res = new_http_client.get(url, nil, follow_redirect: true)
   return if res.status == 200
   raise(nil) unless res.status.to_s.match(/50\d|403/)
 


### PR DESCRIPTION
See https://github.com/nahi/httpclient/issues/445.

The default implementation uses a list of CAs from 2015, and resetting it to use default paths uses (newer) CA certificates from the underlying OS.
