### PR TITLE
Re-enable Rubocop

### DIFF
--- a/.github/workflows/repository.yml
+++ b/.github/workflows/repository.yml
@@ -40,8 +40,8 @@ jobs:
         continue-on-error: true
       - name: Quality Checks
         run: bundle exec ruby ./tests/quality-checks.rb
-      #- name: Validate Ruby scripts
-      #  run: bundle exec rubocop
+      - name: Validate Ruby scripts
+        run: bundle exec rubocop
 
   publish:
     name: Build and Publish files


### PR DESCRIPTION
Follow-up to #7715.

Rubocop seems stable once again and thus I think it's safe to re-enable the test.