### PR TITLE
Fix git diff in Algolia.rb

### DIFF
--- a/scripts/Algolia.rb
+++ b/scripts/Algolia.rb
@@ -12,7 +12,7 @@ excludes = %w[notes documentation recovery]
 
 client = Algolia::Search::Client.create(ALGOLIA_APP_ID, ALGOLIA_API_KEY)
 index = client.init_index(ALGOLIA_INDEX_NAME)
-diff = `git diff --name-only origin/master...HEAD entries/`
+diff = `git diff --name-only #{ARGV[0] || ENV['GITHUB_SHA']} entries/`
 updates = []
 diff.split("\n").each do |entry|
   name, data = JSON.parse(File.read(entry)).first


### PR DESCRIPTION
As the commit is already in origin/master upon script execution the diff is blank.
This PR instead checks the diff of the commit hash rather than comparing HEAD with master.