### PR TITLE
Update AOL Mail

### DIFF
--- a/entries/m/mail.aol.com.json
+++ b/entries/m/mail.aol.com.json
@@ -4,6 +4,7 @@
     "tfa": [
       "sms",
       "call",
+      "totp",
       "email",
       "u2f"
     ],


### PR DESCRIPTION
Add TOTP as a 2fa method for AOL Mail as referenced in the documentation.