### PR TITLE
Change category icons based on regional site

### DIFF
--- a/_data/categories.json
+++ b/_data/categories.json
@@ -67,7 +67,7 @@
   {
     "name": "finance",
     "title": "Finance",
-    "icon": "fas fa-dollar-sign"
+    "icon": "fas fa-file-invoice-dollar"
   },
   {
     "name": "food",

--- a/_data/regions.yml
+++ b/_data/regions.yml
@@ -3,12 +3,16 @@
 
 - id: at
   name: Austria
+  category-icons:
+    - banking: "fas fa-euro-sign"
 
 - id: au
   name: Australia
 
 - id: be
   name: Belgium
+  category-icons:
+    - banking: "fas fa-euro-sign"
 
 - id: br
   name: Brazil
@@ -25,36 +29,54 @@
 
 - id: de
   name: Germany
+  category-icons:
+    - banking: "fas fa-euro-sign"
 
 - id: dk
   name: Denmark
 
 - id: es
   name: Spain
+  category-icons:
+    - banking: "fas fa-euro-sign"
 
 - id: fi
   name: Finland
+  category-icons:
+    - banking: "fas fa-euro-sign"
 
 - id: fr
   name: France
+  category-icons:
+    - banking: "fas fa-euro-sign"
 
 - id: hr
   name: Croatia
 
 - id: ie
   name: Ireland
+  category-icons:
+    - banking: "fas fa-euro-sign"
 
 - id: in
   name: India
+  category-icons:
+    - banking: "fas fa-rupee-sign"
 
 - id: it
   name: Italy
+  category-icons:
+    - banking: "fas fa-euro-sign"
 
 - id: jp
   name: Japan
+  category-icons:
+    - banking: "fas fa-yen-sign"
 
 - id: nl
   name: Netherlands
+  category-icons:
+    - banking: "fas fa-euro-sign"
 
 - id: "no"
   name: Norway
@@ -70,6 +92,8 @@
 
 - id: pt
   name: Portugal
+  category-icons:
+    - banking: "fas fa-euro-sign"
 
 - id: se
   name: Sweden
@@ -79,6 +103,8 @@
 
 - id: gb
   name: United Kingdom
+  category-icons:
+    - banking: "fas fa-pound-sign"
 
 - id: us
   name: United States

--- a/scripts/regions.rb
+++ b/scripts/regions.rb
@@ -14,6 +14,7 @@ git_dir = Dir.glob('.git')
 FileUtils.cp_r(git_dir, "#{tmp_dir}/") unless File.exist?("#{tmp_dir}/.git")
 
 # Region loop
+# rubocop:disable Metrics/BlockLength
 regions.each do |region|
   dest_dir = "#{tmp_dir}/#{region['id']}"
   unless File.exist?(dest_dir)
@@ -39,7 +40,7 @@ regions.each do |region|
 
   categories = JSON.parse(File.read("#{dest_dir}/_data/categories.json"))
 
-  if !region['category-icons'].nil?
+  unless region['category-icons'].nil?
     icons = region['category-icons'].reduce({}, :merge)
     categories.map do |category|
       category['icon'] = icons[category['name']] unless icons[category['name']].nil?
@@ -55,3 +56,4 @@ regions.each do |region|
   puts `bundle exec jekyll build -s #{dest_dir} --config _config.yml -d #{out_dir} --baseurl #{region['id']}`
   puts "#{region['id']} built."
 end
+# rubocop:enable Metrics/BlockLength

--- a/scripts/regions.rb
+++ b/scripts/regions.rb
@@ -39,6 +39,13 @@ regions.each do |region|
 
   categories = JSON.parse(File.read("#{dest_dir}/_data/categories.json"))
 
+  if !region['category-icons'].nil?
+    icons = region['category-icons'].reduce({}, :merge)
+    categories.map do |category|
+      category['icon'] = icons[category['name']] unless icons[category['name']].nil?
+    end
+  end
+
   File.open("#{dest_dir}/_data/categories.json", 'w') do |file|
     file.write JSON.generate(categories.select { |cat| used_categories[cat['name']] })
   end


### PR DESCRIPTION
Thought it would be cool to display different currency symbols for the `banking` category based on the regional site accessed.

Also changed `finance` icon