### PR TITLE
Fix Bootstrap 5 CSS bugs

### DIFF
--- a/_includes/html/navbar.html
+++ b/_includes/html/navbar.html
@@ -13,7 +13,7 @@
       {% assign regions2 = regions | map: 'id' %}
       {% if page.name == "index.html" %}
       <li class="nav-item dropdown">
-        <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle" data-toggle="dropdown" id="regionDropdown" role="button" tabindex="0">
+        <a class="nav-link dropdown-toggle" id="regionDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false" aria-haspopup="true" tabindex="0">
           Region
           {% assign baseurl = site.baseurl %}
           {% if regions2 contains baseurl %}

--- a/_includes/scss/tables.scss
+++ b/_includes/scss/tables.scss
@@ -9,6 +9,14 @@
   }
 }
 
+.table-success, .table-success > td {
+  background: var(--bs-table-bg);
+}
+
+.table-danger, .table-danger > td {
+  background: var(--bs-table-bg);
+}
+
 @media (prefers-color-scheme: dark) {
   body {
     background-color: #212121;

--- a/_includes/scss/tables.scss
+++ b/_includes/scss/tables.scss
@@ -9,11 +9,7 @@
   }
 }
 
-.table-success, .table-success > td {
-  background: var(--bs-table-bg);
-}
-
-.table-danger, .table-danger > td {
+.table-success, .table-danger {
   background: var(--bs-table-bg);
 }
 


### PR DESCRIPTION
Some CSS issues that I missed in #6485

The issues fixed are:
* Regions dropdown not clickable
* tables don't include background color on mobile in with light theme

In my defense for not noticing the last bug, no sane person writes code without system dark theme enabled 😉