### PR TITLE
Update Pixiv

### DIFF
--- a/entries/p/pixiv.net.json
+++ b/entries/p/pixiv.net.json
@@ -1,10 +1,6 @@
 {
   "Pixiv": {
     "domain": "pixiv.net",
-    "contact": {
-      "twitter": "pixiv_en",
-      "email": "support@pixiv.net"
-    },
     "tfa": [
       "totp"
     ],

--- a/entries/p/pixiv.net.json
+++ b/entries/p/pixiv.net.json
@@ -4,7 +4,7 @@
     "tfa": [
       "totp"
     ],
-    "documentation": "https://www.pixiv.help/hc/en-us/articles/20876082054553-What-is-two-factor-authentication-",
+    "documentation": "https://www.pixiv.help/hc/en-us/articles/20876082054553",
     "categories": [
       "social",
       "creativity"

--- a/entries/p/pixiv.net.json
+++ b/entries/p/pixiv.net.json
@@ -5,6 +5,10 @@
       "twitter": "pixiv_en",
       "email": "support@pixiv.net"
     },
+    "tfa": [
+      "totp"
+    ],
+    "documentation": "https://www.pixiv.help/hc/en-us/articles/20876082054553-What-is-two-factor-authentication-",
     "categories": [
       "social",
       "creativity"


### PR DESCRIPTION
I put a link to the [help page(available in English and Japanese)](https://www.pixiv.help/hc/en-us/articles/20876082054553-What-is-two-factor-authentication-) in the "documentation", but the [new feature announcement page(only Japanese)](https://www.pixiv.net/info.php?id=10043) has more details.
Which is desirable?