### PR TITLE
Update GLS

### DIFF
--- a/entries/g/gls.de.json
+++ b/entries/g/gls.de.json
@@ -3,10 +3,16 @@
     "domain": "gls.de",
     "url": "https://www.gls.de/",
     "tfa": [
-      "sms",
+      "custom-software",
       "custom-hardware"
     ],
-    "documentation": "https://www.gls.de/privatkunden/faq/onlinebanking-sicherheit/was-ist-die-zwei-faktor-authentifizierung-2fa/",
+    "custom-software": [
+      "SecureGo plus"
+    ],
+    "custom-hardware": [
+      "Sm@rtTAN"
+    ],
+    "documentation": "https://www.gls.de/privatkunden/faq/onlinebanking/was-ist-die-zwei-faktor-authentifizierung-2fa-1/",
     "keywords": [
       "banking"
     ],


### PR DESCRIPTION
SMS will no longer be supported from 2022-06-30,
the URL for 2FA description has changed,
add details for custom soft- and hardware.