### PR TITLE
Update Mail.ru

### DIFF
--- a/entries/m/mail.ru.json
+++ b/entries/m/mail.ru.json
@@ -3,9 +3,9 @@
     "domain": "mail.ru",
     "tfa": [
       "sms",
-      "custom-software"
+      "u2f"
     ],
-    "documentation": "https://help.mail.ru/mail-help/2auth",
+    "documentation": "https://help.mail.ru/mail/settings/2fa",
     "categories": [
       "email"
     ],


### PR DESCRIPTION
I haven't found any proof of them supporting software 2FA. I did, however, find that they support hardware keys through WebAuthn.

>Questions about logging in using an electronic key
>No. __WebAuthn__ technology is designed in such a way that data is stored on the device and not in the Mail.ru system.
\- https://help.mail.ru/mail/account/login/keys

>Log in to the mailbox using an external device (USB, Bluetooth, NFC key) on the computer
>1. Go [to the login page](https://account.mail.ru/login) .
>1. Enter a name for the mailbox.
>1. Click "Enter Password".
>1. __Insert the external device and touch it if required.__
>
>\- https://help.mail.ru/mail/account/login/keys