### PR TITLE
Update vcu.edu.json - Remove "Call" option

### DIFF
--- a/entries/v/vcu.edu.json
+++ b/entries/v/vcu.edu.json
@@ -2,7 +2,6 @@
   "Virginia Commonwealth University": {
     "domain": "vcu.edu",
     "tfa": [
-      "call",
       "custom-software",
       "custom-hardware",
       "u2f"


### PR DESCRIPTION
Remove "Call" option as 2FA option for vcu.edu. No longer permitted as of July 31, 2019. Only use of DUO Mobile (software) and DUO-supported hardware keys are permitted.

- Source: https://ts.vcu.edu/askit/essential-computing/information-security/2factor/duo-phone-shut-off/