### PR TITLE
Update letterboxd

### DIFF
--- a/entries/l/letterboxd.com.json
+++ b/entries/l/letterboxd.com.json
@@ -6,6 +6,9 @@
 			"facebook": "letterboxd",
 			"twitter": "letterboxd"
 		},
+    "tfa": [
+      "totp"
+    ],
 		"categories": [
 			"entertainment",
 			"social"

--- a/entries/l/letterboxd.com.json
+++ b/entries/l/letterboxd.com.json
@@ -1,11 +1,6 @@
 {
 	"Letterboxd": {
 		"domain": "letterboxd.com",
-		"contact": {
-			"email": "help@letterboxd.com",
-			"facebook": "letterboxd",
-			"twitter": "letterboxd"
-		},
     "tfa": [
       "totp"
     ],

--- a/entries/l/letterboxd.com.json
+++ b/entries/l/letterboxd.com.json
@@ -1,15 +1,15 @@
 {
-	"Letterboxd": {
-		"domain": "letterboxd.com",
+  "Letterboxd": {
+    "domain": "letterboxd.com",
+    "additional-domains": [
+      "ltrbxd.com"
+    ],
     "tfa": [
       "totp"
     ],
-		"categories": [
-			"entertainment",
-			"social"
-		],
-		"additional-domains": [
-			"ltrbxd.com"
-		]
-	}
+    "categories": [
+      "entertainment",
+      "social"
+    ]
+  }
 }


### PR DESCRIPTION
[letterboxd](https://letterboxd.com/) now supports 2FA via OTP.

The changelog of the iOS app even mentiones "Apple Keychain". I assume this is an iOS-only feature so I didn't add it here.