### PR TITLE
Update OpenAI

### DIFF
--- a/entries/o/openai.com.json
+++ b/entries/o/openai.com.json
@@ -1,6 +1,9 @@
 {
     "OpenAI (ChatGPT)": {
         "domain": "openai.com",
+        "additional-domains": [
+        	"chatgpt.com"
+        ],
         "tfa": [
           "totp"
         ],


### PR DESCRIPTION
It seems like OpenAI has finally gotten the `chatgpt.com` domain because visiting `chat.openai.com` now redirects to `chatgpt.com`.