### PR TITLE
Update dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ group :jekyll_plugins do
 end
 
 gem 'parallel'
+gem 'webrick'
 
 group :test do
   gem 'addressable'


### PR DESCRIPTION
With Ruby V3, the `webrick` gem needs to be added - see https://jekyllrb.com/docs/

I think this should be harmless for older versions.