### PR TITLE
Update Open Collective

### DIFF
--- a/entries/o/opencollective.com.json
+++ b/entries/o/opencollective.com.json
@@ -2,7 +2,8 @@
   "Open Collective": {
     "domain": "opencollective.com",
     "tfa": [
-      "totp"
+      "totp",
+      "u2f"
     ],
     "documentation": "https://docs.opencollective.com/help/product/two-factor-authentication",
     "categories": [


### PR DESCRIPTION
This adds 'u2f' hardware keys as a 2FA option for Open Collective. I don't see this option documented on their website, but the option is available in the website security settings.