### PR TITLE
Update CIBC

### DIFF
--- a/entries/c/cibc.com.json
+++ b/entries/c/cibc.com.json
@@ -11,7 +11,7 @@
     "custom-software": [
        "CIBC App"
      ],
-    "documentation": "https://www.cibc.com/en/privacy-security/two-step-verification-b.html",
+    "documentation": "https://www.cibc.com/en/privacy-security/two-step-verification.html",
     "regions": [
       "ca"
     ],

--- a/entries/c/cibc.com.json
+++ b/entries/c/cibc.com.json
@@ -5,7 +5,6 @@
     "tfa": [
       "sms",
       "call",
-      "email",
       "custom-software"
     ],
     "custom-software": [

--- a/entries/c/cibc.com.json
+++ b/entries/c/cibc.com.json
@@ -2,6 +2,10 @@
   "CIBC": {
     "domain": "cibc.com",
     "url": "https://www.cibc.com",
+    "contact": {
+      "facebook": "CIBC",
+      "twitter": "cibc"
+    },
     "regions": [
       "ca"
     ],

--- a/entries/c/cibc.com.json
+++ b/entries/c/cibc.com.json
@@ -2,15 +2,6 @@
   "CIBC": {
     "domain": "cibc.com",
     "url": "https://www.cibc.com",
-    "tfa": [
-      "sms",
-      "call",
-      "custom-software"
-    ],
-    "custom-software": [
-       "CIBC App"
-     ],
-    "documentation": "https://www.cibc.com/en/privacy-security/two-step-verification.html",
     "regions": [
       "ca"
     ],


### PR DESCRIPTION
Hello! CIBC's [current page on two-step verification](https://www.cibc.com/en/privacy-security/two-step-verification.html) states they no longer send email verification codes:

![CIBC's webpage with highlighted text stating they no longer send one-time verification codes via email.](https://user-images.githubusercontent.com/4267710/198970614-01c51c92-037c-4244-8b2d-e477249ce741.png)

The [previously-referenced page](https://www.cibc.com/en/privacy-security/two-step-verification-b.html) is still live and is inaccurate. It's unclear why CIBC has not removed the old page. It is also _extremely_ unapparent to users they may be viewing an out-of-date page.

This pull request amends the doc link and removes email as a 2fa method. Thanks!