### PR TITLE
Update Adobe

### DIFF
--- a/entries/a/adobe.com.json
+++ b/entries/a/adobe.com.json
@@ -4,6 +4,7 @@
     "tfa": [
       "sms",
       "email",
+      "totp",
       "custom-software"
     ],
 	  "custom-software": [


### PR DESCRIPTION
Adobe ID is currently listed as TFA with their custom app, email and SMS. They do support general TOTP authentication as well. This is a screenshot of my Account and Security settings, showing the option available and active.

![image](https://user-images.githubusercontent.com/8067792/210186339-d035a434-7fa2-4d92-aa4d-92e62810833a.png)

Weirdly, their own documentation does not reference this in screenshots or content, but I can confirm it's there, I've had it in use in an enterprise environment for a while.
