### PR TITLE
Update Canada Revenue Agency

### DIFF
--- a/entries/c/canada.ca.json
+++ b/entries/c/canada.ca.json
@@ -3,7 +3,7 @@
     "domain": "canada.ca",
     "url": "https://www.canada.ca/en/revenue-agency.html",
     "additional-domains": [
-      "ams-sga.cra-arc.gc.ca"
+      "cra-arc.gc.ca"
     ],
     "tfa": [
       "sms",

--- a/entries/c/canada.ca.json
+++ b/entries/c/canada.ca.json
@@ -2,9 +2,13 @@
   "Canada Revenue Agency": {
     "domain": "canada.ca",
     "url": "https://www.canada.ca/en/revenue-agency.html",
+    "additional-domains": [
+      "cra-arc.gc.ca"
+    ],
     "tfa": [
       "sms",
-      "call"
+      "call",
+      "totp"
     ],
     "documentation": "https://www.canada.ca/en/revenue-agency/services/e-services/cra-login-services/multi-factor-authentication-access-cra-login-services.html",
     "categories": [

--- a/entries/c/canada.ca.json
+++ b/entries/c/canada.ca.json
@@ -3,7 +3,7 @@
     "domain": "canada.ca",
     "url": "https://www.canada.ca/en/revenue-agency.html",
     "additional-domains": [
-      "cra-arc.gc.ca"
+      "ams-sga.cra-arc.gc.ca"
     ],
     "tfa": [
       "sms",


### PR DESCRIPTION
The existing documentation mentions the TOTP feature:
https://www.canada.ca/en/revenue-agency.html

The "CRA sign in" takes place on a few subdomains from what I added (eg. `cms-sgj.cra-arc.gc.ca`, `ams-sga.cra-arc.gc.ca`). Not sure what the rules are for subdomains, so I just added the common parent.