### PR TITLE
Remove Facebook U2F exception

### DIFF
--- a/entries/f/facebook.com.json
+++ b/entries/f/facebook.com.json
@@ -10,7 +10,6 @@
       "u2f"
     ],
     "documentation": "https://www.facebook.com/help/148233965247823",
-    "notes": "Hardware 2FA requires also enabling a back-up method",
     "categories": [
       "social"
     ]


### PR DESCRIPTION
Resolves #7365

I have verified that backup methods are indeed not required.