### PR TITLE
Add Shockbyte

### DIFF
--- a/entries/s/shockbyte.com.json
+++ b/entries/s/shockbyte.com.json
@@ -1,24 +1,15 @@
-{\rtf1\ansi\ansicpg1252\cocoartf2708
-\cocoatextscaling0\cocoaplatform0{\fonttbl\f0\fnil\fcharset0 .AppleSystemUIFontMonospaced-Regular;}
-{\colortbl;\red255\green255\blue255;\red0\green0\blue0;\red255\green255\blue255;}
-{\*\expandedcolortbl;;\cssrgb\c0\c0\c0;\cssrgb\c100000\c100000\c99985\c0;}
-\margl1440\margr1440\vieww11520\viewh8400\viewkind0
-\deftab720
-\pard\pardeftab720\partightenfactor0
-
-\f0\fs27\fsmilli13600 \cf2 \cb3 \expnd0\expndtw0\kerning0
-\{\
-  \'93Shockbyte\'94: \{\
-    "domain": \'93https://shockbyte.com\'94,\
-    "img": "{\field{\*\fldinst{HYPERLINK "https://shockbyte.com/branding/logomarks/shockbyte_logomark.svg"}}{\fldrslt https://shockbyte.com/branding/logomarks/shockbyte_logomark.svg}}\'94,\
-    "tfa": [\
-      \'93totp\'94\
-    ],\
-    "documentation": "{\field{\*\fldinst{HYPERLINK "https://shockbyte.com/billing/knowledgebase/23/How-to-Enable-2-Factor-Authentication-in-Your-Shockbyte-Account.html"}}{\fldrslt https://shockbyte.com/billing/knowledgebase/23/How-to-Enable-2-Factor-Authentication-in-Your-Shockbyte-Account.html}}",\
-	\'93notes\'94: \'93The control panel and client area use separate accounts. So, 2FA will need to be enabled separately for each site.\'94\
-    "categories": [\
-      \'93Hosting\'94,\
-      \'93Gaming\'94\
-    ]\
-  \}\
-\}}
+{
+  “Shockbyte”: {
+    "domain": “https://shockbyte.com”,
+    "img": "https://shockbyte.com/branding/logomarks/shockbyte_logomark.svg”,
+    "tfa": [
+      “totp”
+    ],
+    "documentation": "https://shockbyte.com/billing/knowledgebase/23/How-to-Enable-2-Factor-Authentication-in-Your-Shockbyte-Account.html",
+	“notes”: “The control panel and client area use separate accounts. So, 2FA will need to be enabled separately for each site.”
+    "categories": [
+      “Hosting”,
+      “Gaming”
+    ]
+  }
+}

--- a/entries/s/shockbyte.com.json
+++ b/entries/s/shockbyte.com.json
@@ -1,0 +1,24 @@
+{\rtf1\ansi\ansicpg1252\cocoartf2708
+\cocoatextscaling0\cocoaplatform0{\fonttbl\f0\fnil\fcharset0 .AppleSystemUIFontMonospaced-Regular;}
+{\colortbl;\red255\green255\blue255;\red0\green0\blue0;\red255\green255\blue255;}
+{\*\expandedcolortbl;;\cssrgb\c0\c0\c0;\cssrgb\c100000\c100000\c99985\c0;}
+\margl1440\margr1440\vieww11520\viewh8400\viewkind0
+\deftab720
+\pard\pardeftab720\partightenfactor0
+
+\f0\fs27\fsmilli13600 \cf2 \cb3 \expnd0\expndtw0\kerning0
+\{\
+  \'93Shockbyte\'94: \{\
+    "domain": \'93https://shockbyte.com\'94,\
+    "img": "{\field{\*\fldinst{HYPERLINK "https://shockbyte.com/branding/logomarks/shockbyte_logomark.svg"}}{\fldrslt https://shockbyte.com/branding/logomarks/shockbyte_logomark.svg}}\'94,\
+    "tfa": [\
+      \'93totp\'94\
+    ],\
+    "documentation": "{\field{\*\fldinst{HYPERLINK "https://shockbyte.com/billing/knowledgebase/23/How-to-Enable-2-Factor-Authentication-in-Your-Shockbyte-Account.html"}}{\fldrslt https://shockbyte.com/billing/knowledgebase/23/How-to-Enable-2-Factor-Authentication-in-Your-Shockbyte-Account.html}}",\
+	\'93notes\'94: \'93The control panel and client area use separate accounts. So, 2FA will need to be enabled separately for each site.\'94\
+    "categories": [\
+      \'93Hosting\'94,\
+      \'93Gaming\'94\
+    ]\
+  \}\
+\}}


### PR DESCRIPTION
**Added shockbyte.com.json**

- Domain: https://shockbyte.com
- Methods: TOTP Only
- Notes: The control panel and client area use separate accounts. So, 2FA will need to be enabled separately for each site
- Image: https://shockbyte.com/branding/logomarks/shockbyte_logomark.svg
- Docs: https://shockbyte.com/billing/knowledgebase/23/How-to-Enable-2-Factor-Authentication-in-Your-Shockbyte-Account.html
- Categories: Hosting, Gaming