### PR TITLE
Update Dashlane

### DIFF
--- a/entries/d/dashlane.com.json
+++ b/entries/d/dashlane.com.json
@@ -2,12 +2,7 @@
   "Dashlane": {
     "domain": "dashlane.com",
     "url": "https://www.dashlane.com",
-    "tfa": [
-      "totp",
-      "u2f"
-    ],
     "documentation": "https://support.dashlane.com/hc/en-us/articles/202625042",
-    "notes": "FIDO U2F is a Premium feature only and requires the desktop app which has been deprecated and is no longer available to the public.",
     "keywords": [
       "identity"
     ]

--- a/entries/d/dashlane.com.json
+++ b/entries/d/dashlane.com.json
@@ -2,6 +2,9 @@
   "Dashlane": {
     "domain": "dashlane.com",
     "url": "https://www.dashlane.com",
+    "tfa": [
+      "totp"
+    ],
     "documentation": "https://support.dashlane.com/hc/en-us/articles/202625042",
     "keywords": [
       "identity"

--- a/entries/d/dashlane.com.json
+++ b/entries/d/dashlane.com.json
@@ -7,7 +7,7 @@
       "u2f"
     ],
     "documentation": "https://support.dashlane.com/hc/en-us/articles/202625042",
-    "notes": "FIDO U2F is a Premium feature only.",
+    "notes": "FIDO U2F is a Premium feature only and requires the desktop app which has been deprecated and is no longer available to the public.",
     "keywords": [
       "identity"
     ]


### PR DESCRIPTION
Dashlane does not currently support U2F for public use following the transition to using the webapp and removing their desktop app (the desktop app can be installed, but then refuses to run once the user logs in and instead directs them to the webapp). As such, it is no longer possible (despite advertising saying otherwise) to use U2F with dashlane.