### PR TITLE
Readme: Fix command to build with Docker on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,16 @@ npm i babel-minify
 
 ## Building :running:
 
-Docker (Windows/Linux/MacOS):
+Docker (Linux/MacOS):
 
 ```BASH
 docker run -p 4000:4000 -v $(pwd):/twofactorauth 2factorauth/twofactorauth
+```
+
+Docker (Windows PowerShell):
+
+```powershell
+docker run -p 4000:4000 -v ${pwd}:/twofactorauth 2factorauth/twofactorauth
 ```
 
 Snap/Manual:

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ npm i babel-minify
 
 ## Building :running:
 
-Docker (Windows PowerShell/Linux/MacOS/):
+Docker (Windows/Linux/MacOS):
 
 ```BASH
 docker run -p 4000:4000 -v ${pwd}:/twofactorauth 2factorauth/twofactorauth

--- a/README.md
+++ b/README.md
@@ -71,15 +71,9 @@ npm i babel-minify
 
 ## Building :running:
 
-Docker (Linux/MacOS):
+Docker (Windows PowerShell/Linux/MacOS/):
 
 ```BASH
-docker run -p 4000:4000 -v $(pwd):/twofactorauth 2factorauth/twofactorauth
-```
-
-Docker (Windows PowerShell):
-
-```powershell
 docker run -p 4000:4000 -v ${pwd}:/twofactorauth 2factorauth/twofactorauth
 ```
 


### PR DESCRIPTION
The command from the README.md for building with Docker does not work on Windows.

`$(pwd)` is not valid. Neither in CMD nor in PowerShell.

This PR adds a separate listing and command for PowerShell with `${pwd}` that works (braces instead of parentheses).