### PR TITLE
Replace Font-Awesome with Bootstrap Icons

### DIFF
--- a/_data/categories.json
+++ b/_data/categories.json
@@ -2,32 +2,32 @@
   {
     "name": "backup",
     "title": "Backup and Sync",
-    "icon": "fas fa-cloud-upload-alt"
+    "icon": "bi bi-cloud-arrow-up-fill"
   },
   {
     "name": "banking",
     "title": "Banking",
-    "icon": "fas fa-dollar-sign"
+    "icon": "bi bi-currency-dollar"
   },
   {
     "name": "betting",
     "title": "Betting",
-    "icon": "fas fa-trophy"
+    "icon": "bi bi-trophy-fill"
   },
   {
     "name": "cloud",
     "title": "Cloud Computing",
-    "icon": "fas fa-cloud"
+    "icon": "bi bi-cloud-fill"
   },
   {
     "name": "communication",
     "title": "Communication",
-    "icon": "fas fa-comments"
+    "icon": "bi bi-chat-left-fill"
   },
   {
     "name": "creativity",
     "title": "Creativity",
-    "icon": "fas fa-palette"
+    "icon": "bi bi-palette-fill"
   },
   {
     "name": "crowdfunding",
@@ -37,7 +37,7 @@
   {
     "name": "cryptocurrencies",
     "title": "Cryptocurrencies",
-    "icon": "fab fa-btc"
+    "icon": "bi bi-currency-bitcoin"
   },
   {
     "name": "developer",
@@ -47,7 +47,7 @@
   {
     "name": "domains",
     "title": "Domains",
-    "icon": "fas fa-globe-europe"
+    "icon": "bi bi-globe"
   },
   {
     "name": "education",
@@ -57,12 +57,12 @@
   {
     "name": "email",
     "title": "Email",
-    "icon": "fas fa-envelope"
+    "icon": "bi bi-envelope-fill"
   },
   {
     "name": "entertainment",
     "title": "Entertainment",
-    "icon": "fas fa-play"
+    "icon": "bi bi-play-circle-fill"
   },
   {
     "name": "finance",
@@ -87,12 +87,12 @@
   {
     "name": "health",
     "title": "Health",
-    "icon": "fas fa-heartbeat"
+    "icon": "bi bi-heart-pulse-fill"
   },
   {
     "name": "hosting",
     "title": "Hosting/VPS",
-    "icon": "fas fa-server"
+    "icon": "bi bi-hdd-stack-fill"
   },
   {
     "name": "hotels",
@@ -102,17 +102,17 @@
   {
     "name": "identity",
     "title": "Identity Management",
-    "icon": "fas fa-id-card"
+    "icon": "bi bi-person-badge-fill"
   },
   {
     "name": "investing",
     "title": "Investing",
-    "icon": "fas fa-chart-line"
+    "icon": "bi bi-graph-up-arrow"
   },
   {
     "name": "iot",
     "title": "IoT",
-    "icon": "fas fa-wifi"
+    "icon": "bi bi-wifi"
   },
   {
     "name": "legal",
@@ -122,17 +122,17 @@
   {
     "name": "marketing",
     "title": "Marketing & Analytics",
-    "icon": "fas fa-bullhorn"
+    "icon": "bi bi-megaphone-fill"
   },
   {
     "name": "other",
     "title": "Other",
-    "icon": "fas fa-ellipsis-h"
+    "icon": "bi bi-three-dots"
   },
   {
     "name": "payments",
     "title": "Payments",
-    "icon": "fas fa-credit-card"
+    "icon": "bi bi-credit-card-fill"
   },
   {
     "name": "postal",
@@ -142,32 +142,32 @@
   {
     "name": "remote",
     "title": "Remote Access",
-    "icon": "fas fa-desktop"
+    "icon": "bi bi-pc-display"
   },
   {
     "name": "retail",
     "title": "Retail",
-    "icon": "fas fa-shopping-cart"
+    "icon": "bi bi-cart-fill"
   },
   {
     "name": "security",
     "title": "Security",
-    "icon": "fas fa-unlock"
+    "icon": "bi bi-unlock-fill"
   },
   {
     "name": "social",
     "title": "Social",
-    "icon": "fas fa-users"
+    "icon": "bi bi-people-fill"
   },
   {
     "name": "task",
     "title": "Task Management",
-    "icon": "fas fa-tasks"
+    "icon": "bi bi-list-task"
   },
   {
     "name": "tickets",
     "title": "Tickets and Events",
-    "icon": "fas fa-ticket-alt"
+    "icon": "bi bi-ticket-detailed-fill"
   },
   {
     "name": "transport",
@@ -177,16 +177,16 @@
   {
     "name": "universities",
     "title": "Universities",
-    "icon": "fas fa-graduation-cap"
+    "icon": "bi bi-mortarboard-fill"
   },
   {
     "name": "utilities",
     "title": "Utilities",
-    "icon": "fas fa-phone-alt"
+    "icon": "bi bi-telephone-fill"
   },
   {
     "name": "vpn",
     "title": "VPN Providers",
-    "icon": "fas fa-shield-alt"
+    "icon": "bi bi-shield-lock-fill"
   }
 ]

--- a/_includes/html/desktop-table.html
+++ b/_includes/html/desktop-table.html
@@ -37,7 +37,7 @@
               {{ name }}</a>
 
               {% if website.notes %}
-                <i class="fas fa-exclamation-triangle exception" data-content="{{ website.notes }}"></i>
+                <i class="bi bi-exclamation-triangle-fill exception" data-content="{{ website.notes }}"></i>
               {% endif %}
             </div>
           </td>
@@ -49,12 +49,12 @@
               <div class="row">
               {% if website.documentation %}
                 <a href="{{ website.documentation | remove: 'https://2fa.directory' }}" class="col">
-                  <i class="fas fa-book"></i>
+                  <i class="bi bi-file-earmark-text-fill"></i>
                 </a>
               {% endif %}
               {% if website.recovery %}
                 <a href="{{ website.recovery }}" class="col">
-                  <i class="fas fa-redo"></i>
+                  <i class="bi bi-arrow-counterclockwise"></i>
                 </a>
               {% endif %}
               </div>
@@ -62,26 +62,26 @@
 
             <td class="icon-cell">
               {% if tfa contains "sms" %}
-                <i class="tfa-icon fas fa-check"></i>
+                <i class="tfa-icon checkmark" aria-label="sms"></i>
               {% endif %}
             </td>
 
             <td class="icon-cell">
               {% if tfa contains "call" %}
-                <i class="tfa-icon fas fa-check"></i>
-                {%endif%}
+                <i class="tfa-icon checkmark" aria-label="phone call"></i>
+              {%endif%}
             </td>
 
             <td class="icon-cell">
               {% if tfa contains "email" %}
-                <i class="tfa-icon fas fa-check"></i>
+                <i class="tfa-icon checkmark" aria-label="email"></i>
               {% endif %}
             </td>
 
             <td class="icon-cell">
               <div class="row">
                 {% if tfa contains "custom-hardware" %}
-                  <i class="tfa-icon fas fa-info col"
+                  <i class="tfa-icon bi bi-info-circle-fill col"
                      title="{%- if website.custom-hardware -%}
                      {%- if website.custom-hardware.size > 1 -%}
                      Requires one of:
@@ -108,10 +108,10 @@
             <td class="icon-cell">
               <div class="row">
                 {% if tfa contains "totp" %}
-                  <i class="tfa-icon fas fa-check col" title="TOTP support"></i>
+                  <i class="tfa-icon checkmark col" aria-label="TOTP" title="TOTP support"></i>
                 {% endif %}
                 {% if tfa contains "custom-software" %}
-                  <i class="tfa-icon fas fa-info col"
+                  <i class="tfa-icon bi bi-info-circle-fill col"
                      title="{%- if website.custom-software -%}
                      {%- if website.custom-hardware.size > 1 -%}
                      Requires one of:
@@ -134,19 +134,19 @@
               <div class="social-button-group">
                 {% if website.contact.twitter %}
                   <div class="twitter-button social-button btn" data-twitter="{{ website.contact.twitter }}" data-lang="{{ website.contact.language }}">
-                    <i class="fab fa-twitter"></i>
+                    <i class="bi bi-twitter"></i>
                     On Twitter
                   </div>
                 {% endif %}
                 {% if website.contact.facebook %}
                   <div class="facebook-button social-button btn" data-facebook="{{ website.contact.facebook }}">
-                    <i class="fab fa-facebook-f"></i>
+                    <i class="bi bi-facebook"></i>
                     On Facebook
                   </div>
                 {% endif %}
                 {% if website.contact.email %}
                   <div class="email-button social-button btn" data-email="{{ website.contact.email }}" data-lang="{{ website.contact.language }}">
-                    <i class="fas fa-envelope"></i>
+                    <i class="bi bi-envelope-fill"></i>
                     Via Email</div>
                 {% endif %}
               </div>

--- a/_includes/html/mobile-table.html
+++ b/_includes/html/mobile-table.html
@@ -26,19 +26,20 @@
 
           {{ name }}</a>
           {% if website.notes %}
-                <i class="fas fa-exclamation-triangle exception" data-content="{{ website.notes }}"></i>
+                <i class="bi bi-exclamation-triangle-fill exception" data-content="{{ website.notes }}"></i>
           {% endif %}
       </div>
 
       <!-- tfa options -->
       {% if website.tfa %}
-        <div class="row row-cols-2">
+    <p class="text-success">Supported options:</p>
+    <div class="row row-cols-3 rows-cols-sm">
           {% for tfa in website.tfa %}
 
             <div class="col text-success tfa-option">
-              <i class="fas fa-check"></i>
               <b>
-                {{ tfa | replace: "custom-software", "custom Software" | replace: "custom-hardware", "custom Hardware" | capitalize | replace: "Sms", "SMS" | replace: "Totp", "TOTP" | replace: "U2f", "U2F" }}</b>
+                {{ tfa | replace: "custom-software", "custom Software" | replace: "custom-hardware", "custom Hardware" | capitalize | replace: "Sms", "SMS" | replace: "Totp", "TOTP" | replace: "U2f", "U2F" }}
+              </b>
             </div>
 
           {% endfor %}
@@ -48,7 +49,7 @@
         {% if website.documentation %}
           <div class="btn doc-btn col-11 col-sm-8 d-flex justify-content-center website-doc">
             <a href="{{ website.documentation | remove: 'https://2fa.directory' }}">
-              <i class="fas fa-book"></i>
+              <i class="bi bi-file-earmark-text-fill"></i>
               Documentation
             </a>
           </div>
@@ -62,7 +63,7 @@
           {% if website.contact.twitter %}
 
             <div class="col ml-md-auto twitter-button social-button btn" title="Tweet them!" data-twitter="{{ website.contact.twitter }}" data-lang="{{ website.contact.language }}">
-              <i class="fab fa-twitter"></i>
+              <i class="bi bi-twitter"></i>
             </div>
 
           {% endif %}
@@ -70,7 +71,7 @@
           {% if website.contact.facebook %}
 
             <div class="col facebook-button social-button btn" title="Contact them!" data-facebook="{{ website.contact.facebook }}">
-              <i class="fab fa-facebook-f"></i>
+              <i class="bi bi-facebook"></i>
             </div>
 
           {% endif %}
@@ -78,7 +79,7 @@
           {% if website.contact.email %}
 
             <div class="col email-button social-button btn" title="Email them!" data-email="{{ website.contact.email }}" data-lang="{{ website.contact.language }}">
-              <i class="fas fa-envelope"></i>
+              <i class="bi bi-envelope-fill"></i>
             </div>
 
           {% endif %}

--- a/_includes/scss/categories.scss
+++ b/_includes/scss/categories.scss
@@ -1,4 +1,5 @@
 .category-btn-outer {
+  margin-top: 0;
   padding: 12px;
 }
 
@@ -22,7 +23,9 @@
     color: #3e3e3e;
     border: none;
     font-size: 2.5em;
-
+    &.bi::before {
+        font-size: 50px;
+      }
   }
 
   .category-title {
@@ -34,6 +37,9 @@
     bottom: 0;
     top: 0;
     text-align: center;
+    font-weight: 600;
+    font-size: 1.2em;
+    margin-bottom: 8px;
   }
 
   /* Let the category-title adjust freely when not paired with .box */

--- a/_includes/scss/desktop-table.scss
+++ b/_includes/scss/desktop-table.scss
@@ -51,6 +51,7 @@
         }
 
         td {
+          vertical-align: middle !important;
           font-weight: 400;
           font-family: "Open Sans", sans-serif;
           font-size: 18px !important;
@@ -69,6 +70,10 @@
               padding-right: 24px;
             }
           }
+
+          .exception {
+            font-size: 25px;
+          }
         }
 
         /* 2FA cells */
@@ -80,14 +85,17 @@
             img {
               text-align: center;
               margin: auto;
-              height:30px;
+              height: 30px;
               transform: rotate(30deg);
             }
           }
 
-          .fa-book,
-          .tfa-icon,
-          .fa-redo {
+          .bi-arrow-counterclockwise,
+          .bi-file-earmark-text-fill {
+            font-size: 35px;
+          }
+
+          .tfa-icon {
             font-size: 27px;
             line-height: 35px;
           }
@@ -96,6 +104,26 @@
             color: #2c662d;
           }
         }
+      }
+
+      .checkmark::before {
+        display: inline-block;
+        content: "";
+        vertical-align: -.125em;
+        background-image: url("data:image/svg+xml,<svg viewBox='0 0 16 16' fill='%232c662d' xmlns='http://www.w3.org/2000/svg'><path d='M13.854 3.646a.5.5 0 0 1 0 .708l-7 7a.5.5 0 0 1-.708 0l-3.5-3.5a.5.5 0 1 1 .708-.708L6.5 10.293l6.646-6.647a.5.5 0 0 1 .708 0z'/></svg>");
+        background-repeat: no-repeat;
+        height: 37px;
+        width: 37px;
+      }
+
+      .documentation::before {
+        display: inline-block;
+        content: "";
+        vertical-align: -.125em;
+        background-image: url("data:image/svg+xml,<svg viewBox='0 0 16 16' fill='%233596ff' xmlns='http://www.w3.org/2000/svg'><path d='M9.293 0H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2V4.707A1 1 0 0 0 13.707 4L10 .293A1 1 0 0 0 9.293 0zM9.5 3.5v-2l3 3h-2a1 1 0 0 1-1-1zM4.5 9a.5.5 0 0 1 0-1h7a.5.5 0 0 1 0 1h-7zM4 10.5a.5.5 0 0 1 .5-.5h7a.5.5 0 0 1 0 1h-7a.5.5 0 0 1-.5-.5zm.5 2.5a.5.5 0 0 1 0-1h4a.5.5 0 0 1 0 1h-4z'/></svg>");
+        background-repeat: no-repeat;
+        height: 35px;
+        width: 27px;
       }
 
       /* Both body and head */

--- a/_includes/scss/social-media.scss
+++ b/_includes/scss/social-media.scss
@@ -7,7 +7,7 @@
 
 .social-button {
   height: 100%;
-  width: 140px;
+  width: 144px;
   color: white;
   margin: 0 6px;
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -11,7 +11,9 @@
     {% include html/icons.html %}
     <link href="/manifest.json" rel="manifest">
     <link rel="stylesheet" href="/css/bootstrap.css"/>
-    <link rel="stylesheet" crossorigin="anonymous" integrity="sha512-9BwLAVqqt6oFdXohPLuNHxhx36BVj5uGSGmizkmGkgl3uMSgNalKc/smum+GJU/TTP0jy0+ruwC3xNAk3F759A==" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.1/css/all.min.css"/>
+    <link rel="stylesheet" crossorigin="anonymous" referrerpolicy="no-referrer" integrity="sha512-P9vJUXK+LyvAzj8otTOKzdfF1F3UYVl13+F8Fof8/2QNb8Twd6Vb+VD52I7+87tex9UXxnzPgWA3rH96RExA7A==" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/fontawesome.min.css"/>
+    <link rel="stylesheet" crossorigin="anonymous" referrerpolicy="no-referrer" integrity="sha512-6/gTF62BJ06BajySRzTm7i8N2ZZ6StspU9uVWDdoBiuuNu5rs1a8VwiJ7skCz2BcvhpipLKfFerXkuzs+npeKA==" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/solid.min.css"/>
+    <link rel="stylesheet" crossorigin="anonymous" referrerpolicy="no-referrer" integrity="sha512-Oy+sz5W86PK0ZIkawrG0iv7XwWhYecM3exvUtMKNJMekGFJtVAhibhRPTpmyTj8+lJCkmWfnpxKgT2OopquBHA==" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-icons/1.8.1/font/bootstrap-icons.min.css"/>
     <link rel="stylesheet" crossorigin="anonymous" integrity="sha512-xbKj38YamwOa1yyC9gTFLExhbbV6r8WZwaEYYYaedfU0gosQuncv6p//9zcjK1NO2nkV/Nv5X5TkM/zjOnlc+w==" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/3.4.6/css/flag-icon.min.css"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:400,700|Roboto:300|Spartan:500&display=swap">
     <link href="/css/main.css" rel="stylesheet">

--- a/css/main.scss
+++ b/css/main.scss
@@ -14,15 +14,15 @@
 
 body {
   background-color: var(--background);
-  font-family: open sans, Helvetica, Arial, sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "open sans", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
   min-width: 300px;
   color: var(--text-color);
 }
 html {
   scroll-behavior: smooth;
 }
-h1, h2, h3, h4 {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+h1, h2, h3, h4, .category-title {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
 }
 
 @media (prefers-color-scheme: dark) {


### PR DESCRIPTION
Apologies as this turned out to be a rather massive pull request.
As Font Awesome goes further and further away from FOSS I thought it could be a good idea to replace it with something that better aligns with this project. Bootstrap Icons have equivalent icons for almost all Font Awesome icons that we use and using Bootstrap Icons would result in a smaller library size for all users.

I had some issues with the webfont version of the documentation and checkmark icons which is why those icons use SVG instead of webfonts.

As the Bootstrap Icons project is rather new and a few categories don't have equivalent icons I couldn't remove Font Awesome completely but instead only have the Solid icons which still results in a smaller size.

Here's a screenshot of the page with Bootstrap Icons:
![](https://user-images.githubusercontent.com/3535780/158218359-b6d25bcd-a6dc-43fe-80dc-499d3052affb.png)

