### PR TITLE
Add note for proton.me

### DIFF
--- a/entries/p/proton.me.json
+++ b/entries/p/proton.me.json
@@ -11,7 +11,7 @@
       "u2f"
     ],
     "documentation": "https://proton.me/support/two-factor-authentication-2fa",
-    "notes": "An authenticator app must be enabled to use a hardware token.",
+    "notes": "TOTP must be enabled to use a hardware token.",
     "keywords": [
       "email",
       "backup",

--- a/entries/p/proton.me.json
+++ b/entries/p/proton.me.json
@@ -11,6 +11,7 @@
       "u2f"
     ],
     "documentation": "https://proton.me/support/two-factor-authentication-2fa",
+    "notes": "An authenticator app must be enabled to use a hardware token.",
     "keywords": [
       "email",
       "backup",


### PR DESCRIPTION
proton.me requires enabling TOTP in order to use a security key, [as stated on their help page](https://proton.me/support/two-factor-authentication-2fa):
> Note that to use a security key, you must first set up 2FA using an authenticator app, as described below.

This is also restated on the [help page for setting up security keys](https://proton.me/support/2fa-security-key).