### PR TITLE
Wrike: Clarify restrictions

### DIFF
--- a/entries/w/wrike.com.json
+++ b/entries/w/wrike.com.json
@@ -6,7 +6,7 @@
       "totp"
     ],
     "documentation": "https://help.wrike.com/hc/en-us/articles/210324445",
-    "notes": "Users with Enterprise accounts may need to contact their account administrator to enable 2FA.",
+    "notes": "Only accessible to Enterprise accounts and users may need to contact their account administrator to enable 2FA.",
     "keywords": [
       "task"
     ]


### PR DESCRIPTION
Only enterprise customers have access to 2FA - clarified