### PR TITLE
Make dark scroll bar in dark theme for Chromium-based browsers

### DIFF
--- a/_includes/scss/search.scss
+++ b/_includes/scss/search.scss
@@ -20,6 +20,11 @@
     height: 100%;
     float: right;
     outline: none;
+    @media (prefers-color-scheme: dark) {
+      background-color: #fff;
+      color: #000;
+      caret-color: #000;
+    }
   }
 }
 

--- a/css/main.scss
+++ b/css/main.scss
@@ -6,6 +6,8 @@
   --secondary-background: #eeeeee96;
   --text-color: #212529;
   @media (prefers-color-scheme: dark) {
+    color-scheme: dark;
+    
     --background: #212121;
     --secondary-background: #6f6f6f96;
     --text-color: #eee;


### PR DESCRIPTION
Make dark scroll bar in dark theme for Chromium-based browsers (show scrollbar must be enabled "Always" in system settings).