### PR TITLE
Update Vivaldi

### DIFF
--- a/entries/v/vivaldi.com.json
+++ b/entries/v/vivaldi.com.json
@@ -1,6 +1,9 @@
 {
   "Vivaldi": {
-    "domain": "vivaldi.net",
+    "domain": "vivaldi.com",
+    "additional-domains": [
+      "vivaldi.net"
+    ],
     "tfa": [
       "totp",
       "u2f"

--- a/entries/v/vivaldi.com.json
+++ b/entries/v/vivaldi.com.json
@@ -1,10 +1,11 @@
 {
   "Vivaldi": {
-    "domain": "vivaldi.com",
-    "contact": {
-      "facebook": "vivaldi.browser",
-      "twitter": "vivaldibrowser"
-    },
+    "domain": "vivaldi.net",
+    "tfa": [
+      "totp",
+      "u2f"
+    ],
+    "documentation": "https://help.vivaldi.com/services/account/two-factor-authentication/",
     "categories": [
       "other"
     ]


### PR DESCRIPTION
Hello,

Vivaldi is a web browser that also hosts [online services called Vivaldi.net which comprises webmail, blogs, forums, and Mastodon](https://vivaldi.net).

They [added 2-factor authentication to those services on 2023-05-04](https://vivaldi.com/blog/community/two-factor-authentication-for-vivaldi-accounts).

### Changes
- Added the `totp` and `u2f` authentication methods.
- Added [documentation URL](https://help.vivaldi.com/services/account/two-factor-authentication/)
- Removed the `contact` object.
- I also changed the domain from `vivaldi.com` to `vivaldi.net`, because `vivaldi.com` is just the download site for the web browser, while `vivaldi.net` is the community site you actually sign in to that manages your account and hosts all the services (webmail, blogs, forums, and Mastodon). If this is an issue we can revert the domain though.

### 2FA setup page
![profile page](https://user-images.githubusercontent.com/1417794/236362052-c8ba2966-47be-43b1-9da1-3d5077d83647.png)

You can set up 2FA from your [profile page](https://login.vivaldi.net/profile/me) by clicking the Manage button under "Two-Factor Authentication", which brings you to https://login.vivaldi.net/profile/2fa.

![2fa page](https://user-images.githubusercontent.com/1417794/236362222-5ed33fdb-3c0e-4853-a185-7dd8212e4c05.png)

