### PR TITLE
Mountain America Credit Union now supports TOTP

### DIFF
--- a/entries/m/macu.com.json
+++ b/entries/m/macu.com.json
@@ -3,8 +3,8 @@
     "domain": "macu.com",
     "url": "https://www.macu.com",
     "tfa": [
+      "totp",
       "sms",
-      "call",
       "email"
     ],
     "regions": [


### PR DESCRIPTION
There's no public facing documentation for the support of TOTP at Mountain America Credit Union however it works well with Google Authenticator, Yubikey TOTP, etc. Crucially after TOTP being enabled in the account security settings the SMS and EMAIL methods for MFA can then be disabled leaving TOTP as the only allowed active MFA method. Configuration is through the normal Security settings of the account; A secret key is displayed along with a QR code for configuration and entry of a generated one-time pin confirms the action. There does not appear to be an option anymore for a phone call as an MFA method.