### PR TITLE
Fix bug closing categories directly after opening

### DIFF
--- a/_includes/html/category-button.html
+++ b/_includes/html/category-button.html
@@ -2,7 +2,7 @@
 {% assign title = include.category-param.title %}
 {% assign icon = include.category-param.icon %}
 <div class="col {{ include.viewport }}-only category-btn-outer">
-  <button class="row {% unless include.viewport == 'mobile' %}box{% endunless %} category-btn" data-toggle="collapse" data-target="#{{name}}-table" aria-expanded="false" aria-controls="{{ name }}-table">
+  <button class="row {% unless include.viewport == 'mobile' %}box{% endunless %} category-btn" id="{{ name }}" href="#{{ name }}" aria-controls="{{ name }}-table">
     <div class="col"></div>
     <div class="col-12 align-self-center">
       <i class="{{ icon }} category-icon fa-fw mx-auto d-block"></i>

--- a/js/main.js
+++ b/js/main.js
@@ -1,57 +1,47 @@
-$(document).ready(function () {
-  // Show region notice
-  if (window.localStorage.getItem('region-notice') !== 'hidden') $('#region-notice').collapse('show');
+$(document).ready(() => {
 
   // Register service worker
   if ('serviceWorker' in navigator) navigator.serviceWorker.register('/service-worker.js');
+
+  // Show region notice
+  if (window.localStorage.getItem('region-notice') !== 'hidden') $('#region-notice').collapse('show');
 
   // Show category of query
   const query = window.location.hash;
   if (query && query.indexOf('#') > -1) showCategory(query.substring(1));
 });
 
-$(window).on('hashchange', function () {
+$(window).on('hashchange', async () => {
   const query = window.location.hash;
-  if (query && query.indexOf('#') > -1) showCategory(query.substring(1));
+  if (query && query.indexOf('#') > -1) await showCategory(query.substring(1));
 });
-
-$('.exception').popup({position: 'right center', hoverable: true, title: 'Exceptions & Restrictions'});
 
 // On category click
-$('.category-btn').click(function () {
-  let query = window.location.hash.substring(1);
-
-  // Collapse all other tables
-  $('.category-table.collapse').collapse('hide');
-  $('.category-btn').removeClass('active');
-
-  const id = $(this).data('target').replace('-table', '').substring(1);
-  // Check if category tables are displayed
-  if (!$(`#${query}-table`).hasClass('collapsing') && !$(`#${query}-mobile-table`).hasClass('collapsing') || query !== id) {
-    window.location.hash = id;
-    showCategory(id);
-  } else {
-    // Remove #category in URL
+$('.category-btn').click(async function () {
+  const href = $(this).attr('href');
+  if (window.location.hash === href) {
     history.pushState("", document.title, window.location.pathname + window.location.search);
+    $('.category-table.collapse').collapse('hide');
+    $('.category-btn').removeClass('active');
+  } else {
+    window.location.hash = href;
   }
-});
+})
 
-$('#region-notice-close-btn').click(function () {
+$('#region-notice-close-btn').click(async () => {
   $('#region-notice').collapse('hide');
   window.localStorage.setItem('region-notice', 'hidden');
 });
 
 // Show desktop and mobile tables
-function showCategory(category) {
-  $('.category-table.collapse').collapse('hide');
-  $(`#${category}-table`).collapse("show");
-  $(`#${category}-mobile-table`).collapse("show");
-  $('.category-btn').removeClass('active');
-  $(`.category-btn[data-target="#${category}-table"]`).addClass('active');
+async function showCategory(category) {
+  $(`.category-table.collapse:not(#${category}-table, ${category}-mobile-table)`).collapse('hide');
+  $(`.category-btn:not([id=${category}])`).removeClass('active');
+  $(`#${category}-table, ${category}-mobile-table`).collapse("show");
+  $(`[id=${category}]`).addClass('active');
 }
 
 let resizeObserver = new ResizeObserver(() => {
-  // Fix the footer to bottom of viewport if body is less than viewport
   if ($('body').height() < $(window).height()) {
     $('.footer').css({position: 'absolute'});
   } else {
@@ -60,3 +50,5 @@ let resizeObserver = new ResizeObserver(() => {
 });
 
 resizeObserver.observe($('body')[0]);
+
+$('.exception').popup({position: 'right center', hoverable: true, title: 'Exceptions & Restrictions'});


### PR DESCRIPTION
There's a bug where a category table closes directly after being opened. To fix the bug I had to dissect the main.js file and rewrite the window.location.hash handling.

Notice the address bar in the following screen recording:

https://user-images.githubusercontent.com/3535780/164553655-54eddf53-197c-44c8-b5af-7aa507ba1ed1.mp4




