### PR TITLE
Update Firefox & Pocket

### DIFF
--- a/entries/a/accounts.firefox.com.json
+++ b/entries/a/accounts.firefox.com.json
@@ -5,6 +5,7 @@
       "totp"
     ],
     "documentation": "https://support.mozilla.org/en-US/kb/secure-firefox-account-two-step-authentication",
+    "recovery": "https://support.mozilla.org/en-US/kb/what-if-im-locked-out-two-step-authentication",
     "keywords": [
       "other"
     ]

--- a/entries/g/getpocket.com.json
+++ b/entries/g/getpocket.com.json
@@ -1,12 +1,11 @@
 {
   "Pocket": {
     "domain": "getpocket.com",
-    "url": "https://www.getpocket.com",
-    "contact": {
-      "email": "support@getpocket.com",
-      "facebook": "pocket",
-      "twitter": "Pocket"
-    },
+    "tfa": [
+      "totp"
+    ],
+    "documentation": "https://support.mozilla.org/en-US/kb/secure-firefox-account-two-step-authentication",
+    "recovery": "https://support.mozilla.org/en-US/kb/what-if-im-locked-out-two-step-authentication",
     "keywords": [
       "other"
     ]


### PR DESCRIPTION
For Pocket; as per these instructions after account transition to Firefox account you are able to use 2FA methods for Firefox account. https://help.getpocket.com/article/1187-pocket-migration-to-firefox-accounts#howto

I didn't add a note as previous PRs submitted where account transition or migration was required, the note was removed.