### PR TITLE
Fix excluded regions

### DIFF
--- a/scripts/regions.rb
+++ b/scripts/regions.rb
@@ -32,7 +32,7 @@ regions.each do |region|
       site_regions = website['regions'].reject { |r| r.start_with?('-') }
       site_excluded_regions = website['regions'].select { |r| r.start_with?('-') }
     end
-    next unless website['regions'].nil? || site_regions.include?(region['id']) || region['id'].eql?('int')
+    next unless site_regions.nil? || site_regions.include?(region['id']) || region['id'].eql?('int')
     next if !site_excluded_regions.nil? && site_excluded_regions.include?(region['id'])
 
     all[name] = website


### PR DESCRIPTION
Sites excluded from a region are not being displayed on any regional site other than `int` due to the nil checking of `website['regions']` rather than `site_regions`.