### PR TITLE
Update Santander [PL]

### DIFF
--- a/entries/s/santander.pl.json
+++ b/entries/s/santander.pl.json
@@ -6,6 +6,9 @@
       "sms",
       "custom-software"
     ],
+    "custom-software": [
+      "Santander mobile app"
+    ],
     "documentation": "https://www.santander.pl/klient-indywidualny/kontakt/pytania-i-odpowiedzi-bankowosc-internetowa",
     "regions": [
       "pl"


### PR DESCRIPTION
There is somewhat limited information about the custom software tool and how it functions, but it appears that [this app](https://play.google.com/store/apps/details?id=pl.bzwbk.bzwbk24) can be used instead of SMS 2FA. According to a page I read, installing that app disables the ability to request SMS 2FA.