### PR TITLE
Update HUK-Coburg

### DIFF
--- a/entries/h/huk.de.json
+++ b/entries/h/huk.de.json
@@ -1,12 +1,10 @@
 {
   "HUK-Coburg": {
     "domain": "huk.de",
-    "url": "https://www.huk.de/",
-    "contact": {
-      "email": "info@huk-coburg.de",
-      "twitter": "HUK",
-      "language": "de"
-    },
+    "tfa": [
+      "sms",
+      "call"
+    ],
     "keywords": [
       "finance"
     ],


### PR DESCRIPTION
2FA is now mandatory, but I haven't found any documentation. SMS is the default, with a phone call as the fallback.

That's how the 2FA login screen looks like:
![huk-2fa](https://user-images.githubusercontent.com/520841/158063695-73153564-e189-4578-908d-fa975f561612.png)
