### PR TITLE
Update Seznam.cz

### DIFF
--- a/entries/s/seznam.cz.json
+++ b/entries/s/seznam.cz.json
@@ -2,6 +2,7 @@
   "Seznam.cz": {
     "domain": "seznam.cz",
     "tfa": [
+      "totp",
       "custom-software"
     ],
     "custom-software": [

--- a/entries/s/seznam.cz.json
+++ b/entries/s/seznam.cz.json
@@ -8,7 +8,7 @@
     "custom-software": [
       "Seznam.cz mobile app"
     ],
-    "documentation": "https://blog.seznam.cz/2018/04/seznam-cz-ma-nove-dvoufazove-overeni-u-vsech-svych-sluzeb-zvysi-zabezpeci-prihlasovani-napriklad-do-emailu/",
+    "documentation": "https://napoveda.seznam.cz/cz/login/dvoufazove-overeni/",
     "categories": [
       "email"
     ],


### PR DESCRIPTION
I've also changed the docs link to a general 2FA info page. They also have a dedicated TOTP help page here https://napoveda.seznam.cz/cz/login/dvoufazove-overeni-ucet/autentizacni-aplikace/ which is linked from the general info page too (but currently that link on the general info page uses a wrong/internal hostname oops).

Partially related to 2factorauth#7801