### PR TITLE
Update outdated link republicwireless.com

### DIFF
--- a/entries/r/republicwireless.com.json
+++ b/entries/r/republicwireless.com.json
@@ -4,7 +4,7 @@
     "tfa": [
       "totp"
     ],
-    "documentation": "https://help.republicwireless.com/hc/en-us/articles/360008803994",
+    "documentation": "https://help.republicwireless.com/hc/en-us/articles/360008807234",
     "categories": [
       "utilities"
     ],


### PR DESCRIPTION
The `documentation` link for republicwireless.com is dead. I've updated the URL to an active one.