### PR TITLE
Generate regions in parallel

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ end
 group :test do
   gem 'httpclient'
   gem 'json_schemer'
+  gem 'parallel'
   gem 'rubocop'
   gem 'twitter'
 end

--- a/scripts/regions.rb
+++ b/scripts/regions.rb
@@ -19,11 +19,9 @@ FileUtils.cp_r(git_dir, "#{tmp_dir}/") unless File.exist?("#{tmp_dir}/.git")
 # rubocop:disable Layout/LineLength
 Parallel.each(-> { regions.pop || Parallel::Stop }) do |region|
   dest_dir = "#{tmp_dir}/#{region['id']}"
-  unless File.exist?(dest_dir)
-    Dir.mkdir(dest_dir) unless File.exist?(dest_dir)
-    files = %w[index.html _includes _layouts _data]
-    FileUtils.cp_r(files, dest_dir)
-  end
+  Dir.mkdir(dest_dir) unless File.exist?(dest_dir)
+  files = %w[index.html _includes _layouts _data]
+  FileUtils.cp_r(files, dest_dir)
 
   all = {}
   used_categories = {}

--- a/scripts/regions.rb
+++ b/scripts/regions.rb
@@ -4,6 +4,7 @@
 require 'json'
 require 'fileutils'
 require 'yaml'
+require 'parallel'
 
 data_dir = './_data'
 websites = JSON.parse(File.read("#{data_dir}/all.json"))
@@ -16,7 +17,7 @@ FileUtils.cp_r(git_dir, "#{tmp_dir}/") unless File.exist?("#{tmp_dir}/.git")
 # Region loop
 # rubocop:disable Metrics/BlockLength
 # rubocop:disable Layout/LineLength
-regions.each do |region|
+Parallel.each(-> { regions.pop || Parallel::Stop }) do |region|
   dest_dir = "#{tmp_dir}/#{region['id']}"
   unless File.exist?(dest_dir)
     Dir.mkdir(dest_dir) unless File.exist?(dest_dir)


### PR DESCRIPTION
This PR allows for the generation of regional sites in parallel which allows for sped up builds on multi-core architectures. As GitHub Actions runs in a 2-core environment it should theoretically half the runtime of `regions.rb`.

I also removed the if-statement ignoring generation of sites if the site already exists in `/tmp/{region}` which should improve testing on local systems.