### PR TITLE
Update FirstBank

### DIFF
--- a/entries/e/efirstbank.com.json
+++ b/entries/e/efirstbank.com.json
@@ -1,13 +1,12 @@
 {
   "FirstBank": {
     "domain": "efirstbank.com",
-    "url": "https://www.efirstbank.com/",
     "tfa": [
       "custom-software"
-      ],
+    ],
     "custom-software": [
       "FirstBank App"
-      ],
+    ],
     "regions": [
       "us"
     ],

--- a/entries/e/efirstbank.com.json
+++ b/entries/e/efirstbank.com.json
@@ -2,14 +2,16 @@
   "FirstBank": {
     "domain": "efirstbank.com",
     "url": "https://www.efirstbank.com/",
-    "contact": {
-      "email": "banking@efirstbank.com",
-      "facebook": "efirstbank",
-      "twitter": "efirstbank"
-    },
+    "tfa": [
+      "custom-software"
+      ],
+    "custom-software": [
+      "Firstbank App"
+      ],
     "regions": [
       "us"
     ],
+    "documentation": "https://www.efirstbank.com/internet-banking/login-options.htm",
     "categories": [
       "banking"
     ]

--- a/entries/e/efirstbank.com.json
+++ b/entries/e/efirstbank.com.json
@@ -6,7 +6,7 @@
       "custom-software"
       ],
     "custom-software": [
-      "Firstbank App"
+      "FirstBank App"
       ],
     "regions": [
       "us"


### PR DESCRIPTION
This is a continuation of a pull back from last year (apologies for the delay). I wasn't sure how best to re-open this from the previous request (https://github.com/2factorauth/twofactorauth/pull/6913), so I figured I'd just start over from the current branch. 

To answer/speak to the comments from last time and clarify, currently Firstbank only offers 2FA through a desktop website sign-on through "Quick Login" (tied to the current browser being used), which requires registering a device with the mobile app. The mobile device receives a PUSH notification when the user is logging into the website, and prompts a biometric check on the device. In my previous comments, I mentioned an OTP process for getting access. This wasn't entirely accurate. With respect to Quick Login, there's no method in place for bypassing it on the enrolled browser. The customer could deactivate Quick Login on the browser by performing the normal login flow (password based) and switching the setting off for the current browser.

For the comment regarding the SMS and email code, this would not apply to logging in to a new device (or clearing cookies). Notifications are sent when a new device is enrolled through Quick Login, but it simply serves as an email notification.

I hope this is sufficient, but if not I can speak more to it. Apologies once again for the delay and re-opening.