### PR TITLE
Switch logo height constraint to max-height 

### DIFF
--- a/_includes/scss/tables.scss
+++ b/_includes/scss/tables.scss
@@ -1,6 +1,6 @@
 /* Site name and logo */
 .logo {
-  height: 32px;
+  max-height: 32px;
   width: 32px;
   margin-right: .8em;
 


### PR DESCRIPTION
Makes non-square viewBoxes work as expected.

Before:
![before](https://d.tempfiles.download/D619A3DAB9E7C1/?p=OGIUdu9M)
After:
![after](https://d.tempfiles.download/D619A3D8A82E4B/?p=OBi6PmaW0HNbKdRy1tg)
