### PR TITLE
Add robots.txt

### DIFF
--- a/.github/workflows/repository.yml
+++ b/.github/workflows/repository.yml
@@ -93,6 +93,7 @@ jobs:
           mkdir -p public/icons
           cp -r api/. public/
           cp -r img/. public/icons/
+          cp robots.txt public/
       - uses: actions/upload-pages-artifact@v1
         with:
           path: public/

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,3 @@
+# Block access to icons.
+User-agent: *
+Disallow: /icons/


### PR DESCRIPTION
A robots.txt isn't strictly needed as we already block third-party access to `https://api.2fa.directory/icons/` but adding one can result in fewer unnecessary requests to our CDN.