### PR TITLE
Update PayPal

### DIFF
--- a/entries/p/paypal.com.json
+++ b/entries/p/paypal.com.json
@@ -5,10 +5,9 @@
     "tfa": [
       "sms",
       "totp",
-      "u2f",
-      "custom-software"
+      "u2f"
     ],
-    "documentation": "https://www.paypal.com/ee/smarthelp/article/faq4502",
+    "documentation": "https://www.paypal.com/ee/smarthelp/article/faq4057",
     "keywords": [
       "payments"
     ]

--- a/entries/p/paypal.com.json
+++ b/entries/p/paypal.com.json
@@ -4,10 +4,11 @@
     "url": "https://www.paypal.com/",
     "tfa": [
       "sms",
-      "totp"
+      "totp",
+      "u2f",
+      "custom-software"
     ],
-    "documentation": "https://www.paypal.com/us/smarthelp/article/faq4057",
-    "notes": "2FA is only available in a few countries. Contact PayPal on Twitter for an up-to-date list of available countries.",
+    "documentation": "https://www.paypal.com/ee/smarthelp/article/faq4502",
     "keywords": [
       "payments"
     ]

--- a/entries/p/paypal.com.json
+++ b/entries/p/paypal.com.json
@@ -7,7 +7,7 @@
       "totp",
       "u2f"
     ],
-    "documentation": "https://www.paypal.com/ee/smarthelp/article/faq4057",
+    "documentation": "https://www.paypal.com/us/smarthelp/article/faq4057",
     "keywords": [
       "payments"
     ]

--- a/entries/p/paypal.com.json
+++ b/entries/p/paypal.com.json
@@ -7,6 +7,7 @@
       "totp",
       "u2f"
     ],
+    "notes": "Some methods of 2FA are only available in a few countries. Contact PayPal for more information.",
     "documentation": "https://www.paypal.com/us/smarthelp/article/faq4057",
     "keywords": [
       "payments"


### PR DESCRIPTION
Symantec VIP (custom-ish TOTP) is being deprecated, the listed alternatives are:

* Mobile phone SMS
* Authenticator apps: Options include Authy, Google Authenticator, Microsoft Authenticator, DUO, YubiKey Auth App, and many others. 
* YubiKey 5 Series: All of its desktop, authenticator app, and hard tokens will work for primary and secondary users via the “Authenticator Option” in the 2-step verification process.