### PR TITLE
Update GitLab

### DIFF
--- a/entries/g/gitlab.com.json
+++ b/entries/g/gitlab.com.json
@@ -6,7 +6,6 @@
       "u2f"
     ],
     "documentation": "https://docs.gitlab.com/ee/user/profile/account/two_factor_authentication.html",
-    "notes": "U2F requires enabling TOTP as a backup",
     "categories": [
       "developer"
     ]


### PR DESCRIPTION
Resolves #7619

Duo push is not supported in GitLab at this time (see [their issue](https://gitlab.com/gitlab-org/gitlab/-/issues/396704)).