### PR TITLE
Add custom-hardware/software entries

### DIFF
--- a/entries/1/1822direkt.de.json
+++ b/entries/1/1822direkt.de.json
@@ -1,10 +1,12 @@
 {
   "1822direkt": {
     "domain": "1822direkt.de",
-    "url": "https://www.1822direkt.de/",
     "tfa": [
       "sms",
       "custom-software"
+    ],
+    "custom-software": [
+      "1822TAN+"
     ],
     "documentation": "https://www.1822direkt.de/service/sicherheitsportal/sicheres-online-banking/",
     "categories": [

--- a/entries/a/allianz.de.json
+++ b/entries/a/allianz.de.json
@@ -1,10 +1,8 @@
 {
   "Allianz": {
     "domain": "allianz.de",
-    "url": "https://www.allianz.de/",
     "tfa": [
-      "sms",
-      "custom-hardware"
+      "sms"
     ],
     "documentation": "https://www.allianz.de/datenschutz/allianz-deutschland-ag/online-service-meine-allianz/",
     "categories": [

--- a/entries/a/apobank.de.json
+++ b/entries/a/apobank.de.json
@@ -1,12 +1,14 @@
 {
   "Deutsche Apotheker- und &Auml;rztebank": {
     "domain": "apobank.de",
-    "url": "https://www.apobank.de/",
     "tfa": [
       "sms",
       "custom-software"
     ],
-    "documentation": "https://www.apobank.de/footer/tan-app.html",
+    "custom-software": [
+      "apoTAN"
+    ],
+    "documentation": "https://www.apobank.de/unsere-leistungen/konto-karte/mobile-banking/apotan",
     "categories": [
       "banking"
     ],

--- a/entries/b/bbbank.de.json
+++ b/entries/b/bbbank.de.json
@@ -1,10 +1,15 @@
 {
   "BBBank": {
     "domain": "bbbank.de",
-    "url": "https://www.bbbank.de/",
     "tfa": [
       "custom-software",
       "custom-hardware"
+    ],
+    "custom-hardware": [
+      "Sm@rt-TAN card reader"
+    ],
+    "custom-software": [
+      "BBBank SecureGo+"
     ],
     "documentation": "https://www.bbbank.de/produkte/konten-und-karten/online-banking/tan-verfahren.html",
     "categories": [

--- a/entries/b/bw-bank.de.json
+++ b/entries/b/bw-bank.de.json
@@ -1,10 +1,15 @@
 {
   "Baden-Württembergische Bank": {
     "domain": "bw-bank.de",
-    "url": "https://www.bw-bank.de/",
     "tfa": [
       "custom-software",
       "custom-hardware"
+    ],
+    "custom-hardware": [
+      "chipTAN-QR card reader"
+    ],
+    "custom-software": [
+      "BW-pushTAN"
     ],
     "documentation": "https://meine.bw-bank.de/articles/am-14-september-tritt-psd2-in-kraft-was-bedeutet-das-fuer-sie",
     "regions": [

--- a/entries/c/comdirect.de.json
+++ b/entries/c/comdirect.de.json
@@ -1,11 +1,16 @@
 {
   "comdirect": {
     "domain": "comdirect.de",
-    "url": "https://www.comdirect.de/",
     "tfa": [
       "sms",
       "custom-software",
       "custom-hardware"
+    ],
+    "custom-hardware": [
+      "photoTAN card reader"
+    ],
+    "custom-software": [
+      "comdirect photoTAN"
     ],
     "documentation": "https://www.comdirect.de/konto/psd2-phototan.html",
     "regions": [

--- a/entries/c/commerzbank.de.json
+++ b/entries/c/commerzbank.de.json
@@ -1,13 +1,18 @@
 {
   "Commerzbank": {
     "domain": "commerzbank.de",
-    "url": "https://www.commerzbank.de/",
     "tfa": [
       "sms",
       "custom-software",
       "custom-hardware"
     ],
-    "documentation": "https://www.commerzbank.de/portal/de/privatkunden/konten-karten/wissen/zahlungsverkehr-organisieren/psd2.html",
+    "custom-hardware": [
+      "photoTAN card reader"
+    ],
+    "custom-software": [
+      "Commerzbank photoTAN"
+    ],
+    "documentation": "https://www.commerzbank.de/konten-zahlungsverkehr/service/tan-verfahren/",
     "regions": [
       "de"
     ],

--- a/entries/c/consorsbank.de.json
+++ b/entries/c/consorsbank.de.json
@@ -1,10 +1,15 @@
 {
   "Consorsbank": {
     "domain": "consorsbank.de",
-    "url": "https://www.consorsbank.de/",
     "tfa": [
       "custom-software",
       "custom-hardware"
+    ],
+    "custom-hardware": [
+      "SecurePlus card reader"
+    ],
+    "custom-software": [
+      "Consorsbank SecurePlus"
     ],
     "documentation": "https://www.consorsbank.de/ev/Service-Beratung/secureplus",
     "regions": [

--- a/entries/d/degussa-bank.de.json
+++ b/entries/d/degussa-bank.de.json
@@ -7,6 +7,12 @@
       "sms",
       "custom-software"
     ],
+    "custom-hardware": [
+      "Biometrics (via app)"
+    ],
+    "custom-software": [
+      "Degussa Bank Banking+Brokerage"
+    ],
     "documentation": "https://www.degussa-bank.de/apptan-verfahren",
     "categories": [
       "banking"

--- a/entries/d/deutsche-bank.de.json
+++ b/entries/d/deutsche-bank.de.json
@@ -1,11 +1,16 @@
 {
   "Deutsche Bank": {
     "domain": "deutsche-bank.de",
-    "url": "https://www.deutsche-bank.de/",
     "tfa": [
       "sms",
       "custom-software",
       "custom-hardware"
+    ],
+    "custom-hardware": [
+      "photoTAN card reader"
+    ],
+    "custom-software": [
+      "Deutsche Bank Mobile"
     ],
     "documentation": "https://www.deutsche-bank.de/pk/lp/psd2.html",
     "categories": [

--- a/entries/d/deutsche-rentenversicherung.de.json
+++ b/entries/d/deutsche-rentenversicherung.de.json
@@ -1,9 +1,12 @@
 {
   "Deutsche Rentenversicherung": {
     "domain": "deutsche-rentenversicherung.de",
-    "url": "https://www.deutsche-rentenversicherung.de/",
     "tfa": [
       "custom-hardware"
+    ],
+    "custom-hardware": [
+      "National identity card",
+      "Signature card"
     ],
     "documentation": "https://www.deutsche-rentenversicherung.de/DRV/DE/Online-Dienste/unsere_online-dienste.html",
     "categories": [

--- a/entries/d/dkb.de.json
+++ b/entries/d/dkb.de.json
@@ -1,10 +1,17 @@
 {
   "Deutsche Kreditbank (DKB)": {
     "domain": "dkb.de",
-    "url": "https://www.dkb.de/",
     "tfa": [
       "custom-software",
       "custom-hardware"
+    ],
+    "custom-hardware": [
+      "chipTAN card reader"
+    ],
+    "custom-software": [
+      "DKB app",
+      "DKB-Banking",
+      "DKB-TAN2go"
     ],
     "documentation": "https://www.dkb.de/info/neue-anmeldung",
     "categories": [

--- a/entries/e/elster.de.json
+++ b/entries/e/elster.de.json
@@ -7,7 +7,7 @@
     ],
     "custom-hardware": [
       "National identity card",
-      "Security dongle",
+      "G&D StarSign Crypto Key",
       "Signature card"
     ],
     "custom-software": [

--- a/entries/e/elster.de.json
+++ b/entries/e/elster.de.json
@@ -1,10 +1,18 @@
 {
   "Elster": {
     "domain": "elster.de",
-    "url": "https://www.elster.de/",
     "tfa": [
       "custom-software",
       "custom-hardware"
+    ],
+    "custom-hardware": [
+      "National identity card",
+      "Security dongle",
+      "Signature card"
+    ],
+    "custom-software": [
+      "ElsterSecure",
+      "ElsterSmart"
     ],
     "documentation": "https://www.elster.de/eportal/helpGlobal?themaGlobal=help_eop",
     "categories": [

--- a/entries/h/hypovereinsbank.de.json
+++ b/entries/h/hypovereinsbank.de.json
@@ -1,12 +1,17 @@
 {
   "HypoVereinsbank": {
     "domain": "hypovereinsbank.de",
-    "url": "https://www.hypovereinsbank.de/",
     "img": "unicredit.svg",
     "tfa": [
       "sms",
       "custom-software",
       "custom-hardware"
+    ],
+    "custom-hardware": [
+      "photoTAN card reader"
+    ],
+    "custom-software": [
+      "HVB Mobile Banking"
     ],
     "documentation": "https://www.hypovereinsbank.de/hvb/services/digitales-banking/psd2/tan-verfahren",
     "regions": [

--- a/entries/m/mail.de.json
+++ b/entries/m/mail.de.json
@@ -3,7 +3,7 @@
     "domain": "mail.de",
     "tfa": [
       "totp",
-      "custom-hardware"
+      "u2f"
     ],
     "documentation": "https://mail.de/hilfe/u2f-authenticator",
     "categories": [

--- a/entries/n/norisbank.de.json
+++ b/entries/n/norisbank.de.json
@@ -1,11 +1,16 @@
 {
   "norisbank": {
     "domain": "norisbank.de",
-    "url": "https://www.norisbank.de/",
     "tfa": [
       "sms",
       "custom-software",
       "custom-hardware"
+    ],
+    "custom-hardware": [
+      "photoTAN card reader"
+    ],
+    "custom-software": [
+      "norisbank photoTAN"
     ],
     "documentation": "https://www.norisbank.de/service/zwei-faktor-authentifizierung.html",
     "regions": [

--- a/entries/p/postbank.de.json
+++ b/entries/p/postbank.de.json
@@ -1,10 +1,15 @@
 {
   "Postbank": {
     "domain": "postbank.de",
-    "url": "https://www.postbank.de/",
     "tfa": [
       "custom-software",
       "custom-hardware"
+    ],
+    "custom-hardware": [
+      "Seal One dongle"
+    ],
+    "custom-software": [
+      "Postbank BestSign"
     ],
     "documentation": "https://www.postbank.de/privatkunden/sicherheitsverfahren.html",
     "regions": [

--- a/entries/s/santander.de.json
+++ b/entries/s/santander.de.json
@@ -1,11 +1,13 @@
 {
   "Santander DE": {
     "domain": "santander.de",
-    "url": "https://www.santander.de/",
     "img": "santander.svg",
     "tfa": [
       "sms",
       "custom-software"
+    ],
+    "custom-software": [
+      "SantanderSign"
     ],
     "documentation": "https://www.santander.de/privatkunden/service-kontakt/information/faq/psd2/",
     "categories": [

--- a/entries/s/serviceportal.hamburg.de.json
+++ b/entries/s/serviceportal.hamburg.de.json
@@ -4,6 +4,9 @@
     "tfa": [
       "custom-hardware"
     ],
+    "custom-hardware": [
+      "National identity card"
+    ],
     "documentation": "https://serviceportal.hamburg.de/HamburgGateway/FVP/FV/BasisHilfe/HilfeA-Z.aspx#Wie_kann_ich_die_Funktion_%E2%80%9EAnmelden_mit_Online-Ausweisfunktion%E2%80%9C_einrichten?",
     "categories": [
       "government"

--- a/entries/s/sparda.de.json
+++ b/entries/s/sparda.de.json
@@ -1,10 +1,15 @@
 {
   "Sparda Banken": {
     "domain": "sparda.de",
-    "url": "https://www.sparda.de/",
     "tfa": [
       "custom-software",
       "custom-hardware"
+    ],
+    "custom-hardware": [
+      "chipTAN card reader"
+    ],
+    "custom-software": [
+      "SpardaSecureApp"
     ],
     "documentation": "https://www.sparda.de/online-sicherheit-psd2/",
     "regions": [

--- a/entries/s/sparkasse.de.json
+++ b/entries/s/sparkasse.de.json
@@ -1,11 +1,16 @@
 {
   "Sparkasse": {
     "domain": "sparkasse.de",
-    "url": "https://www.sparkasse.de/",
     "tfa": [
       "sms",
       "custom-software",
       "custom-hardware"
+    ],
+    "custom-hardware": [
+      "chipTAN card reader"
+    ],
+    "custom-software": [
+      "S-pushTAN"
     ],
     "documentation": "https://www.sparkasse.de/service/sicherheit-im-internet/tan-verfahren.html",
     "regions": [

--- a/entries/t/targobank.de.json
+++ b/entries/t/targobank.de.json
@@ -1,13 +1,18 @@
 {
   "TARGOBANK": {
     "domain": "targobank.de",
-    "url": "https://www.targobank.de/",
     "tfa": [
       "sms",
       "custom-software",
       "custom-hardware"
     ],
-    "documentation": "https://www.targobank.de/service/psd2/index.html",
+    "custom-hardware": [
+      "photoTAN card reader"
+    ],
+    "custom-software": [
+      "TARGOBANK Mobile Banking"
+    ],
+    "documentation": "https://www.targobank.de/de/service/tan-verfahren/index.html",
     "regions": [
       "de"
     ],

--- a/entries/t/tk.de.json
+++ b/entries/t/tk.de.json
@@ -1,9 +1,11 @@
 {
   "Techniker Krankenkasse": {
     "domain": "tk.de",
-    "url": "https://www.tk.de/",
     "tfa": [
       "custom-software"
+    ],
+    "custom-software": [
+      "TK-App"
     ],
     "documentation": "https://www.tk.de/techniker/unternehmensseiten/unternehmen/die-tk-app/2023678",
     "categories": [

--- a/entries/u/uni-marburg.de.json
+++ b/entries/u/uni-marburg.de.json
@@ -1,10 +1,12 @@
 {
   "Philipps-Universität Marburg": {
     "domain": "uni-marburg.de",
-    "url": "https://www.uni-marburg.de/",
     "tfa": [
       "totp",
       "custom-hardware"
+    ],
+    "custom-hardware": [
+      "Yubico OTP"
     ],
     "documentation": "https://www.uni-marburg.de/de/hrz/dienste/2fa",
     "categories": [


### PR DESCRIPTION
see #6845

Also:
* _Allianz:_ National identity card is not supported anymore
* _mail.de:_ `u2f` instead of `custom-hardware`
* Removed superfluous `url` entries
* Updated some `documentation` links