### PR TITLE
Handle numeric Facebook handles

### DIFF
--- a/tests/facebook.rb
+++ b/tests/facebook.rb
@@ -17,7 +17,7 @@ diff = `git diff origin/master...HEAD entries/ | sed -n 's/^+.*"facebook"[^"]*"\
 def fetch(handle)
   response = Net::HTTP.get_response(URI("https://m.me/#{handle}"), @headers)
   output = nil
-  if response.header['location'].start_with?("https://m.facebook.com/msg/#{handle}")
+  if response.header['location'] =~ %r{^https://m\.facebook\.com/msg/(\d+|#{handle})/}
     body = Net::HTTP.get_response(URI(response.header['location']), @headers).body
     output = Nokogiri::HTML.parse(body).at_css('._4ag7.img')&.attr('src')
   end


### PR DESCRIPTION
PR to fix a bug discovered in #7594 

Instead of checking that the location header contains the Facebook handle, the if statement is now true if the location header contains either the Facebook handle or a string of numbers.