### PR TITLE
Add hardware key support for Apple/iCloud

### DIFF
--- a/entries/a/appleid.apple.com.json
+++ b/entries/a/appleid.apple.com.json
@@ -4,6 +4,7 @@
     "tfa": [
       "sms",
       "call",
+      "u2f",
       "custom-software"
     ],
     "custom-software": [

--- a/entries/i/icloud.com.json
+++ b/entries/i/icloud.com.json
@@ -4,6 +4,7 @@
     "tfa": [
       "sms",
       "call",
+      "u2f",
       "custom-software"
     ],
     "custom-software": [


### PR DESCRIPTION
Since macOS 13.2/iOS 16.3 Apple IDs support FIDO tokens for authentication.

Source: https://support.apple.com/en-us/HT213154