### PR TITLE
Update Kaspersky

### DIFF
--- a/entries/k/kaspersky.com.json
+++ b/entries/k/kaspersky.com.json
@@ -7,6 +7,7 @@
       "sms"
     ],
     "documentation": "https://help.kaspersky.com/KPC/1.0/en-US/152628.htm",
+    "notes": "SMS 2FA must be enabled before TOTP 2FA can be setup. SMS 2FA cannot be disabled even when TOTP is enabled.",
     "keywords": [
       "security"
     ]

--- a/entries/k/kaspersky.com.json
+++ b/entries/k/kaspersky.com.json
@@ -7,7 +7,7 @@
       "sms"
     ],
     "documentation": "https://help.kaspersky.com/KPC/1.0/en-US/152628.htm",
-    "notes": "SMS 2FA must be enabled before TOTP 2FA can be setup. SMS 2FA cannot be disabled even when TOTP is enabled.",
+    "notes": "SMS 2FA must be enabled before TOTP 2FA can be set up. SMS 2FA cannot be disabled even when TOTP is enabled.",
     "keywords": [
       "security"
     ]


### PR DESCRIPTION
> At the current time, authenticator apps cannot be used on My Kaspersky as a standalone verification method. You must first set up two-step verification via your mobile phone number. If you turn off two-step verification via your mobile phone number, verification via an authenticator app is turned off automatically. After you have set up both verification via SMS and via an app, you will be able to select a verification method on the sign-in page.

