### PR TITLE
Clean up validate-urls.rb

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ source 'https://rubygems.org'
 
 group :tests, optional: true do
   gem 'addressable'
-  gem 'httpclient'
   gem 'json_schemer'
   gem 'rubocop'
   gem 'twitter'


### PR DESCRIPTION
Removed last usage of httpclient gem.
Cleaned up code in validate-urls

I also removed the exit code changing on certain HTTP errors as test failures are ignored in the [workflow](https://github.com/2factorauth/twofactorauth/blob/master/.github/workflows/repository.yml#L38). (Uncertain if this is desirable?)