### PR TITLE
Scroll to category when it is opened (fixes table outside of viewport)

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -37,7 +37,9 @@ $('#region-notice-close-btn').click(async () => {
 async function showCategory(category) {
   $(`.category-table.collapse:not(#${category}-table, #${category}-mobile-table)`).collapse('hide');
   $(`.category-btn:not([id=${category}])`).removeClass('active');
-  $(`#${category}-table, #${category}-mobile-table`).collapse("show");
+  $(`#${category}-table, #${category}-mobile-table`).one("shown.bs.collapse", () => {
+    document.getElementById(category)?.scrollIntoView(true);
+  }).collapse("show");
   $(`[id=${category}]`).addClass('active');
 }
 


### PR DESCRIPTION
When a category with many websites is open, and you click a different category with less websites the already open one, the table is collapsed and the new table is shown, but outside of the viewport.

Steps to reproduce:

- open category “Developer”
- scroll down and click on category “Food”
- → table with websites is outside of viewport

This PR implements a fix, by listening to the Bootstrap collapse components shown-event, and scrolling to the opened category when fired. (jQuery `one()` to listen to the event only once)

As far as I can tell it works fine, but please check if my idea using the bootstrap `shown.bs.collapse` event is correct.