### PR TITLE
Set issue titles using action

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-add-site-with-2fa.yml
+++ b/.github/ISSUE_TEMPLATE/01-add-site-with-2fa.yml
@@ -1,6 +1,6 @@
 name: 🔒 Add site with 2FA
 description: Request that a site that supports 2FA be added.
-title: Add [site name]
+title: Add site with 2FA
 labels: add site
 body:
 

--- a/.github/ISSUE_TEMPLATE/02-add-site-without-2fa.yml
+++ b/.github/ISSUE_TEMPLATE/02-add-site-without-2fa.yml
@@ -1,6 +1,6 @@
 name: 🔓 Add site without 2FA
 description: Request that a site that does not support 2FA be added.
-title: Add [site name]
+title: Add site without 2FA
 labels: add site
 body:
   - type: input

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -7,7 +7,9 @@ env:
   GH_TOKEN: ${{ github.token }}
 
 jobs:
-  process:
+  replace:
+    name: Replace Issue Title
+    if: contains(toJson(github.event.issue.labels.*.name), 'add site') || contains(toJson(github.event.issue.labels.*.name), 'update site')
     runs-on: ubuntu-latest
     steps:
       - name: Issue Forms Body Parser

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -1,0 +1,25 @@
+name: Replace Issue Title
+on:
+  issues:
+    types:
+      - opened
+env:
+  GH_TOKEN: ${{ github.token }}
+
+jobs:
+  process:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Issue Forms Body Parser
+        id: parse
+        uses: zentered/issue-forms-body-parser@v2.0.0
+      - name: Extract site-name
+        id: extract-site-name
+        uses: 2factorauth/issue-title-action@master
+        with:
+          repository: ${{ github.repository }}
+          issue_number: ${{ github.event.issue.number }}
+          data: ${{ toJSON(steps.parse.outputs.data) }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          labels: "${{ toJSON(github.event.issue.labels) }}"
+


### PR DESCRIPTION
I built a simple GitHub Action for automatically replacing the title of issues with the labels `add site` and `update site` as I've seen many users not following any common naming convention or forgetting to set a title.