### PR TITLE
Update Facebook test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,7 @@ jobs:
       - run:
           name: Bundler
           command: |
+            bundle config with :tests
             bundle cache
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
 
       - run:
           name: Check Facebook handles
-          command: ruby ./tests/facebook.rb
+          command: bundle exec ruby ./tests/facebook.rb
 
       - run:
           name: Check Similarweb ranking

--- a/tests/facebook.rb
+++ b/tests/facebook.rb
@@ -6,7 +6,7 @@ require 'uri'
 require 'nokogiri'
 
 status = 0
-diff = `git diff  entries/ | sed -n 's/^+.*"facebook"[^"]*"\\(.*\\)".*/\\1/p'`
+diff = `git diff origin/master...HEAD entries/ | sed -n 's/^+.*"facebook"[^"]*"\\(.*\\)".*/\\1/p'`
 
 @headers = {
   'User-Agent' => 'Mozilla/5.0 (iPhone; CPU iPhone OS 14_6 like Mac OS X) ' \

--- a/tests/facebook.rb
+++ b/tests/facebook.rb
@@ -3,32 +3,35 @@
 
 require 'net/http'
 require 'uri'
+require 'nokogiri'
 
 status = 0
-diff = `git diff origin/master...HEAD entries/ | sed -n 's/^+.*"facebook"[^"]*"\\(.*\\)".*/\\1/p'`
+diff = `git diff  entries/ | sed -n 's/^+.*"facebook"[^"]*"\\(.*\\)".*/\\1/p'`
+
 @headers = {
-  'User-Agent' => '2FactorAuth/FacebookValidator '\
-  "(Ruby/#{RUBY_VERSION}; +https://2fa.directory/bot)",
+  'User-Agent' => 'Mozilla/5.0 (iPhone; CPU iPhone OS 14_6 like Mac OS X) ' \
+  'AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.3 Mobile/15E148 Safari/604.1',
   'From' => 'https://2fa.directory/'
 }
+@redirects = %w[301 302 318]
+
+def fetch(handle)
+  response = Net::HTTP.get_response(URI("https://m.me/#{handle}"), @headers)
+  output = nil
+  if response.header['location'].start_with?("https://m.facebook.com/msg/#{handle}")
+    body = Net::HTTP.get_response(URI(response.header['location']), @headers).body
+    output = Nokogiri::HTML.parse(body).at_css('._4ag7.img')&.attr('src')
+  end
+  output
+end
 
 diff.split("\n").each do |page|
-  url = URI("https://www.facebook.com/pg/#{page}")
-  http = Net::HTTP.new(url.host, url.port)
-  http.use_ssl = true
-  request = Net::HTTP::Get.new(url, @headers)
-  response = http.request(request)
-  begin
-    raise("\"#{page}\" is either private or doesn't exist.") if response.code.eql? '404'
-    next if response.header['location'].nil?
+  raise("Facebook page \"#{page}\" is either private or doesn't exist.") unless fetch(page)
 
-    fb_page = response.header['location'].split('/').last
-    raise("\"#{page}\" should be \"#{fb_page}\".") unless fb_page.eql? page
-
-    puts("#{page} is valid.")
-  rescue StandardError => e
-    puts "\e[31m#{e.message}\e[39m"
-    status = 1
-  end
+  puts("#{page} is valid.")
+rescue StandardError => e
+  puts "\e[31m#{e.message}\e[39m"
+  status = 1
 end
+
 exit status

--- a/tests/facebook.rb
+++ b/tests/facebook.rb
@@ -13,7 +13,6 @@ diff = `git diff  entries/ | sed -n 's/^+.*"facebook"[^"]*"\\(.*\\)".*/\\1/p'`
   'AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.3 Mobile/15E148 Safari/604.1',
   'From' => 'https://2fa.directory/'
 }
-@redirects = %w[301 302 318]
 
 def fetch(handle)
   response = Net::HTTP.get_response(URI("https://m.me/#{handle}"), @headers)


### PR DESCRIPTION
An updated test that _hopefully_ will work with Facebook's newer page types.
Instead of evaluating the apparently deprecated `facebook.com/pg/{page}` URL, this test uses `m.me/{page}` to see if a page exists. If the m.me page redirects to a new page that contains a profile image the test succeeds. If it on the other hand redirects to a page without a profile image the Facebook page is most likely restricted/private or doesn't exist.

This test is slower and more complicated than the older one but should return less false negatives.