### PR TITLE
Exclude entries dir from Jekyll build

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,4 +18,5 @@ exclude:
   - vendor/
   - scripts/
   - tests/
+  - entries/
 theme: null


### PR DESCRIPTION
Excluding `entries/` as there's no reason for the it to be published on the website.