### PR TITLE
Show TOTP on hover over checkmark

### DIFF
--- a/_includes/html/desktop-table.html
+++ b/_includes/html/desktop-table.html
@@ -108,7 +108,7 @@
             <td class="icon-cell">
               <div class="row">
                 {% if tfa contains "totp" %}
-                  <i class="tfa-icon fas fa-check col"></i>
+                  <i class="tfa-icon fas fa-check col" title="TOTP support"></i>
                 {% endif %}
                 {% if tfa contains "custom-software" %}
                   <i class="tfa-icon fas fa-info col"


### PR DESCRIPTION
Makes the meaning of the check in the software column slightly clearer.

Acts as a partial solution for #5168, #3037.