### PR TITLE
Disable Facebook test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,10 +31,6 @@ jobs:
           command: bundle exec ruby ./tests/twitter.rb
 
       - run:
-          name: Check Facebook handles
-          command: bundle exec ruby ./tests/facebook.rb
-
-      - run:
           name: Check Similarweb ranking
           command: bundle exec ruby ./tests/similarweb.rb
 


### PR DESCRIPTION
Facebook reworked the login page, so the page handle is no longer mentioned. The Facebook handle validation test thus no longer works.

PR to keep this facebook test script in but disable the execution of the script by CircleCI.