### PR TITLE
Update Erste Bank [HR]

### DIFF
--- a/entries/e/erstebank.hr.json
+++ b/entries/e/erstebank.hr.json
@@ -1,12 +1,17 @@
 {
   "Erste Bank [HR]": {
     "domain": "erstebank.hr",
-    "url": "https://www.erstebank.hr/",
     "tfa": [
       "custom-software",
       "custom-hardware"
     ],
-    "documentation": "https://www.erstebank.hr/content/dam/hr/ebc/www_erstebank_hr/gradani/downloads/e-bankarstvo/Upute%20za%20prijavu.pdf",
+    "custom-software": [
+      "George App"
+    ],
+    "custom-hardware": [
+      "Display card"
+    ],
+    "documentation": "https://www.erstebank.hr/hr/sigurnost#/modalComponent/isOpen/true/url/%2Fhr%2Fconfiguration%2Fleads%2Fsigurnost0%2Fsigurno-online-bankarenje.modal",
     "regions": [
       "hr"
     ],


### PR DESCRIPTION
From what I understand through Google Translate, the bank offers two different auth options.
1. OTP from their phone app ("George App")
2. HOTP using their [Erste Maestro® PayPass™ Display Card](https://www.youtube.com/watch?app=desktop&v=JAvQhXXMh9M)

>If you use a Display card, to log in to George Web or NetBanking, you must enter a username and only one one-time password obtained by pressing button 6 on the Display card. And nothing more. In case you use mToken, you enter the one-time password that you received when logging in to mToken.

>Never disclose your access information to George, NetBanking or mBanking, such as username, password, one-time password, mPIN or card number.

Paragraph 1 seems to indicate that only username & OTP is used, while the second paragraph indicates to me that username + password + OTP is used. Unsure which it is :shrug: 