### PR TITLE
Noscript Site

### DIFF
--- a/_includes/html/category-button.html
+++ b/_includes/html/category-button.html
@@ -2,7 +2,11 @@
 {% assign title = include.category-param.title %}
 {% assign icon = include.category-param.icon %}
 <div class="col {{ include.viewport }}-only category-btn-outer">
+  {% if page.noscript %}
+  <a class="row {% unless include.viewport == 'mobile' %}box{% endunless %} category-btn" href="#{{ name }}">
+  {% else %}
   <button class="row {% unless include.viewport == 'mobile' %}box{% endunless %} category-btn" id="{{ name }}" href="#{{ name }}" aria-controls="{{ name }}-table">
+  {% endif %}
     <div class="col"></div>
     <div class="col-12 align-self-center">
       <i class="{{ icon }} category-icon fa-fw mx-auto d-block"></i>
@@ -10,5 +14,9 @@
     <div class="col-12 align-self-end position-relative overflow-hidden">
       <label class="category-title">{{ title }}</label>
     </div>
+  {% if page.noscript %}
+  </a>
+  {% else %}
   </button>
+  {% endif %}
 </div>

--- a/_includes/html/desktop-table.html
+++ b/_includes/html/desktop-table.html
@@ -1,5 +1,5 @@
 {% assign entries = include.entries %}
-<div id="{{ include.category.name }}-table" class="collapse category-table desktop-only">
+<div id="{{ include.category.name }}-table" class="{% unless page.noscript %} collapse {% endunless %} category-table desktop-only">
   <a id="{{ include.category.name }}" class="category-href"></a>
   <table class="table table-bordered table-bordered">
     <thead class="sticky-top">
@@ -32,12 +32,24 @@
                 {% assign image = website.domain | append: ".svg" | prepend: letter %}
               {% endif %}
 
+              {% if page.noscript %}
+              <div class="logo desktop-only" style="background-image: url('/img/{{ image }}');" aria-hidden="true"></div>
+              {% else %}
               <img class="logo desktop-only" loading="lazy" src="/img/{{ image }}" alt="">
+              {% endif %}
+              
 
               {{ name }}</a>
 
               {% if website.notes %}
+              {% if page.noscript %}
+                <details class="col">
+                  <summary><i class="fas fa-exclamation-triangle exception"></i></summary>
+                  {{ website.notes }}
+                </details>
+              {% else %}
                 <i class="fas fa-exclamation-triangle exception col" tabindex="0" data-bs-toggle="popover" data-bs-content="{{ website.notes }}"></i>
+              {% endif %}
               {% endif %}
             </div>
           </td>
@@ -82,8 +94,13 @@
               <div class="row">
                 {% if tfa contains "custom-hardware" %}
                 {% if website.custom-hardware %}
+                  {% if page.noscript %}
+                  <i class="tfa-icon fas fa-info col"
+                     title="Custom Hardware 2FA {%- for item in website.custom-hardware -%}&#013;- {{ item }} {%- endfor -%}"></i>
+                  {% else %}
                   <i class="tfa-icon fas fa-info col custom-hardware-popover" tabindex="0" data-bs-content="{%- for item in website.custom-hardware -%}&#60;li&#62;{{ item }}&#60;/li&#62;{%- endfor -%}" data-bs-toggle="popover">
                   </i>
+                  {% endif %}
                 {% else %}
                   <i class="tfa-icon fas fa-info col" title="Requires custom hardware token"></i>
                 {% endif %}
@@ -104,8 +121,13 @@
                 {% endif %}
                 {% if tfa contains "custom-software" %}
                 {% if website.custom-software %}
+                  {% if page.noscript %}
+                  <i class="tfa-icon fas fa-info col"
+                     title="Custom Software 2FA {%- for item in website.custom-software -%}&#013;- {{ item }} {%- endfor -%}"></i>
+                  {% else %}
                   <i class="tfa-icon fas fa-info col custom-software-popover" tabindex="0" data-bs-content="{%- for item in website.custom-software -%}&#60;li&#62;{{ item }}&#60;/li&#62;{%- endfor -%}" data-bs-toggle="popover">
                   </i>
+                  {% endif %}
                 {% else %}
                   <i class="tfa-icon fas fa-info col" title="Requires proprietary app/software"></i>
                 {% endif %}
@@ -117,22 +139,45 @@
             <td colspan="6">
               Tell them to support 2FA
               <div class="social-button-group">
-                {% if website.contact.twitter %}
+                {% if page.noscript %}
+                  <!-- Social links with no js -->
+                  {% if website.contact.twitter %}
+                  <a class="twitter-button social-button btn" href="https://twitter.com/{{ website.contact.twitter }}">
+                    <i class="fab fa-twitter"></i>
+                    On Twitter
+                  </a>
+                  {% endif %}
+                  {% if website.contact.facebook %}
+                  <a class="facebook-button social-button btn" href="https://facebook.com/{{ website.contact.facebook }}">
+                    <i class="fab fa-facebook-f"></i>
+                    On Facebook
+                  </a>
+                  {% endif %}
+                  {% if website.contact.email %}
+                  <a class="email-button social-button btn" href="mailto:{{ website.contact.email }}">
+                    <i class="fas fa-envelope"></i>
+                    Via Email</a>
+                  {% endif %}
+
+                {% else %}
+                  <!-- Social buttons with js -->
+                  {% if website.contact.twitter %}
                   <div tabindex="0" role="button" class="twitter-button social-button btn" data-twitter="{{ website.contact.twitter }}" data-lang="{{ website.contact.language }}">
                     <i class="fab fa-twitter"></i>
                     On Twitter
                   </div>
-                {% endif %}
-                {% if website.contact.facebook %}
+                  {% endif %}
+                  {% if website.contact.facebook %}
                   <div tabindex="0" role="button" class="facebook-button social-button btn" data-facebook="{{ website.contact.facebook }}">
                     <i class="fab fa-facebook-f"></i>
                     On Facebook
                   </div>
-                {% endif %}
-                {% if website.contact.email %}
+                  {% endif %}
+                  {% if website.contact.email %}
                   <div tabindex="0" role="button" class="email-button social-button btn" data-email="{{ website.contact.email }}" data-lang="{{ website.contact.language }}">
                     <i class="fas fa-envelope"></i>
                     Via Email</div>
+                  {% endif %}
                 {% endif %}
               </div>
             </td>

--- a/_includes/html/desktop-table.html
+++ b/_includes/html/desktop-table.html
@@ -43,10 +43,7 @@
 
               {% if website.notes %}
               {% if page.noscript %}
-                <details class="col">
-                  <summary><i class="fas fa-exclamation-triangle exception"></i></summary>
-                  {{ website.notes }}
-                </details>
+                <i class="fas fa-exclamation-triangle exception col" title="{{ website.notes }}"></i>
               {% else %}
                 <i class="fas fa-exclamation-triangle exception col" tabindex="0" data-bs-toggle="popover" data-bs-content="{{ website.notes }}"></i>
               {% endif %}
@@ -142,19 +139,19 @@
                 {% if page.noscript %}
                   <!-- Social links with no js -->
                   {% if website.contact.twitter %}
-                  <a class="twitter-button social-button btn" href="https://twitter.com/{{ website.contact.twitter }}">
+                  <a class="twitter-button social-button btn" href="https://twitter.com/{{ website.contact.twitter }}" target="_blank">
                     <i class="fab fa-twitter"></i>
                     On Twitter
                   </a>
                   {% endif %}
                   {% if website.contact.facebook %}
-                  <a class="facebook-button social-button btn" href="https://facebook.com/{{ website.contact.facebook }}">
+                  <a class="facebook-button social-button btn" href="https://facebook.com/{{ website.contact.facebook }}" target="_blank">
                     <i class="fab fa-facebook-f"></i>
                     On Facebook
                   </a>
                   {% endif %}
                   {% if website.contact.email %}
-                  <a class="email-button social-button btn" href="mailto:{{ website.contact.email }}">
+                  <a class="email-button social-button btn" href="mailto:{{ website.contact.email }}" target="_blank">
                     <i class="fas fa-envelope"></i>
                     Via Email</a>
                   {% endif %}

--- a/_includes/scss/categories.scss
+++ b/_includes/scss/categories.scss
@@ -16,6 +16,8 @@
   border-radius: 2%;
   //box-shadow: 0 3px 8px 0 #00000033, 0 0 0 1px #00000014;
   box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 1px 5px 0 rgba(0, 0, 0, 0.12);
+  text-decoration: none;
+  text-align: center;
 
   &:focus {
     outline: none;

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -31,14 +31,10 @@
     </a>
 
     <div class="container">
-      <noscript>
+      <noscript id="default-noscript">
         <div class="alert bg-danger text-white border p-1 mt-2">
           <h2>It looks like you have JavaScript disabled!</h2>
-          <p>Without JavaScript, this page probably won't work very well.
-                  For more information, or if you would like to talk to us about this,
-                  please take a look at our
-            <b><a href="{{ site.github.repository_url }}" class="text-white">
-              GitHub repository</a></b>.</p>
+          <p>Please visit our <b><a href="noscript" class="text-white">no JavaScript version of this page</a></b>.</p>
         </div>
       </noscript>
       {{ content }}

--- a/css/noscript.html.scss
+++ b/css/noscript.html.scss
@@ -1,0 +1,36 @@
+---
+---
+
+{% include scss/categories.scss %}
+
+{% include scss/tables.scss %}
+
+{% include scss/desktop-table.scss %}
+
+{% include scss/social-media.scss %}
+
+.table-outer {
+    display: none;
+    max-height: 0;
+    overflow: hidden;
+    transition: max-height 0.2s ease-out;
+}
+
+.table-outer:target {
+    display: block;
+    max-height: 100%;
+    width: 100%;
+}
+
+.logo {
+    height: 32px;
+    background-repeat: no-repeat;
+    background-position: center;
+    vertical-align: middle;
+    background-size: contain;
+    display: inline-block;
+}
+
+#default-noscript {
+    display: none;
+}

--- a/noscript.html
+++ b/noscript.html
@@ -1,0 +1,58 @@
+---
+layout: default
+noscript: true
+---
+<div class="row justify-content-center main">
+    <div class="alert bg-warning border p-1 mt-2">
+        <h2>Warning! No JavaScript Version</h2>
+        <p>This page is a basic version of the site with limited functionality intended to be used by users with JavaScript disabled. If you landed on this page by mistake, please visit the <a href="/">homepage</a> to use the site with its full functionality</p>
+    </div>
+    <div id="logo-outer" class="col-12 col-md-4 col-xl-12">
+        <img alt="" loading="lazy" id="logo" src="/img/icons/icon.svg">
+    </div>
+
+    <div class="col-12 col-md-8 col-xl-12 text-center position-relative">
+        <div class="description">
+            <h1>{{ site.title }}</h1>
+            <div class="sub header">List of websites and whether or not they support
+                <a href="https://en.wikipedia.org/wiki/Two-factor_authentication">2FA</a>.
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Categories list -->
+<div class="row justify-content-start category-list row-cols-1 row-cols-lg-{{ site.category-buttons }} g-2 m-2 m-md-0">
+    {% assign keywordsMain = site.data.categories | sort: "title" | where_exp: "item", "item.name != 'other'" %}
+    {% assign keywordsOther = site.data.categories | where_exp: "item", "item.name == 'other'" %}
+    {% assign keywords = keywordsMain | concat: keywordsOther %}
+    {% assign all_entries = site.data.all %}
+    {% assign keywords_length = keywords | size %}
+
+    <!-- Category loop -->
+    {% for keyword in keywords %}
+
+    {% assign entries = "" | split: ',' %}
+    {% for entry in all_entries %}
+    {% if entry[1].keywords contains keyword.name %}
+    {% assign entries = entries | push: entry %}
+    {% endif %}
+    {% endfor %}
+
+    {% assign _offset = forloop.index | minus: 1 %}
+    {% assign md_desktop = _offset | modulo: site.category-buttons %}
+  
+    <!-- List previous 6 categories (desktop view) -->
+    {% if md_desktop == 0 %}
+      {% for _keyword in keywords limit: site.category-buttons offset: _offset %}
+        {% include html/category-button.html category-param=_keyword viewport="desktop" %}
+      {% endfor %}
+    {% endif %}
+    
+    <div class="table-outer" id="{{ keyword.name }}">
+    <!-- Display desktop table -->
+    {% include html/desktop-table.html category=keyword entries=entries %}
+    </div>
+
+    {% endfor %}
+</div>

--- a/scripts/regions.rb
+++ b/scripts/regions.rb
@@ -20,7 +20,7 @@ FileUtils.cp_r(git_dir, "#{tmp_dir}/") unless File.exist?("#{tmp_dir}/.git")
 Parallel.each(-> { regions.pop || Parallel::Stop }) do |region|
   dest_dir = "#{tmp_dir}/#{region['id']}"
   Dir.mkdir(dest_dir) unless File.exist?(dest_dir)
-  files = %w[index.html _includes _layouts _data]
+  files = %w[index.html noscript.html _includes _layouts _data]
   FileUtils.cp_r(files, dest_dir)
 
   File.open("#{dest_dir}/_config_region.yml", 'w') do |file|


### PR DESCRIPTION
Closes #2536
This PR creates a separate page noscript.html on which the site can be used without JS. Most of the functionality other than the search and social actions have been replicated.

Key changes on noscript page:
- Category buttons are `<a>` elements to allow displaying the table via the `:target` pseudo-class (tables can still be accessed via their ids in the URL)
- Logos on `noscript.html` are `<div>`s with background image set as logo as this prevents the browser from loading images until the category table is displayed. This avoids the problem mentioned in the issue with large amounts of assets being served.
- ~~Exception popovers are displayed with `<details>` element.~~
- Custom-* data displayed in title attributes like they were before #6833
- Social buttons replaced with links to pages

![image](https://user-images.githubusercontent.com/20560218/178310244-7ab5c4ea-f445-45c9-a7dc-42393358faa5.png)
![image](https://user-images.githubusercontent.com/20560218/178310358-cd0fee7d-91dc-442f-8d90-0f3038ac52a7.png)
![image](https://user-images.githubusercontent.com/20560218/178310469-095802d0-39e8-406c-a31e-ade96ec732e2.png)

