### PR TITLE
Update lhv.ee

### DIFF
--- a/entries/l/lhv.ee.json
+++ b/entries/l/lhv.ee.json
@@ -1,7 +1,6 @@
 {
   "LHV": {
     "domain": "lhv.ee",
-    "url": "https://www.lhv.ee/",
     "tfa": [
       "custom-software",
       "custom-hardware"

--- a/entries/l/lhv.ee.json
+++ b/entries/l/lhv.ee.json
@@ -2,12 +2,6 @@
   "LHV": {
     "domain": "lhv.ee",
     "url": "https://www.lhv.ee/",
-    "contact": {
-      "email": "info@lhv.ee",
-      "facebook": "LHVPank",
-      "twitter": "ellhaavee",
-      "language": "et"
-    },
     "tfa": [
       "custom-software",
       "custom-hardware"

--- a/entries/l/lhv.ee.json
+++ b/entries/l/lhv.ee.json
@@ -5,6 +5,13 @@
       "custom-software",
       "custom-hardware"
     ],
+    "custom-software": [
+      "eIDAS (SmartID)"
+    ],
+    "custom-hardware": [
+      "eIDAS (ID-card, mobile-ID)",
+      "Security token"
+    ],
     "regions": [
       "ee"
     ],

--- a/entries/l/lhv.ee.json
+++ b/entries/l/lhv.ee.json
@@ -6,10 +6,11 @@
       "custom-hardware"
     ],
     "custom-software": [
-      "eIDAS (SmartID)"
+      "SmartID"
     ],
     "custom-hardware": [
-      "eIDAS (ID-card, mobile-ID)",
+      "ID-card",
+      "mobile-ID",
       "Security token"
     ],
     "regions": [

--- a/entries/l/lhv.ee.json
+++ b/entries/l/lhv.ee.json
@@ -8,6 +8,10 @@
       "twitter": "ellhaavee",
       "language": "et"
     },
+    "tfa": [
+      "custom-software",
+      "custom-hardware"
+    ],
     "regions": [
       "ee"
     ],


### PR DESCRIPTION
The current selection of 2FA methods is somewhat incomplete. I chose "custom-hardware" even though mTLS using Smart Cards isn't more proprietary than say Yubikey Webauthn, but there's no option for that. LHV and all other Estonian banks have supported mTLS authentication for 8 or so years now. I also added "custom-software" because by now there is a mobile app as well. 

Both methods fall under the EU-wide eIDAS regulation/specification, which is now being adopted by more and more countries each year. So maybe it should just be "software-eidas" and "hardware-eidas", if there's a wish to differentiate.

I should also mention that all entries concerning EU-member country banks should probably be updated if they currently list no 2FA. This specific bank offered these options before PSD2 was turned into a law in 2017, but PSD2 has made it mandatory EU-wide.
