### PR TITLE
Update ESET

### DIFF
--- a/entries/e/eset.com.json
+++ b/entries/e/eset.com.json
@@ -2,10 +2,10 @@
   "ESET": {
     "domain": "eset.com",
     "url": "https://www.eset.com",
-    "contact": {
-      "facebook": "eset",
-      "twitter": "ESET"
-    },
+    "tfa": [
+      "totp"
+    ],
+    "documentation": "https://help.eset.com/home_eset/en-US/two_factor_authentication.html",
     "keywords": [
       "security"
     ]

--- a/entries/e/eset.com.json
+++ b/entries/e/eset.com.json
@@ -1,7 +1,6 @@
 {
-  "ESET": {
+  "ESET HOME": {
     "domain": "eset.com",
-    "url": "https://www.eset.com",
     "tfa": [
       "totp"
     ],


### PR DESCRIPTION
Hello,

ESET HOME (previously known as My ESET) is an online management portal for users' antivirus licenses and devices. It used to only support username and password authentication, but at some point they added support for generic TOTP.

They also offer their own TOTP mobile app called ESET Secure Authentication, but it's not mandatory to use that, you can just use Google Authenticator or whatever you like with the provided QR or numeric codes.

- 2FA can be enabled from the [My Account](https://home.eset.com/account) page of ESET HOME.
- [Documentation for 2FA](https://help.eset.com/home_eset/en-US/?two_factor_authentication.html)
- [Documentation for 2FA with ESET Secure Authentication mobile app](https://support.eset.com/en/kb8269-set-up-two-factor-authentication-in-eset-home)

![My Account screenshot](https://user-images.githubusercontent.com/1417794/181181508-35e64b04-a7f0-41ba-9efb-d1e5f06afaaa.png)
