### PR TITLE
Split Klarna

### DIFF
--- a/entries/k/klarna.com.json
+++ b/entries/k/klarna.com.json
@@ -1,12 +1,13 @@
 {
   "Klarna": {
     "domain": "klarna.com",
-    "url": "https://www.klarna.com",
     "tfa": [
       "email",
-      "custom-software"
+      "sms",
+      "call"
     ],
-    "notes": "Software 2FA is only available for Swedish citizens with BankID.",
+    "documentation": "https://www.klarna.com/us/customer-service/how-do-i-log-in/",
+    "recovery": "https://www.klarna.com/us/customer-service/i-cant-log-in-what-can-i-do/",
     "keywords": [
       "payments"
     ],
@@ -25,11 +26,9 @@
       "ie",
       "it",
       "nl",
-      "no",
       "nz",
       "pl",
       "pt",
-      "se",
       "us"
     ]
   }

--- a/entries/k/klarna.com.json
+++ b/entries/k/klarna.com.json
@@ -9,8 +9,28 @@
       "payments"
     ],
     "regions": [
-      "-no",
-      "-se"
+      "at",
+      "au",
+      "be",
+      "ca",
+      "ch",
+      "cn",
+      "cz",
+      "de",
+      "dk",
+      "es",
+      "fi",
+      "fr",
+      "gb",
+      "gr",
+      "ie",
+      "it",
+      "jp",
+      "nl",
+      "nz",
+      "pl",
+      "pt",
+      "us"
     ]
   }
 }

--- a/entries/k/klarna.com.json
+++ b/entries/k/klarna.com.json
@@ -12,24 +12,8 @@
       "payments"
     ],
     "regions": [
-      "at",
-      "au",
-      "be",
-      "ca",
-      "ch",
-      "de",
-      "dk",
-      "es",
-      "gb",
-      "fi",
-      "fr",
-      "ie",
-      "it",
-      "nl",
-      "nz",
-      "pl",
-      "pt",
-      "us"
+      "-no",
+      "-se"
     ]
   }
 }

--- a/entries/k/klarna.com.json
+++ b/entries/k/klarna.com.json
@@ -1,13 +1,10 @@
 {
   "Klarna": {
     "domain": "klarna.com",
-    "tfa": [
-      "email",
-      "sms",
-      "call"
-    ],
-    "documentation": "https://www.klarna.com/us/customer-service/how-do-i-log-in/",
-    "recovery": "https://www.klarna.com/us/customer-service/i-cant-log-in-what-can-i-do/",
+    "contact": {
+      "twitter": "AskKlarna",
+      "facebook": "Klarna"
+    },
     "keywords": [
       "payments"
     ],

--- a/entries/k/klarna.no.json
+++ b/entries/k/klarna.no.json
@@ -1,0 +1,21 @@
+{
+  "Klarna Norge": {
+    "domain": "klarna.no",
+    "tfa": [
+      "custom-software"
+    ],
+    "img": "klarna.com.svg",
+    "custom-software": [
+      "BankID"
+    ],
+    "documentation": "https://www.klarna.com/no/kundeservice/hvordan-logger-jeg-inn/",
+    "recovery": "https://www.klarna.com/no/kundeservice/jeg-kan-ikke-logge-inn-hva-kan-jeg-gjore/",
+    "keywords": [
+      "payments",
+      "banking"
+    ],
+    "regions": [
+      "no"
+    ]
+  }
+}

--- a/entries/k/klarna.se.json
+++ b/entries/k/klarna.se.json
@@ -1,0 +1,21 @@
+{
+  "Klarna Sverige": {
+    "domain": "klarna.se",
+    "tfa": [
+      "custom-software"
+    ],
+    "img": "klarna.com.svg",
+    "custom-software": [
+      "BankID"
+    ],
+    "documentation": "https://www.klarna.com/se/kundservice/hur-loggar-jag-in/",
+    "recovery": "https://www.klarna.com/se/kundservice/jag-kan-inte-logga-in-vad-kan-jag-gora/",
+    "keywords": [
+      "payments",
+      "banking"
+    ],
+    "regions": [
+      "se"
+    ]
+  }
+}


### PR DESCRIPTION
Klarna offers:
* payment services internationally and authenticates through email/SMS/calls (except in NO & SE).
* banking and payment services to Norway and Sweden using software authentication called BankID.

_Note that "BankID" refers to different methods in the two different countries as it's run by completely unrelated companies. It thus can't be merged into the same entry._

To not make duplicate entries I had to use different domain names for all the entries resulting in Klarna SE and Klarna NO not receiving the appropriate SimilarWeb ranking as the domain which they 301 to. Should still be possible to merge though. 