### PR TITLE
Update guildwars2.com.json to include arena.net

### DIFF
--- a/entries/g/guildwars2.com.json
+++ b/entries/g/guildwars2.com.json
@@ -11,7 +11,7 @@
       "totp"
     ],
     "documentation": "https://help.guildwars2.com/hc/en-us/articles/230672927",
-    "recovery": "https://help.guildwars2.com/hc/en-us/requests/new?ticket_form_id=360003248533",
+    "recovery": "https://help.guildwars2.com/hc/en-us/articles/360000819168",
     "keywords": [
       "gaming"
     ]

--- a/entries/g/guildwars2.com.json
+++ b/entries/g/guildwars2.com.json
@@ -1,12 +1,17 @@
 {
   "Guild Wars 2": {
     "domain": "guildwars2.com",
+    "additional-domains": [
+      "arena.net"
+    ],
     "url": "https://www.guildwars2.com",
     "tfa": [
+      "email",
       "sms",
       "totp"
     ],
     "documentation": "https://help.guildwars2.com/hc/en-us/articles/230672927",
+    "recovery": "https://help.guildwars2.com/hc/en-us/requests/new?ticket_form_id=360003248533",
     "keywords": [
       "gaming"
     ]


### PR DESCRIPTION
`arena.net` (`account.arena.net`, to be precise) is where the actual account configuration happens and 2FA settings live.

This also adds email as a code option as well as linking to the ticket creation page in case of MFA issues/failure.