### PR TITLE
Send webhook to CF via workflows

### DIFF
--- a/.github/workflows/repository.yml
+++ b/.github/workflows/repository.yml
@@ -95,3 +95,5 @@ jobs:
           path: public/
       - name: Deploy to GitHub Pages
         uses: actions/deploy-pages@v1
+      - name: Send webhook to Cloudflare
+        run: curl -X POST -IL "${{ secrets.webhook }}" -o /dev/null -w '%{http_code}\n' -s


### PR DESCRIPTION
Currently webhook requests are sent out by GitHub on each push to master. This proposal instead sends out the requests after the API has been regenerated, ensuring that the most up to date data is fetched by Cloudflare Pages during the hugo build.