### PR TITLE
Update Instagram

### DIFF
--- a/entries/i/instagram.com.json
+++ b/entries/i/instagram.com.json
@@ -7,6 +7,7 @@
       "totp"
     ],
     "documentation": "https://help.instagram.com/566810106808145",
+    "notes": "TOTP can only be activated through the mobile app",
     "keywords": [
       "social"
     ]


### PR DESCRIPTION
Instagram only allows TOTP activation through their mobile app

<img width="339" alt="instagram-totp-exception" src="https://user-images.githubusercontent.com/16967687/207734325-5f02891d-9383-45fd-8ebf-2d44b7dd44e4.png">
