### PR TITLE
Update Adobe ID

### DIFF
--- a/entries/a/adobe.com.json
+++ b/entries/a/adobe.com.json
@@ -4,7 +4,6 @@
     "tfa": [
       "sms",
       "email",
-      "totp",
       "custom-software"
     ],
 	  "custom-software": [


### PR DESCRIPTION
Adobe ID doesn't support totp anymore, as you can see in the documentation: https://helpx.adobe.com/manage-account/using/secure-your-adobe-account.html