### PR TITLE
Supress validate-url.rb errors

### DIFF
--- a/.github/workflows/repository.yml
+++ b/.github/workflows/repository.yml
@@ -34,6 +34,7 @@ jobs:
         run: bundle exec ruby ./tests/validate-images.rb
       - name: Validate URL/Domain reachability
         run: bundle exec ruby ./tests/validate-urls.rb
+        continue-on-error: true
       - name: Quality Checks
         run: bundle exec ruby ./tests/quality-checks.rb
       - name: Validate Ruby scripts

--- a/tests/validate-urls.rb
+++ b/tests/validate-urls.rb
@@ -39,7 +39,7 @@ def check_url(path, url)
 
   puts "::warning file=#{path}:: Unexpected response from #{url} (#{res.status})"
 rescue StandardError => e
-  puts "::error file=#{path}:: Unable to reach #{url} #{res.respond_to?('status') ? res.status : nil}"
+  puts "::warning file=#{path}:: Unable to reach #{url} #{res.respond_to?('status') ? res.status : nil}"
   puts e.full_message unless e.instance_of?(TypeError)
   1
 end


### PR DESCRIPTION
As the validate-url script continually breaks I think it's better to treat the errors as warnings.