### PR TITLE
Add GNU version of tar

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ruby:2.7-alpine
 WORKDIR /app
 COPY Gemfile .
 COPY ./scripts/entrypoint.sh .
-RUN apk add --no-cache build-base git bash dos2unix npm gnupg
+RUN apk add --no-cache build-base git bash dos2unix npm gnupg tar
 RUN bundle config set path '/app/vendor/cache'
 RUN bundle install
 RUN npm i -g babel-minify


### PR DESCRIPTION
[actions/cache](https://github.com/actions/cache) expects flags from tar that aren't present in the busybox version. This PR replaces /bin/tar with the GNU-version.