### PR TITLE
Use threads instead of processes for parallel processing

### DIFF
--- a/tests/language-codes.rb
+++ b/tests/language-codes.rb
@@ -34,7 +34,7 @@ end
 
 status = 0
 
-Parallel.each(Dir.glob('entries/*/*.json'), in_threads:16) do |file|
+Parallel.each(Dir.glob('entries/*/*.json'), in_threads: 16) do |file|
   website = JSON.parse(File.read(file)).values[0]
   next if website['contact'].nil? || website['contact']['language'].nil?
 

--- a/tests/language-codes.rb
+++ b/tests/language-codes.rb
@@ -34,7 +34,7 @@ end
 
 status = 0
 
-Parallel.each(Dir.glob('entries/*/*.json')) do |file|
+Parallel.each(Dir.glob('entries/*/*.json'), in_threads:16) do |file|
   website = JSON.parse(File.read(file)).values[0]
   next if website['contact'].nil? || website['contact']['language'].nil?
 

--- a/tests/validate-json.rb
+++ b/tests/validate-json.rb
@@ -14,7 +14,7 @@ def error(file, msg)
 end
 
 # rubocop:disable Metrics/BlockLength
-Parallel.each(Dir.glob('entries/*/*.json'), in_threads:16) do |file|
+Parallel.each(Dir.glob('entries/*/*.json'), in_threads: 16) do |file|
   begin
     JSON.parse(File.read(file))
   rescue JSON::ParserError => e

--- a/tests/validate-json.rb
+++ b/tests/validate-json.rb
@@ -14,7 +14,7 @@ def error(file, msg)
 end
 
 # rubocop:disable Metrics/BlockLength
-Parallel.each(Dir.glob('entries/*/*.json')) do |file|
+Parallel.each(Dir.glob('entries/*/*.json'), in_threads:16) do |file|
   begin
     JSON.parse(File.read(file))
   rescue JSON::ParserError => e


### PR DESCRIPTION
When threads are used instead of processes, global variables like `@status` may be modified.

You need to specify the number of threads in this case - 16 seems to be a reasonable value for me.