### PR TITLE
Update OpenAI

### DIFF
--- a/entries/o/openai.com.json
+++ b/entries/o/openai.com.json
@@ -1,12 +1,13 @@
 {
     "OpenAI": {
         "domain": "openai.com",
-        "contact": {
-            "twitter": "OpenAI",
-            "email": "support@openai.com"
-        },
+        "tfa": [
+          "totp"
+        ],
+        "notes": "Enabling 2FA only available from the ChatGPT interface at the moment."
         "categories": [
-            "other"
+            "other",
+            "developer"
         ]
     }
 }

--- a/entries/o/openai.com.json
+++ b/entries/o/openai.com.json
@@ -4,7 +4,7 @@
         "tfa": [
           "totp"
         ],
-        "notes": "Enabling 2FA only available from the ChatGPT interface at the moment."
+        "notes": "Enabling 2FA only available from the ChatGPT interface at the moment.",
         "categories": [
             "other",
             "developer"

--- a/entries/o/openai.com.json
+++ b/entries/o/openai.com.json
@@ -4,7 +4,7 @@
         "tfa": [
           "totp"
         ],
-        "notes": "Enabling 2FA only available from the ChatGPT interface at the moment.",
+        "notes": "Enabling 2FA is only available from the ChatGPT interface at the moment.",
         "categories": [
             "other",
             "developer"

--- a/entries/o/openai.com.json
+++ b/entries/o/openai.com.json
@@ -6,7 +6,6 @@
         ],
         "notes": "Enabling 2FA is only available from the ChatGPT interface at the moment.",
         "categories": [
-            "other",
             "developer"
         ]
     }


### PR DESCRIPTION
2FA now available to enable from the ChatGPT interface under the `Data controls` settings.  No public documentation found on the topic just yet.

![image](https://user-images.githubusercontent.com/1686187/236608819-99ab4e41-ab8e-47e0-b9d4-aed5059a66de.png)