### PR TITLE
Discord now supports WebAuthn

### DIFF
--- a/entries/d/discord.com.json
+++ b/entries/d/discord.com.json
@@ -6,7 +6,8 @@
     ],
     "tfa": [
       "sms",
-      "totp"
+      "totp",
+      "u2f"
     ],
     "documentation": "https://support.discord.com/hc/en-us/articles/219576828",
     "categories": [


### PR DESCRIPTION
Proof:
![image](https://github.com/Nitrokey/dongleauth/assets/24937357/cb4a5d19-102c-494f-8ae6-e02e27014d09)
It is now also mentioned [here](https://support.discord.com/hc/en-us/articles/219576828#docs-internal-guid-c08017e4-7fff-6508-8580-d9b7737f7440) in the already linked docs site