### PR TITLE
Update Blizzard

### DIFF
--- a/entries/b/blizzard.com.json
+++ b/entries/b/blizzard.com.json
@@ -1,12 +1,15 @@
 {
-  "Blizzard": {
+  "Blizzard/Battle.net": {
     "domain": "blizzard.com",
+    "additional-domains": [
+      "battle.net"
+    ],
     "tfa": [
       "sms",
       "custom-software",
       "custom-hardware"
     ],
-    "documentation": "https://us.battle.net/support/en/article/Blizzard-Authenticator",
+    "documentation": "https://battle.net/support/article/24520",
     "keywords": [
       "gaming"
     ]

--- a/entries/b/blizzard.com.json
+++ b/entries/b/blizzard.com.json
@@ -8,6 +8,9 @@
       "sms",
       "custom-software"
     ],
+    "custom-software": [
+      "Battle.net Authenticator"
+    ],
     "documentation": "https://battle.net/support/article/24520",
     "keywords": [
       "gaming"

--- a/entries/b/blizzard.com.json
+++ b/entries/b/blizzard.com.json
@@ -6,8 +6,7 @@
     ],
     "tfa": [
       "sms",
-      "custom-software",
-      "custom-hardware"
+      "custom-software"
     ],
     "documentation": "https://battle.net/support/article/24520",
     "keywords": [


### PR DESCRIPTION
Unsure if "custom-hardware" should get removed because they don't sell it anymore ([Forum Post](https://us.forums.blizzard.com/en/wow/t/physical-blizzard-authenticator/237506/15)). And it isn't even mentioned in the [article](https://battle.net/support/article/24520). 