### PR TITLE
Add note about phone number to Google services

### DIFF
--- a/entries/c/chat.google.com.json
+++ b/entries/c/chat.google.com.json
@@ -13,6 +13,7 @@
       "Google Smart Lock"
     ],
     "documentation": "https://www.google.com/intl/en-US/landing/2step/features.html",
+    "notes": "To activate two factor authentication, you must provide a mobile phone number.",
     "keywords": [
       "communication"
     ]

--- a/entries/c/cloud.google.com.json
+++ b/entries/c/cloud.google.com.json
@@ -13,6 +13,7 @@
       "Google Smart Lock"
     ],
     "documentation": "https://www.google.com/intl/en-US/landing/2step/features.html",
+    "notes": "To activate two factor authentication, you must provide a mobile phone number.",
     "keywords": [
       "cloud"
     ]

--- a/entries/d/domains.google.com.json
+++ b/entries/d/domains.google.com.json
@@ -13,6 +13,7 @@
       "Google Smart Lock"
     ],
     "documentation": "https://www.google.com/intl/en-US/landing/2step/features.html",
+    "notes": "To activate two factor authentication, you must provide a mobile phone number.",
     "keywords": [
       "domains"
     ]

--- a/entries/d/drive.google.com.json
+++ b/entries/d/drive.google.com.json
@@ -13,6 +13,7 @@
       "Google Smart Lock"
     ],
     "documentation": "https://www.google.com/intl/en-US/landing/2step/features.html",
+    "notes": "To activate two factor authentication, you must provide a mobile phone number.",
     "recovery": "https://support.google.com/accounts/answer/185834",
     "keywords": [
       "backup"

--- a/entries/f/fit.google.com.json
+++ b/entries/f/fit.google.com.json
@@ -13,6 +13,7 @@
       "Google Smart Lock"
     ],
     "documentation": "https://www.google.com/intl/en-US/landing/2step/features.html",
+    "notes": "To activate two factor authentication, you must provide a mobile phone number.",
     "keywords": [
       "health"
     ]

--- a/entries/h/hangouts.google.com.json
+++ b/entries/h/hangouts.google.com.json
@@ -13,6 +13,7 @@
       "Google Smart Lock"
     ],
     "documentation": "https://www.google.com/intl/en-US/landing/2step/features.html",
+    "notes": "To activate two factor authentication, you must provide a mobile phone number.",
     "keywords": [
       "communication"
     ]

--- a/entries/m/mail.google.com.json
+++ b/entries/m/mail.google.com.json
@@ -13,6 +13,7 @@
       "Google Smart Lock"
     ],
     "documentation": "https://www.google.com/intl/en-US/landing/2step/features.html",
+    "notes": "To activate two factor authentication, you must provide a mobile phone number.",
     "keywords": [
       "email"
     ]

--- a/entries/m/meet.google.com.json
+++ b/entries/m/meet.google.com.json
@@ -13,6 +13,7 @@
       "Google Smart Lock"
     ],
     "documentation": "https://www.google.com/intl/en-US/landing/2step/features.html",
+    "notes": "To activate two factor authentication, you must provide a mobile phone number.",
     "keywords": [
       "communication"
     ]

--- a/entries/p/pay.google.com.json
+++ b/entries/p/pay.google.com.json
@@ -13,6 +13,7 @@
       "Google Smart Lock"
     ],
     "documentation": "https://www.google.com/intl/en-US/landing/2step/features.html",
+    "notes": "To activate two factor authentication, you must provide a mobile phone number.",
     "keywords": [
       "payments"
     ]

--- a/entries/p/play.google.com.json
+++ b/entries/p/play.google.com.json
@@ -13,6 +13,7 @@
       "Google Smart Lock"
     ],
     "documentation": "https://www.google.com/intl/en-US/landing/2step/features.html",
+    "notes": "To activate two factor authentication, you must provide a mobile phone number.",
     "keywords": [
       "entertainment"
     ]

--- a/entries/y/youtube.com.json
+++ b/entries/y/youtube.com.json
@@ -14,6 +14,7 @@
       "Google Smart Lock"
     ],
     "documentation": "https://www.google.com/intl/en-US/landing/2step/features.html",
+    "notes": "To activate two factor authentication, you must provide a mobile phone number.",
     "keywords": [
       "entertainment"
     ]


### PR DESCRIPTION
Add notes about phone requirements to all Google services, resolves #4849

This matches the style used for Twitch and other services with similar requirements