### PR TITLE
Add HSBC US

### DIFF
--- a/entries/u/us.hsbc.com.json
+++ b/entries/u/us.hsbc.com.json
@@ -1,0 +1,16 @@
+{
+  "HSBC US": {
+    "domain": "us.hsbc.com",
+    "img": "hsbc.svg",
+    "contact": {
+      "facebook": "HSBCUS",
+      "twitter": "HSBC_US"
+    },
+    "regions": [
+      "us"
+    ],
+    "keywords": [
+      "banking"
+    ]
+  }
+}


### PR DESCRIPTION
See #6301 for discussion

2FA is not (fully) supported for HSBC US/`us.hsbc.com` following the FAQ content from https://www.us.hsbc.com/online-banking/security-device/device-faq/ 

> "There is no way I am going to keep another fob on my key ring or carry this around. Isn't there a way that I can just do my online banking like I used to without using this? 
You do still have the option to log on to Personal Internet Banking without your HSBC Security Device, but you will not be able to conduct certain transactions."