### PR TITLE
Update paysafecard 2FA options

### DIFF
--- a/entries/p/paysafecard.com.json
+++ b/entries/p/paysafecard.com.json
@@ -9,7 +9,7 @@
     "custom-software": [
       "paysafecard app"
     ],
-    "documentation": "https://www.paysafecard.com/en/help/2-faktor-authentifizierung/",
+    "recovery": "https://www.paysafecard.com/en/help/2-faktor-authentifizierung/",
     "keywords": [
       "payments"
     ],

--- a/entries/p/paysafecard.com.json
+++ b/entries/p/paysafecard.com.json
@@ -3,9 +3,13 @@
     "domain": "paysafecard.com",
     "url": "https://www.paysafecard.com/",
     "tfa": [
-      "totp"
+      "sms",
+      "custom-software"
     ],
-    "documentation": "https://www.paysafecard.com/en-au/lp-products/2-step-login/",
+    "custom-software": [
+      "paysafecard app"
+    ],
+    "documentation": "https://www.paysafecard.com/en/help/2-faktor-authentifizierung/",
     "keywords": [
       "payments"
     ],


### PR DESCRIPTION
Standard TOTP is not an option anymore, instead, SMS and their custom app are now always enabled 2FA options.