### PR TITLE
Remove totp from Personal Capital

### DIFF
--- a/entries/p/personalcapital.com.json
+++ b/entries/p/personalcapital.com.json
@@ -6,7 +6,6 @@
       "call",
       "email",
       "sms",
-      "totp",
       "custom-software"
     ],
     "custom-software": [


### PR DESCRIPTION
Remove totp from Personal Capital as it only supports 2fa from their mobile app:

https://support.personalcapital.com/hc/en-us/articles/360053562333-Enabling-Mobile-App-Verification-for-Personal-Capital