### PR TITLE
Add Fidelity NetBenefits

### DIFF
--- a/entries/n/nb.fidelity.com.json
+++ b/entries/n/nb.fidelity.com.json
@@ -1,0 +1,17 @@
+{
+  "Fidelity NetBenefits": {
+    "domain": "nb.fidelity.com",
+    "img": "fidelity.com.svg",
+    "tfa": [
+      "call",
+      "sms"
+    ],
+    "documentation": "https://nb.fidelity.com/public/nb/default/resourceslibrary/articles/securityfaqlearnmore",
+    "categories": [
+      "investing"
+    ],
+    "regions": [
+      "us"
+    ]
+  }
+}


### PR DESCRIPTION
Resolves #7727

As far as I can tell, Fidelity NetBenefits is only for U.S. companies, so I added the U.S. region.