### PR TITLE
Update OneDrive / Xbox / Outlook.com

### DIFF
--- a/entries/o/onedrive.live.com.json
+++ b/entries/o/onedrive.live.com.json
@@ -6,7 +6,8 @@
       "call",
       "email",
       "custom-software",
-      "totp"
+      "totp",
+      "u2f"
     ],
     "custom-software": [
       "Microsoft Authenticator"

--- a/entries/o/outlook.com.json
+++ b/entries/o/outlook.com.json
@@ -10,7 +10,8 @@
       "call",
       "email",
       "custom-software",
-      "totp"
+      "totp",
+      "u2f"
     ],
     "custom-software": [
       "Microsoft Authenticator"

--- a/entries/x/xbox.com.json
+++ b/entries/x/xbox.com.json
@@ -7,7 +7,8 @@
       "email",
       "custom-software",
       "call",
-      "totp"
+      "totp",
+      "u2f"
     ],
     "custom-software": [
       "Microsoft Authenticator"


### PR DESCRIPTION
Microsoft accounts have had a "Use a security key" option for seemingly some time by now, so I figured I should add support for U2F to the Microsoft tools that I was most confident would use Microsoft accounts as-is.

Screenshot of the setting:
<details>

![image](https://user-images.githubusercontent.com/22780683/198835148-e7a97040-23da-4c56-8ef9-c7b9d43e3e1e.png)

</details>

#### Notes:
• I lacked recent experience with Skype, Azure, Minecraft, and Microsoft To-Do, and thus I did not wager a guess that they supported Microsoft accounts with U2F as well. I don't think the listing for Office 365 corporate plans would use typical Microsoft accounts.
• Strangely, it doesn't appear to me that Microsoft accounts have native Windows Hello support (At least not when choosing "Use a security key"), meaning that e.g. the Kensington VeriMark is not supported by Microsoft accounts' security key support.