### PR TITLE
Update DNSimple

### DIFF
--- a/entries/d/dnsimple.com.json
+++ b/entries/d/dnsimple.com.json
@@ -2,7 +2,8 @@
   "DNSimple": {
     "domain": "dnsimple.com",
     "tfa": [
-      "totp"
+      "totp",
+      "u2f"
     ],
     "documentation": "https://support.dnsimple.com/articles/two-factor-authentication/",
     "keywords": [


### PR DESCRIPTION
DNSimple now support hardware keys via webauthn.
See https://blog.dnsimple.com/2022/06/support-webauthn-api/
