### PR TITLE
Update termius

### DIFF
--- a/entries/t/termius.com.json
+++ b/entries/t/termius.com.json
@@ -2,6 +2,7 @@
   "Termius": {
     "domain": "termius.com",
     "tfa": [
+      "totp",
       "custom-software"
     ],
     "documentation": "https://docs.termius.com/account/subscription#enable-2fa",

--- a/entries/t/termius.com.json
+++ b/entries/t/termius.com.json
@@ -5,6 +5,9 @@
       "totp",
       "custom-software"
     ],
+    "custom-software": [
+      "Authy"
+    ],
     "documentation": "https://docs.termius.com/account/subscription#enable-2fa",
     "keywords": [
       "remote"


### PR DESCRIPTION
Termius supports 2FA using TOTP. This is not stated in the documentation, but it is there. The documentation also links to the correct [url to change the 2FA settings](https://account.termius.com/).