### PR TITLE
Update Deutsche Telekom

### DIFF
--- a/entries/t/telekom.de.json
+++ b/entries/t/telekom.de.json
@@ -9,7 +9,7 @@
     "categories": [
       "utilities"
     ],
-    "notes": "Mobile phone number required as fallback when enabling authenticator app.",
+    "notes": "Software 2FA requires setting up SMS 2FA as a fallback.",
     "regions": [
       "de"
     ]

--- a/entries/t/telekom.de.json
+++ b/entries/t/telekom.de.json
@@ -9,6 +9,7 @@
     "categories": [
       "utilities"
     ],
+    "notes": "Mobile phone number required as fallback when enabling authenticator app.",
     "regions": [
       "de"
     ]


### PR DESCRIPTION
Setting up an authenticator app unfortunately requires providing a mobile phone number as fallback.