### PR TITLE
Disable Rubocop Style/CombinableLoops

### DIFF
--- a/scripts/APIv2.rb
+++ b/scripts/APIv2.rb
@@ -21,8 +21,10 @@ Dir.glob('entries/*/*.json') do |file|
   }.select { |_, i| i } # Use keep the entries that aren't nil
 
   entry['tfa'] = website['tfa'].map { |e| rplc_ptrn.keys.include?(e) ? rplc_ptrn[e] : e } unless website['tfa'].nil?
+  # rubocop:disable Style/CombinableLoops
   website['contact']&.each { |a, b| a.eql?('email') ? entry['email_address'] = b : entry[a] = b }
   website['regions']&.each { |region| regions[region] = 1 + regions[region].to_i }
+  # rubocop:enable Style/CombinableLoops
 
   all[category].nil? ? all[category] = { name => entry } : all[category][name] = entry # Initialize the object
 end

--- a/scripts/APIv3.rb
+++ b/scripts/APIv3.rb
@@ -12,8 +12,8 @@ Dir.glob('entries/*/*.json') { |file| all[JSON.parse(File.read(file)).keys[0]] =
 all.sort.to_h.each do |k, v|
   # rubocop:disable Style/CombinableLoops
   v['tfa']&.each { |method| (tfa[method].nil? ? tfa[method] = { k => v } : tfa[method][k] = v) }
-   regions[region] = {} unless regions.key? region
-   regions[region]['count'] = 1 + regions[region]['count'].to_i
+    regions[region] = {} unless regions.key? region
+    regions[region]['count'] = 1 + regions[region]['count'].to_i
   end
   # rubocop:enable Style/CombinableLoops
 end

--- a/scripts/APIv3.rb
+++ b/scripts/APIv3.rb
@@ -12,8 +12,8 @@ Dir.glob('entries/*/*.json') { |file| all[JSON.parse(File.read(file)).keys[0]] =
 all.sort.to_h.each do |k, v|
   # rubocop:disable Style/CombinableLoops
   v['tfa']&.each { |method| (tfa[method].nil? ? tfa[method] = { k => v } : tfa[method][k] = v) }
-  v['regions']&.each do |region|
-    regions[region] = {} unless regions.key? region((regions[region]['count'] = 1 + regions[region]['count'].to_i))
+   regions[region] = {} unless regions.key? region
+   regions[region]['count'] = 1 + regions[region]['count'].to_i
   end
   # rubocop:enable Style/CombinableLoops
 end

--- a/scripts/APIv3.rb
+++ b/scripts/APIv3.rb
@@ -12,6 +12,7 @@ Dir.glob('entries/*/*.json') { |file| all[JSON.parse(File.read(file)).keys[0]] =
 all.sort.to_h.each do |k, v|
   # rubocop:disable Style/CombinableLoops
   v['tfa']&.each { |method| (tfa[method].nil? ? tfa[method] = { k => v } : tfa[method][k] = v) }
+  v['regions']&.each do |region|
     regions[region] = {} unless regions.key? region
     regions[region]['count'] = 1 + regions[region]['count'].to_i
   end

--- a/scripts/APIv3.rb
+++ b/scripts/APIv3.rb
@@ -10,11 +10,12 @@ regions = {}
 Dir.glob('entries/*/*.json') { |file| all[JSON.parse(File.read(file)).keys[0]] = JSON.parse(File.read(file)).values[0] }
 
 all.sort.to_h.each do |k, v|
+  # rubocop:disable Style/CombinableLoops
   v['tfa']&.each { |method| (tfa[method].nil? ? tfa[method] = { k => v } : tfa[method][k] = v) }
   v['regions']&.each do |region|
-    regions[region] = {} unless regions.key? region
-    regions[region]['count'] = 1 + regions[region]['count'].to_i
+    regions[region] = {} unless regions.key? region((regions[region]['count'] = 1 + regions[region]['count'].to_i))
   end
+  # rubocop:enable Style/CombinableLoops
 end
 
 avail_regions = YAML.load_file('_data/regions.yml').group_by { |hash| hash['id'] }.keys
@@ -27,6 +28,6 @@ end
 regions['int'] = { 'count' => all.length, 'selection' => true }
 
 File.open('api/v3/regions.json', 'w') { |file| file.write regions.sort_by { |_, v| v['count'] }.reverse!.to_h.to_json }
-# rubocop:disable Layout/LineLength
-File.open('api/v3/tfa.json', 'w') { |file| file.write all.select { |_, v| v.key? 'tfa' }.sort_by { |k, _| k.downcase }.to_json }
-# rubocop:enable Layout/LineLength
+File.open('api/v3/tfa.json', 'w') do |file|
+  file.write all.select { |_, v| v.key? 'tfa' }.sort_by { |k, _| k.downcase }.to_json
+end


### PR DESCRIPTION
Most recent version of Rubocop added Style/CombinableLoops checks.
Adhering to Style/CombinableLoops would create illogical code and thus this PR proposes to disable the checks for the files in question.