### PR TITLE
Update Stanford University

### DIFF
--- a/entries/s/stanford.edu.json
+++ b/entries/s/stanford.edu.json
@@ -11,6 +11,9 @@
     "custom-software": [
       "Duo"
     ],
+    "custom-hardware": [
+      "Fortitoken"
+    ],
     "documentation": "https://uit.stanford.edu/service/webauth/twostep",
     "categories": [
       "universities"

--- a/entries/s/stanford.edu.json
+++ b/entries/s/stanford.edu.json
@@ -6,7 +6,8 @@
       "sms",
       "call",
       "custom-software",
-      "custom-hardware"
+      "custom-hardware",
+      "u2f"
     ],
     "custom-software": [
       "Duo"

--- a/entries/s/stanford.edu.json
+++ b/entries/s/stanford.edu.json
@@ -1,7 +1,6 @@
 {
   "Stanford University": {
     "domain": "stanford.edu",
-    "url": "https://www.stanford.edu/",
     "tfa": [
       "sms",
       "call",


### PR DESCRIPTION
They now support U2F through Duo ([source](https://uit.stanford.edu/service/authentication/twostep/securitykey))