### PR TITLE
Update Synology

### DIFF
--- a/entries/s/synology.com.json
+++ b/entries/s/synology.com.json
@@ -7,7 +7,7 @@
       "totp",
       "u2f"
     ],
-    "documentation": "https://kb.synology.com/en-us/DSM/tutorial/How_to_add_extra_security_to_your_Synology_NAS#t5",
+    "documentation": "https://kb.synology.com/en-us/DSM/help/DSM/SecureSignIn/2factor_authentication",
     "keywords": [
       "backup"
     ]

--- a/entries/s/synology.com.json
+++ b/entries/s/synology.com.json
@@ -7,7 +7,7 @@
       "totp",
       "u2f"
     ],
-    "documentation": "https://originwww.synology.com/en-us/knowledgebase/tutorials/615#t5",
+    "documentation": "https://kb.synology.com/en-us/DSM/tutorial/How_to_add_extra_security_to_your_Synology_NAS#t5",
     "keywords": [
       "backup"
     ]


### PR DESCRIPTION
The documentation URL currently specified for Synology currently remaps to [this URL](https://kb.synology.com/en-us/DSM/tutorial/How_to_add_extra_security_to_your_Synology_NAS#t5)