### PR TITLE
Update 1password.com

### DIFF
--- a/entries/1/1password.com.json
+++ b/entries/1/1password.com.json
@@ -15,6 +15,7 @@
       "Duo"
     ],
     "documentation": "https://support.1password.com/two-factor-authentication/",
+    "recovery": "https://support.1password.com/recovery/",
     "notes": "TOTP 2FA must be enabled before U2F 2FA can be enabled. Teams using Duo with 1Password can't enable other 2FA methods. Non-U2F Hardware tokens and custom software methods are only available through Duo.",
     "categories": [
       "identity"


### PR DESCRIPTION
- Added `recovery` documentation for 1password accounts

*NOTE*: If this is not the desired documentation this does not need to be merged.