### PR TITLE
Temporarily remove Rubocop test

### DIFF
--- a/.github/workflows/repository.yml
+++ b/.github/workflows/repository.yml
@@ -40,8 +40,8 @@ jobs:
         continue-on-error: true
       - name: Quality Checks
         run: bundle exec ruby ./tests/quality-checks.rb
-      - name: Validate Ruby scripts
-        run: bundle exec rubocop
+      #- name: Validate Ruby scripts
+      #  run: bundle exec rubocop
 
   publish:
     name: Build and Publish files


### PR DESCRIPTION
Rubocop is failing due to a new, and buggy, test recently added. Until this is fixed, I suggest we remove the Rubocop validation.