### PR TITLE
Update SE banking 2fa options

### DIFF
--- a/entries/a/avanza.se.json
+++ b/entries/a/avanza.se.json
@@ -1,10 +1,12 @@
 {
   "Avanza": {
     "domain": "avanza.se",
-    "url": "https://www.avanza.se/",
     "tfa": [
       "totp",
-      "custom-hardware"
+      "custom-software"
+    ],
+    "custom-software": [
+      "BankID"
     ],
     "documentation": "https://www.avanza.se/kundservice.html/1335/tvafaktorsinloggning/d264248e-bea3-48a0-bf2d-157309734649",
     "regions": [

--- a/entries/c/credit-suisse.com.json
+++ b/entries/c/credit-suisse.com.json
@@ -5,6 +5,9 @@
     "tfa": [
       "custom-software"
     ],
+    "custom-software": [
+      "SecureSign"
+    ],
     "documentation": "https://www.credit-suisse.com/ch/en/private-clients/account-cards/services/faq-securesign-login.html",
     "keywords": [
       "banking"

--- a/entries/d/danskebank.se.json
+++ b/entries/d/danskebank.se.json
@@ -3,8 +3,10 @@
     "domain": "danskebank.se",
     "img": "danskebank.svg",
     "tfa": [
-      "custom-hardware",
       "custom-software"
+    ],
+    "custom-software": [
+      "BankID"
     ],
     "documentation": "https://danskebank.se/privat/digitala-tjanster/ovriga-tjanster/bankid",
     "keywords": [

--- a/entries/h/handelsbanken.se.json
+++ b/entries/h/handelsbanken.se.json
@@ -1,10 +1,11 @@
 {
   "Handelsbanken": {
     "domain": "handelsbanken.se",
-    "url": "https://www.handelsbanken.se/",
     "tfa": [
-      "custom-software",
-      "custom-hardware"
+      "custom-software"
+    ],
+    "custom-software": [
+      "BankID"
     ],
     "documentation": "https://www.handelsbanken.se/shb/INeT/ICentSv.nsf/Default/qAE99695C4C1D033DC12579120036EB43?Opendocument",
     "regions": [

--- a/entries/i/icabanken.se.json
+++ b/entries/i/icabanken.se.json
@@ -1,10 +1,11 @@
 {
   "ICA Banken": {
     "domain": "icabanken.se",
-    "url": "https://www.icabanken.se/",
     "tfa": [
-      "custom-hardware",
       "custom-software"
+    ],
+    "custom-software": [
+      "BankID"
     ],
     "documentation": "https://www.icabanken.se/kundservice/hjalp-med-att-logga-in/",
     "keywords": [

--- a/entries/l/lansforsakringar.se.json
+++ b/entries/l/lansforsakringar.se.json
@@ -1,10 +1,11 @@
 {
   "Länsförsäkringar": {
     "domain": "lansforsakringar.se",
-    "url": "https://www.lansforsakringar.se/",
     "tfa": [
-      "custom-software",
-      "custom-hardware"
+      "custom-software"
+    ],
+    "custom-software": [
+      "BankID"
     ],
     "documentation": "https://www.lansforsakringar.se/privat/att-vara-kund/digitala-tjanster-telefonbank/internetbanken/",
     "regions": [

--- a/entries/n/nordea.se.json
+++ b/entries/n/nordea.se.json
@@ -1,11 +1,12 @@
 {
   "Nordea Sverige": {
     "domain": "nordea.se",
-    "url": "https://www.nordea.se/",
     "img": "nordea.svg",
     "tfa": [
-      "custom-software",
-      "custom-hardware"
+      "custom-software"
+    ],
+    "custom-software": [
+      "BankID"
     ],
     "documentation": "https://www.nordea.se/privat/vardagstjanster/internet-mobil-telefon/bank-id.html",
     "keywords": [

--- a/entries/n/nordnet.se.json
+++ b/entries/n/nordnet.se.json
@@ -1,12 +1,13 @@
 {
   "Nordnet Sverige": {
     "domain": "nordnet.se",
-    "url": "https://www.nordnet.se/",
     "img": "nordnet.svg",
     "tfa": [
       "custom-software"
     ],
-    "notes": "TFA only available for Swedish residents with BankID.",
+    "custom-software": [
+      "BankID"
+    ],
     "keywords": [
       "banking"
     ],

--- a/entries/s/seb.se.json
+++ b/entries/s/seb.se.json
@@ -2,7 +2,7 @@
   "SEB": {
     "domain": "seb.se",
     "tfa": [
-      "custom-software",
+      "custom-software"
     ],
     "custom-software": [
       "BankID"

--- a/entries/s/seb.se.json
+++ b/entries/s/seb.se.json
@@ -3,7 +3,9 @@
     "domain": "seb.se",
     "tfa": [
       "custom-software",
-      "custom-hardware"
+    ],
+    "custom-software": [
+      "BankID"
     ],
     "documentation": "https://seb.se/privat/digitala-tjanster",
     "regions": [

--- a/entries/s/swedbank.se.json
+++ b/entries/s/swedbank.se.json
@@ -1,11 +1,12 @@
 {
   "Swedbank & Sparbankerna": {
     "domain": "swedbank.se",
-    "url": "https://www.swedbank.se/",
     "img": "swedbank.se.png",
     "tfa": [
-      "custom-software",
-      "custom-hardware"
+      "custom-software"
+    ],
+    "custom-software": [
+      "BankID"
     ],
     "documentation": "https://www.swedbank.se/foretag/digitala-tjanster/mobilt-bankid/fragor-och-svar-om-mobilt-bankid.html",
     "regions": [


### PR DESCRIPTION
There were some inconsistencies in the labeling of BankID as hardware or software 2fa.