### PR TITLE
Docker workflow - Use major version instead of exact

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,22 +20,22 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v3
       - name: Setup Docker QEMU
-        uses: docker/setup-qemu-action@v1.2.0
+        uses: docker/setup-qemu-action@v1
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to Docker Hub
-        uses: docker/login-action@v1.14.0
+        uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1.14.0
+        uses: docker/login-action@v1
         with:
           registry: ghcr.io
           username: ${{ GITHUB.ACTOR }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push Docker images
-        uses: docker/build-push-action@v2.9.0
+        uses: docker/build-push-action@v2
         with:
           context: .
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
Since semantic versioning is used there shouldn't be any critical changes between minor version changes and so this fixes dependabot's constant PRs.

Fixes #6588 