### PR TITLE
Update boursorama TFA

### DIFF
--- a/entries/b/boursorama.com.json
+++ b/entries/b/boursorama.com.json
@@ -6,7 +6,8 @@
     ],
     "tfa": [
       "sms",
-      "call"
+      "call",
+      "u2f"
     ],
     "documentation": "https://www.boursorama.com/aide-en-ligne/mon-espace-client/la-directive-europeenne-relative-aux-services-de-paiement-dsp2/question/64587956",
     "categories": [


### PR DESCRIPTION
Boursorama now allow to use WebAuthn to connect instead of the 8 digit password.

Source: https://www.boursorama.com/aide-en-ligne/securite/proteger-mon-espace-client/question/comment-se-connecter-a-votre-espace-client-grace-aux-cles-de-securite-5165516