### PR TITLE
Update UBS

### DIFF
--- a/entries/u/ubs.com.json
+++ b/entries/u/ubs.com.json
@@ -6,9 +6,19 @@
       "custom-hardware",
       "custom-software"
     ],
+    "custom-hardware": [
+      "Card Reader",
+      "Access Card display"
+    ],
+    "custom-software": [
+      "UBS Access app"
+    ],
     "documentation": "https://www.ubs.com/ch/en/help/e-banking/process.html",
     "keywords": [
       "banking"
+    ],
+    "regions": [
+      "ch"
     ]
   }
 }


### PR DESCRIPTION
2FA is only available for banking services, which are only available in Switzerland.