### PR TITLE
Fix URL test not following redirects

### DIFF
--- a/tests/validate-urls.rb
+++ b/tests/validate-urls.rb
@@ -19,7 +19,7 @@ def new_http_client
 end
 
 def curl(url)
-  res = new_http_client.get(url, nil, follow_redirect: true)
+  res = new_http_client.get(url, follow_redirect: true)
   return if res.status == 200
   raise(nil) unless res.status.to_s.match(/50\d|403/)
 


### PR DESCRIPTION
f915c193ceb245642a3745de5c53f940d6c2ce84 stopped redirects from being followed causing errors on 30* codes
See https://github.com/ApCoder123/twofactorauth/runs/3769555079