### PR TITLE
Update Passwordless Authentication documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -380,10 +380,15 @@ For context, check out the discussion in issue [#242][242].
 
 ### Passwordless Authentication
 
-Many sites are now offering passwordless authentication, which replaces the password (something you know) with a
-different factor, such as something you have or are. Examples of this would be sites that allow users to use a U2F key
-or a magic link to login but do not have a second factor available. Since there is still only one factor being used (
-although it may not be a password), it does not constitute two-factor authentication.
+Many sites are now offering passwordless authentication, which replaces the password
+(something you know) with a different factor, such as something you have or are.
+Examples of this would be sites that allow users to use a U2F key or a magic link
+to login but do not have a second factor available. Since there is still only one
+factor being used (although it may not be a password), it does not constitute two-factor
+authentication.
+
+These sites can be added to the [Passkeys Directory][passkeys-directory]. The repository
+is [2factorauth/passkeys][passkeys-repository].
 
 [json]: https://www.json.org/
 [entries]: entries/
@@ -404,3 +409,5 @@ although it may not be a password), it does not constitute two-factor authentica
 [iso-lang-wikipedia]: https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
 [iso-country-wikipedia]: https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes
 [242]: https://github.com/2factorauth/twofactorauth/issues/242
+[passkeys-directory]: https://passkeys.2fa.directory
+[passkeys-repository]: https://github.com/2factorauth/passkeys

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -380,15 +380,7 @@ For context, check out the discussion in issue [#242][242].
 
 ### Passwordless Authentication
 
-Many sites are now offering passwordless authentication, which replaces the password
-(something you know) with a different factor, such as something you have or are.
-Examples of this would be sites that allow users to use a U2F key or a magic link
-to login but do not have a second factor available. Since there is still only one
-factor being used (although it may not be a password), it does not constitute two-factor
-authentication.
-
-These sites can be added to the [Passkeys Directory][passkeys-directory]. The repository
-is [2factorauth/passkeys][passkeys-repository].
+Many sites now offer passwordless authentication, replacing the traditional password (something you know) with a different factor, such as something you have or are. Examples include sites allowing users to log in using a U2F key or a magic link without requiring a second factor. While these methods enhance security, it's important to note that our 2FA Directory focuses on platforms providing two distinct factors for authentication. For passkey-specific options, we invite you to explore the [Passkeys Directory][passkeys-directory]. The repository is [2factorauth/passkeys][passkeys-repository].
 
 [json]: https://www.json.org/
 [entries]: entries/


### PR DESCRIPTION
This PR adds a reference to the Passkeys Directory and its repository in the passwordless authentication section.