### PR TITLE
Test for invalid categories

### DIFF
--- a/.github/workflows/repository.yml
+++ b/.github/workflows/repository.yml
@@ -23,6 +23,8 @@ jobs:
           key: tmp-files-${{ hashFiles('/tmp/similarweb/*')}}
       - name: Validate JSON structure
         run: bundle exec ruby ./tests/validate-json.rb
+      - name: Validate Categories
+        run: bundle exec ruby ./tests/validate-categories.rb
       - name: Validate Region codes
         run: bundle exec ruby ./tests/region-codes.rb
       - name: Validate Language codes

--- a/tests/validate-categories.rb
+++ b/tests/validate-categories.rb
@@ -1,0 +1,20 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'parallel'
+require 'json'
+require 'net/http'
+require 'uri'
+
+url = URI('https://raw.githubusercontent.com/2factorauth/frontend/master/data/categories.json')
+response = Net::HTTP.get url
+
+categories = JSON.parse(response).keys
+
+Parallel.each(Dir.glob('entries/*/*.json')) do |file|
+  entry = JSON.parse(File.read(file)).values[0]
+  keywords = entry['keywords']
+  keywords.each do |category|
+    raise "::error file=#{file}:: Unknown category '#{category}'" unless categories.include? category
+  end
+end


### PR DESCRIPTION
This script tests for invalid categories/keywords in entry files. The check is run against [2factorauth/frontend/data/categories.json](https://github.com/2factorauth/frontend/blob/master/data/categories.json)