### PR TITLE
Update Mastodon

### DIFF
--- a/entries/j/joinmastodon.org.json
+++ b/entries/j/joinmastodon.org.json
@@ -5,7 +5,8 @@
       "mastodon.social"
     ],
     "tfa": [
-      "totp"
+      "totp",
+      "u2f"
     ],
     "documentation": "https://github.com/McKael/mastodon-documentation/blob/master/Using-Mastodon/2FA.md",
     "categories": [

--- a/entries/j/joinmastodon.org.json
+++ b/entries/j/joinmastodon.org.json
@@ -9,6 +9,7 @@
       "u2f"
     ],
     "documentation": "https://github.com/McKael/mastodon-documentation/blob/master/Using-Mastodon/2FA.md",
+    "notes": "TOTP must be enabled to use a hardware token.",
     "categories": [
       "social"
     ]


### PR DESCRIPTION
As per a few issue comments ([source](https://github.com/mastodon/mastodon/issues/562#issuecomment-910780261), [source](https://github.com/mastodon/mastodon/issues/10149#issuecomment-1303840531)), and [an article](https://sts10.github.io/2022/11/12/mastodon-2fa-security-key.html)