### PR TITLE
Fix excluded regions v3

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -213,6 +213,28 @@ government site - you can note this with the `regions` field.
 
 The country codes should be lowercase [ISO 3166-1][iso-country-wikipedia] codes.
 
+#### Excluded Regions
+
+If a site is available globally apart from a specific region, this can be noted using the `regions` array. Excluded regions should be prefixed with a `-` symbol to exclude them from that region. Region codes and excluded region codes shoul **not** be used together, as adding a region code automatically excludes it from other regions. The example below shows a site that is available in all regions apart from `us`.
+
+```JSON
+{
+  "Site Name": {
+    "domain": "site.com",
+    "tfa": [
+      "totp"
+    ],
+    "documentation": "<link to site TFA documentation>",
+    "keywords": [
+      "keyword"
+    ],
+    "regions": [
+      "-us"
+    ]
+  }
+}
+```
+
 ### Other Properties
 
 - `additional-domains`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -215,7 +215,7 @@ The country codes should be lowercase [ISO 3166-1][iso-country-wikipedia] codes.
 
 #### Excluded Regions
 
-If a site is available globally apart from a specific region, this can be noted using the `regions` array. Excluded regions should be prefixed with a `-` symbol to exclude them from that region. Region codes and excluded region codes should **not** be used together, as adding a region code automatically excludes it from other regions. The example below shows a site that is available in all regions apart from `us`.
+If a site is available globally apart from a specific region, this can be noted using the `regions` array. Excluded regions should be prefixed with a `-` symbol to exclude the site from that region. Region codes and excluded region codes should **not** be used together, as adding a region code automatically excludes the site from other regions. The example below shows a site that is available in all regions apart from `us`.
 
 ```JSON
 {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -215,7 +215,7 @@ The country codes should be lowercase [ISO 3166-1][iso-country-wikipedia] codes.
 
 #### Excluded Regions
 
-If a site is available globally apart from a specific region, this can be noted using the `regions` array. Excluded regions should be prefixed with a `-` symbol to exclude them from that region. Region codes and excluded region codes shoul **not** be used together, as adding a region code automatically excludes it from other regions. The example below shows a site that is available in all regions apart from `us`.
+If a site is available globally apart from a specific region, this can be noted using the `regions` array. Excluded regions should be prefixed with a `-` symbol to exclude them from that region. Region codes and excluded region codes should **not** be used together, as adding a region code automatically excludes it from other regions. The example below shows a site that is available in all regions apart from `us`.
 
 ```JSON
 {

--- a/api.md
+++ b/api.md
@@ -40,7 +40,7 @@ If you only intent on using a specific dataset, like all sites supporting RFC-62
 |recovery|URL||URL to recovery documentation page|
 |notes|String||Text describing any discrepancies in the 2FA implementation|
 |contact|Object||Object containing contact details. See table below for elements|
-|regions|array\<String>||Array containing ISO 3166-1 country codes of the regions in which the site is available|
+|regions|array\<String>||Array containing ISO 3166-1 country codes of the regions in which the site is available. If the site is available everywhere apart from a specific region, that region will be prefixed by a `-` symbol|
 |additional-domains|Array\<hostname>||Array of domains that the site exists at in addition to the main domain listed in the `domain` field.|
 |custom-(software\|hardware)|Array\<String>||Array of custom software/hardware methods that the site supports. Only present if the `tfa` element contains one of these 2FA types|
 |keywords|Array\<String>|:heavy_check_mark:|Array of categories to which the site belongs|

--- a/scripts/regions.rb
+++ b/scripts/regions.rb
@@ -15,6 +15,7 @@ FileUtils.cp_r(git_dir, "#{tmp_dir}/") unless File.exist?("#{tmp_dir}/.git")
 
 # Region loop
 # rubocop:disable Metrics/BlockLength
+# rubocop:disable Layout/LineLength
 regions.each do |region|
   dest_dir = "#{tmp_dir}/#{region['id']}"
   unless File.exist?(dest_dir)
@@ -30,9 +31,13 @@ regions.each do |region|
   websites.each do |name, website|
     unless website['regions'].nil?
       site_regions = website['regions'].reject { |r| r.start_with?('-') }
-      site_excluded_regions = website['regions'].select { |r| r.start_with?('-') }
+      site_excluded_regions = website['regions'].select { |r| r.start_with?('-') }.map! { |region_code| region_code.tr('-', '') }
     end
-    next unless site_regions.nil? || site_regions.include?(region['id']) || region['id'].eql?('int')
+
+    unless website['regions'].nil? || site_regions.empty? || site_regions.include?(region['id']) || region['id'].eql?('int')
+      next
+    end
+
     next if !site_excluded_regions.nil? && site_excluded_regions.include?(region['id'])
 
     all[name] = website
@@ -55,3 +60,4 @@ regions.each do |region|
   puts "#{region['id']} built."
 end
 # rubocop:enable Metrics/BlockLength
+# rubocop:enable Layout/LineLength


### PR DESCRIPTION
Summary:
- #6300 did nothing useful
- #6304 partially solved the problem
- The `site_excluded_regions` still held the "-regioncode" format, so when checking if that array included `region["id"]`, it was failing, meaning excluded regions weren't being detected.
- When there was an array with exclusion codes, `site_regions` was still being initialised, so wasn't `nil`, so the `next` statement was being triggered, resulting in excluded sites not being displayed on any regional site (other than `int`)

Test cases used locally:
- Bankera (not seen on `us`, but seen on all other regional sites)
- Vanguard (not seen on `au`, `gb`, but seen on all other regional sites)
- HSBC (not seen on `ar`, but seen on all other regional sites)