### PR TITLE
Add missing custom-* data (part 7)

### DIFF
--- a/entries/a/afip.gob.ar.json
+++ b/entries/a/afip.gob.ar.json
@@ -2,8 +2,11 @@
   "AFIP": {
     "domain": "afip.gob.ar",
     "tfa": [
-      "custom-hardware",
       "custom-software"
+    ],
+    "custom-software": [
+      "Token AFIP",
+      "AFIP OTP"
     ],
     "documentation": "https://www.afip.gob.ar/claveFiscal/informacion-basica/solicitud.asp",
     "categories": [

--- a/entries/b/bitgo.com.json
+++ b/entries/b/bitgo.com.json
@@ -6,6 +6,9 @@
       "custom-hardware",
       "u2f"
     ],
+    "custom-hardware": [
+      "Yubico OTP"
+    ],
     "categories": [
       "cryptocurrencies"
     ]

--- a/entries/e/entrust.net.json
+++ b/entries/e/entrust.net.json
@@ -1,12 +1,17 @@
 {
   "Entrust": {
     "domain": "entrust.net",
-    "url": "https://www.entrust.net",
     "tfa": [
       "custom-software",
       "custom-hardware"
     ],
-    "documentation": "https://www.entrust.com/multi-factor-authentication-tools/",
+    "custom-software": [
+      "Entrust IdentityGuard"
+    ],
+    "custom-hardware": [
+      "eGrid"
+    ],
+    "documentation": "https://www.entrust.com/knowledgebase/ssl/multifactor-authentication-faq",
     "categories": [
       "security"
     ]

--- a/entries/s/schwab.com.json
+++ b/entries/s/schwab.com.json
@@ -12,6 +12,9 @@
     "custom-software": [
       "Symantec VIP"
     ],
+    "custom-hardware": [
+      "Symantec VIP token"
+    ],
     "documentation": "https://www.schwab.com/help/two-factor-authentication",
     "categories": [
       "investing",

--- a/entries/s/singpass.gov.sg.json
+++ b/entries/s/singpass.gov.sg.json
@@ -4,7 +4,11 @@
     "url": "https://www.singpass.gov.sg/",
     "tfa": [
       "sms",
+	  "custom-software",
       "custom-hardware"
+    ],
+    "custom-software": [
+      "Singpass app"
     ],
     "custom-hardware": [
       "Biometrics"

--- a/entries/s/singpass.gov.sg.json
+++ b/entries/s/singpass.gov.sg.json
@@ -4,10 +4,12 @@
     "url": "https://www.singpass.gov.sg/",
     "tfa": [
       "sms",
-      "custom-software",
       "custom-hardware"
     ],
-    "documentation": "https://www.ifaq.gov.sg/SINGPASS/apps/fcd_faqmain.aspx#TOPIC_111223",
+    "custom-hardware": [
+      "Biometrics"
+    ],
+    "documentation": "https://www.singpass.gov.sg/main/html/faq.html",
     "categories": [
       "government"
     ],

--- a/entries/s/sjsu.edu.json
+++ b/entries/s/sjsu.edu.json
@@ -12,7 +12,7 @@
       "Duo"
     ],
     "custom-hardware": [
-      "Duo D100 Token"
+      "Feitian OTP c100 Token"
     ],
     "documentation": "https://sjsu.edu/it/security/multi-factor/duo-setup.php",
     "categories": [

--- a/entries/s/sjsu.edu.json
+++ b/entries/s/sjsu.edu.json
@@ -2,7 +2,6 @@
   "San José State University": {
     "domain": "sjsu.edu",
     "additional-domains": [
-      "one.sjsu.edu",
       "sjsu.okta.com"
     ],
     "tfa": [
@@ -12,7 +11,10 @@
     "custom-software": [
       "Duo"
     ],
-    "documentation": "https://www.sjsu.edu/it/support/service-desk/duo/index.php",
+    "custom-hardware": [
+      "Duo D100 Token"
+    ],
+    "documentation": "https://sjsu.edu/it/security/multi-factor/duo-setup.php",
     "categories": [
       "universities"
     ],

--- a/entries/t/temple.edu.json
+++ b/entries/t/temple.edu.json
@@ -1,11 +1,17 @@
 {
   "Temple University": {
     "domain": "temple.edu",
-    "url": "https://www.temple.edu/",
     "tfa": [
       "sms",
       "call",
-      "custom-software"
+      "custom-software",
+      "custom-hardware"
+    ],
+    "custom-software": [
+      "Duo"
+    ],
+    "custom-hardware": [
+      "Duo D100 Token"
     ],
     "documentation": "https://its.temple.edu/two-step-verification",
     "categories": [

--- a/entries/t/truekey.com.json
+++ b/entries/t/truekey.com.json
@@ -7,6 +7,9 @@
       "custom-software",
       "custom-hardware"
     ],
+    "custom-software": [
+      "True Key Push Notification"
+    ],
     "custom-hardware": [
       "Biometrics"
     ],

--- a/entries/u/udel.edu.json
+++ b/entries/u/udel.edu.json
@@ -8,6 +8,9 @@
       "sms",
       "custom-hardware"
     ],
+    "custom-hardware": [
+      "Feitian C100 Token"
+    ],
     "documentation": "https://www1.udel.edu/it/help/2fa/main.html",
     "categories": [
       "universities"

--- a/entries/u/udel.edu.json
+++ b/entries/u/udel.edu.json
@@ -9,7 +9,7 @@
       "custom-hardware"
     ],
     "custom-hardware": [
-      "Feitian C100 Token"
+      "Feitian OTP c100 Token"
     ],
     "documentation": "https://www1.udel.edu/it/help/2fa/main.html",
     "categories": [

--- a/entries/w/westernunion.com.json
+++ b/entries/w/westernunion.com.json
@@ -1,11 +1,13 @@
 {
   "Western Union": {
     "domain": "westernunion.com",
-    "url": "https://www.westernunion.com/",
     "tfa": [
       "sms",
       "call",
       "custom-software"
+    ],
+    "custom-software": [
+      "Authy"
     ],
     "documentation": "https://business.westernunion.com/en-us/product-documents/tfa-overview/Set-up-two-Factor",
     "notes": "2FA is only available for business accounts.",

--- a/entries/w/westernunion.com.json
+++ b/entries/w/westernunion.com.json
@@ -9,7 +9,7 @@
     "custom-software": [
       "Authy"
     ],
-    "documentation": "https://business.westernunion.com/en-us/product-documents/tfa-overview/Set-up-two-Factor",
+    "documentation": "https://business.westernunion.com/en-pl/product-documents/psd2-overview/Set-up-two-Factor",
     "notes": "2FA is only available for business accounts.",
     "categories": [
       "payments"

--- a/entries/x/xapo.com.json
+++ b/entries/x/xapo.com.json
@@ -2,11 +2,9 @@
   "Xapo": {
     "domain": "xapo.com",
     "tfa": [
-      "sms",
-      "call",
-      "custom-software"
+      "sms"
     ],
-    "documentation": "https://support.xapo.com/en/articles?id=59",
+    "documentation": "https://customersupport.xapo.com/en_us/r1aIYObOd",
     "categories": [
       "cryptocurrencies"
     ]


### PR DESCRIPTION
AFIP:
Two software 2FA apps are supported:
https://www.afip.gob.ar/celular/apps/AFIP-OTP.asp
https://www.afip.gob.ar/celular/apps/Token-AFIP.asp
Hardware tokens seem to be deprecated: https://www.afip.gob.ar/claveFiscal/solicitar-clave/tramite-presencial.asp

Bitgo:
[Source ](https://github.com/2factorauth/twofactorauth/pull/4542)

Entrust:
The previous documentation page is linked to their SSO services whilst the new one is for their customer portal.

Schwab:
[Source](https://www.schwab.com/help/two-factor-authentication#panel--text-54451)

SingPass:
![source](https://user-images.githubusercontent.com/3535780/235272559-62a6c04d-6b4a-431e-b6f5-f9b74b4f88c9.png)


San José State University:
>displays a continuously updating passcode
[Source](https://kb.mlml.sjsu.edu/books/security-anti-malware/page/set-up-duo-2-factor-authentication)

Sounds like it could only be a C100 HOTP Token.

Temple University:
[Source](https://tuportal6.temple.edu/web/its/multi-factor-authentication)


Truekey:
[Source](https://www.mcafee.com/support/?articleId=TS102352&page=shell&shell=article-view)

University of Delaware:
[This article](https://services.udel.edu/TDClient/32/Portal/KB/ArticleDet?ID=3) talks about the internal clock and device battery. Consistent with a C100 Token.

