### PR TITLE
Increase workflow VM cores

### DIFF
--- a/.github/workflows/repository.yml
+++ b/.github/workflows/repository.yml
@@ -4,7 +4,7 @@ jobs:
 
   tests:
     name: Tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest-8-cores
     steps:
       - uses: actions/checkout@v3
         with:
@@ -56,7 +56,7 @@ jobs:
     permissions:
       pages: write
       id-token: write
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest-8-cores
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
This PR increases the amount of cores available to the workflow VM from 2 to 8. This should increase the speed of multithreaded tests (i.e. Ruby scripts using the `parallel` gem)