### PR TITLE
Update Deutsche Post

### DIFF
--- a/entries/d/deutschepost.de.json
+++ b/entries/d/deutschepost.de.json
@@ -1,13 +1,10 @@
 {
   "Deutsche Post": {
     "domain": "deutschepost.de",
-    "additional-domains": [
-      "epost.de"
+    "tfa": [
+      "totp",
+      "email"
     ],
-    "contact": {
-      "facebook": "deutschepost",
-      "language": "de"
-    },
     "categories": [
       "postal"
     ],


### PR DESCRIPTION
Closes #7774 (no doc, see issue for screenshot)

Also, services on the `epost.de` domain have been discontinued.