### PR TITLE
Update JumpCloud

### DIFF
--- a/entries/j/jumpcloud.com.json
+++ b/entries/j/jumpcloud.com.json
@@ -2,7 +2,8 @@
   "JumpCloud": {
     "domain": "jumpcloud.com",
     "tfa": [
-      "totp"
+      "totp",
+      "u2f"
     ],
     "documentation": "https://support.jumpcloud.com/support/s/article/using-multi-factor-authentication-with-your-jumpcloud-user-account-2019-08-21-10-36-47",
     "categories": [


### PR DESCRIPTION
They list [a help page](https://support.jumpcloud.com/support/s/article/set-up-yubico-authenticator-mfa-for-windows-2019-08-21-10-36-47) for setting up Yubikey with the site, and the account settings list many more physical keys, as can be seen in the screenshot below. I've also got Kensington VeriMark to work natively with that site.

<details><summary>Screenshot:</summary>

![image](https://user-images.githubusercontent.com/22780683/224487631-a31749a8-86ef-4270-8dad-06ff6e6cefbb.png)

</details>