### PR TITLE
Fix fonts on mobile

### DIFF
--- a/_includes/scss/desktop-table.scss
+++ b/_includes/scss/desktop-table.scss
@@ -18,7 +18,6 @@
     }
 
     table {
-      font-family: "Spartan", sans-serif;
       border-radius: 2px;
       width: 100%;
       margin-bottom: 0;

--- a/_includes/scss/mobile-table.scss
+++ b/_includes/scss/mobile-table.scss
@@ -40,7 +40,6 @@
         margin: 0 auto;
 
         a {
-          font-family: Spartan;
           color: #fff;
           text-decoration: none;
 


### PR DESCRIPTION
There were still references to the font removed in #6698, which was causing mobile doc link text to appear unusually. 
![image](https://user-images.githubusercontent.com/20560218/178997784-eabc92c7-6930-469a-9ad4-b99115731618.png)
