### PR TITLE
Update University of Colorado Boulder

### DIFF
--- a/entries/c/colorado.edu.json
+++ b/entries/c/colorado.edu.json
@@ -1,16 +1,10 @@
 {
   "University of Colorado Boulder": {
     "domain": "colorado.edu",
-    "tfa": [
-      "sms",
-      "call",
-      "totp",
-      "custom-software"
-    ],
-    "custom-software": [
-      "Microsoft Authenticator"
-    ],
-    "documentation": "https://oit.colorado.edu/services/identity-access-management/multi-factor-authentication",
+    "contact": {
+      "twitter": "CUBoulderOIT",
+      "email": "oithelp@colorado.edu"
+    },
     "categories": [
       "universities"
     ],


### PR DESCRIPTION
Per #7718, the university does not support MFA on their SSO instance, but do have it on their Microsoft 365 instance.

I opted to use the Office of Information Technology's contact information, but I can switch that to the university's.