### PR TITLE
Update Zaba

### DIFF
--- a/entries/z/zaba.hr.json
+++ b/entries/z/zaba.hr.json
@@ -4,8 +4,10 @@
     "url": "https://www.zaba.hr/",
     "img": "unicredit.svg",
     "tfa": [
-      "custom-software",
-      "custom-hardware"
+      "custom-software"
+    ],
+    "custom-software": [
+      "m-zaba app"
     ],
     "documentation": "https://www.zaba.hr/home/token#pan3",
     "regions": [


### PR DESCRIPTION
According to [this page](https://www.zaba.hr/home/ukidanje-fizickog-tokena-za-gradane), hardware tokens are deprecated and will be EOL in February 2024. I therefore removed the custom-hardware option.

Continuation of #6845