### PR TITLE
Update Truist

### DIFF
--- a/entries/t/truist.com.json
+++ b/entries/t/truist.com.json
@@ -2,7 +2,10 @@
   "Truist": {
     "domain": "truist.com",
     "tfa": [
-      "custom-software"
+      "custom-software",
+      "sms",
+      "call",
+      "email"
     ],
     "custom-software": [
       "Truist Authenticator"


### PR DESCRIPTION
Resolves #7790.

Left the custom-software option in as, based on the latest App Store review, the TOTP app seems to be working (again?)
![review](https://github.com/2factorauth/twofactorauth/assets/3535780/ceacd91c-85b0-41eb-b513-c7c3ca9fe0ec)
