### PR TITLE
Fix documentation link for mailbox.org

### DIFF
--- a/entries/m/mailbox.org.json
+++ b/entries/m/mailbox.org.json
@@ -8,7 +8,7 @@
     "custom-hardware": [
       "Yubico OTP"
     ],
-    "documentation": "https://kb.mailbox.org/x/5AcS",
+    "documentation": "https://kb.mailbox.org/de/privat/sicherheit-privatsphaere/die-zwei-faktor-authentifizierung-einrichten/",
     "categories": [
       "email"
     ]


### PR DESCRIPTION
The old link gives a 404 now.