### PR TITLE
Update JetBrains

### DIFF
--- a/entries/j/jetbrains.com.json
+++ b/entries/j/jetbrains.com.json
@@ -2,11 +2,10 @@
   "JetBrains": {
     "domain": "jetbrains.com",
     "tfa": [
-      "totp",
-      "u2f"
+      "totp"
     ],
-    "documentation": "https://www.jetbrains.com/help/hub/2fa-with-token.html",
-    "notes": "U2F only available for Hub account (e.g. YouTrack). Limited to one software token OR one hardware token.",
+    "documentation": "https://sales.jetbrains.com/hc/en-gb/articles/360013015240",
+    "recovery": "https://sales.jetbrains.com/hc/en-gb/articles/360013090420",
     "keywords": [
       "developer"
     ]


### PR DESCRIPTION
Current entry has info on 2FA for "JetBrains Hub" product, which is self hosted, rather than for the JetBrains account. 