### PR TITLE
Update CommBank

### DIFF
--- a/entries/c/commbank.com.au.json
+++ b/entries/c/commbank.com.au.json
@@ -1,19 +1,14 @@
 {
   "Commonwealth Bank of Australia": {
     "domain": "commbank.com.au",
-    "tfa": [
-      "sms",
-      "custom-hardware",
-      "custom-software"
+    "additional-domains": [
+      "netbank.com.au"
     ],
-    "custom-software": [
-      "CommBank app"
-    ],
-    "custom-hardware": [
-      "NetCode Token"
-    ],
-    "documentation": "https://www.commbank.com.au/support.digital-banking.explain-netcode-token.html",
-    "notes": "NetCode Tokens are only offered to customers who cannot use SMS 2FA or the CommBank app.",
+    "contact": {
+      "facebook": "commonwealthbank",
+      "twitter": "commbank",
+      "form": "https://www.commbank.com.au/retail/netbank/complaints-compliments-form"
+    },
     "regions": [
       "au"
     ],


### PR DESCRIPTION
What they offer isn't actually 2FA, as per the [authorisation definition](https://www.commbank.com.au/support.digital-banking.explain-netcode-sms.html). As described [here](https://www.commbank.com.au/support.digital-banking.explain-netcode-sms.html), NetCodes (or 2FA codes) are only used to confirm certain transactions or tasks. It does not ask for a code when you log into the website or app.