### PR TITLE
Add an "Insurance" category

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -317,21 +317,21 @@ Below is a table of each available category, the name of the category, which tit
 description.
 
 | Name             |           Title           | Description                                                                         |
-|------------------|:-------------------------:|-------------------------------------------------------------------------------------|
+| ---------------- | :-----------------------: | ----------------------------------------------------------------------------------- |
 | backup           |      Backup and Sync      | Online backup and cross-device file synchronization                                 |
 | banking          |          Banking          | Online banking platforms                                                            |
-| betting          |          Betting          | Betting and Gambling                                                                |
+| betting          |          Betting          | Betting and gambling                                                                |
 | cloud            |      Cloud Computing      | "Serverless" cloud computing                                                        |
 | communication    |       Communication       | Online communication platforms excluding email and social media                     |
 | creativity       |        Creativity         | Art and design software                                                             |
 | crowdfunding     |       Crowdfunding        |                                                                                     |
 | cryptocurrencies |     Cryptocurrencies      | Any site whose main purpose is handling cryptocurrencies                            |
 | developer        |         Developer         | Development software                                                                |
-| domains          |          Domains          | DNS Registrars                                                                      |
+| domains          |          Domains          | DNS registrars                                                                      |
 | education        |         Education         | Non-university education platforms                                                  |
 | email            |           Email           | Email providers                                                                     |
 | entertainment    |       Entertainment       | Audio/Video entertainment excluding games                                           |
-| finance          |          Finance          | Financial, insurance and pension services                                           |
+| finance          |          Finance          | Financial and pension services                                                      |
 | food             |           Food            | Food and beverage services                                                          |
 | gaming           |          Gaming           | Games and game platforms. Sites for buying games should be listed in Retail         |
 | government       |        Government         | Government portals. Excluding education                                             |
@@ -339,6 +339,7 @@ description.
 | hosting          |        Hosting/VPS        | Online website hosting, VPS, and dedicated server rentals                           |
 | hotels           | Hotels and Accommodations | Hotels and short term accommodation providers                                       |
 | identity         |    Identity Management    | Authentication providers, Single Sign On platforms                                  |
+| insurance        |         Insurance         | Insurance services                                                                  |
 | investing        |         Investing         | Investment platforms                                                                |
 | iot              |            IoT            | Internet of Things and device management platforms                                  |
 | legal            |           Legal           | Legal aid services                                                                  |

--- a/entries/a/aami.com.au.json
+++ b/entries/a/aami.com.au.json
@@ -6,7 +6,7 @@
       "facebook": "aami"
     },
     "categories": [
-      "finance"
+      "insurance"
     ],
     "regions": [
       "au"

--- a/entries/a/admiral.com.json
+++ b/entries/a/admiral.com.json
@@ -6,7 +6,7 @@
       "twitter": "AdmiralUK"
     },
     "categories": [
-      "finance"
+      "insurance"
     ],
     "regions": [
       "gb"

--- a/entries/a/aetna.com.json
+++ b/entries/a/aetna.com.json
@@ -6,7 +6,7 @@
       "twitter": "Aetna"
     },
     "categories": [
-      "finance"
+      "insurance"
     ],
     "regions": [
       "us"

--- a/entries/a/allianz.de.json
+++ b/entries/a/allianz.de.json
@@ -6,7 +6,7 @@
     ],
     "documentation": "https://www.allianz.de/service/meine-allianz/#faq",
     "categories": [
-      "finance"
+      "insurance"
     ],
     "regions": [
       "de"

--- a/entries/a/anthem.com.json
+++ b/entries/a/anthem.com.json
@@ -7,7 +7,7 @@
       "email"
     ],
     "categories": [
-      "health"
+      "insurance"
     ],
     "regions": [
       "us"

--- a/entries/a/aok.de.json
+++ b/entries/a/aok.de.json
@@ -6,7 +6,7 @@
     ],
     "documentation": "https://meine.aok.de/landingpage/faq",
     "categories": [
-      "finance"
+      "insurance"
     ],
     "regions": [
       "de"

--- a/entries/a/australiansuper.com.json
+++ b/entries/a/australiansuper.com.json
@@ -1,17 +1,17 @@
 {
-    "Australian Super": {
-        "domain": "australiansuper.com",
-        "contact": {
-            "facebook": "AustralianSuper",
-            "twitter": "AustralianSuper",
-            "form": "https://www.australiansuper.com/contact-us/enquiry"
-        },
-        "categories": [
-            "investing",
-            "finance"
-        ],
-        "regions": [
-            "au"
-        ]
-    }
+  "Australian Super": {
+    "domain": "australiansuper.com",
+    "contact": {
+      "facebook": "AustralianSuper",
+      "twitter": "AustralianSuper",
+      "form": "https://www.australiansuper.com/contact-us/enquiry"
+    },
+    "categories": [
+      "finance",
+      "investing"
+    ],
+    "regions": [
+      "au"
+    ]
+  }
 }

--- a/entries/b/baloise.ch.json
+++ b/entries/b/baloise.ch.json
@@ -5,7 +5,7 @@
       "sms"
     ],
     "categories": [
-      "finance"
+      "insurance"
     ],
     "regions": [
       "ch"

--- a/entries/b/barmenia.de.json
+++ b/entries/b/barmenia.de.json
@@ -10,7 +10,7 @@
     ],
     "documentation": "https://www.barmenia.de/deu/bde_privat/bde_service/bde_selfservice/bde_meine_barmenia/erstanmeldung.xhtml",
     "categories": [
-      "finance"
+      "insurance"
     ],
     "regions": [
       "de"

--- a/entries/b/bupa.com.au.json
+++ b/entries/b/bupa.com.au.json
@@ -6,7 +6,7 @@
     ],
     "documentation": "https://www.bupa.com.au/help/privacy-and-security-trust-centre/mybupa-and-digital-security",
     "categories": [
-      "health"
+      "insurance"
     ],
     "regions": [
       "au"

--- a/entries/e/emma.ca.json
+++ b/entries/e/emma.ca.json
@@ -6,7 +6,7 @@
       "twitter": "EmmaAssurance"
     },
     "categories": [
-      "finance"
+      "insurance"
     ],
     "regions": [
       "ca"

--- a/entries/g/geico.com.json
+++ b/entries/g/geico.com.json
@@ -7,7 +7,7 @@
     ],
     "documentation": "https://www.geico.com/web-and-mobile/2SV/",
     "categories": [
-      "finance"
+      "insurance"
     ],
     "regions": [
       "us"

--- a/entries/g/gerberlife.com.json
+++ b/entries/g/gerberlife.com.json
@@ -1,14 +1,14 @@
 {
   "Gerber Life Insurance": {
     "domain": "gerberlife.com",
-    "url": "https://www.gerberlife.com",
     "img": "gerberlife.com.png",
     "contact": {
       "facebook": "gerberlife",
       "twitter": "GerberLife"
     },
     "categories": [
-      "finance"
+      "finance",
+      "insurance"
     ],
     "regions": [
       "us"

--- a/entries/h/healthcare.gov.json
+++ b/entries/h/healthcare.gov.json
@@ -9,7 +9,7 @@
     "documentation": "https://www.healthcare.gov/how-can-i-protect-myself-from-fraud-in-the-health-insurance-marketplace/",
     "categories": [
       "government",
-      "health"
+      "insurance"
     ],
     "regions": [
       "us"

--- a/entries/h/huk.de.json
+++ b/entries/h/huk.de.json
@@ -6,7 +6,7 @@
       "call"
     ],
     "categories": [
-      "finance"
+      "insurance"
     ],
     "regions": [
       "de"

--- a/entries/h/huk24.de.json
+++ b/entries/h/huk24.de.json
@@ -4,12 +4,12 @@
     "tfa": [
       "sms"
     ],
+    "documentation": "https://www.huk24.de/unsere-services/login-und-mehr#spr05",
     "categories": [
-      "finance"
+      "insurance"
     ],
     "regions": [
       "de"
-    ],
-    "documentation": "https://www.huk24.de/unsere-services/login-und-mehr#spr05"
+    ]
   }
 }

--- a/entries/h/humana.com.json
+++ b/entries/h/humana.com.json
@@ -8,7 +8,7 @@
       ],
       "documentation": "https://www.humana.com/2-step-verification",
       "categories": [
-        "health"
+        "insurance"
       ],
       "regions": [
         "us"

--- a/entries/i/independer.nl.json
+++ b/entries/i/independer.nl.json
@@ -6,7 +6,7 @@
       "totp"
     ],
     "categories": [
-      "finance"
+      "insurance"
     ],
     "regions": [
       "nl"

--- a/entries/i/independer.nl.json
+++ b/entries/i/independer.nl.json
@@ -6,6 +6,7 @@
       "totp"
     ],
     "categories": [
+      "finance",
       "insurance"
     ],
     "regions": [

--- a/entries/i/insurance.everyday.com.au.json
+++ b/entries/i/insurance.everyday.com.au.json
@@ -9,7 +9,7 @@
       "email"
     ],
     "categories": [
-      "finance"
+      "insurance"
     ],
     "regions": [
       "au"

--- a/entries/m/my.cigna.com.json
+++ b/entries/m/my.cigna.com.json
@@ -6,7 +6,7 @@
       "email"
     ],
     "categories": [
-      "health"
+      "insurance"
     ],
     "regions": [
       "es",

--- a/entries/n/nbc.ca.json
+++ b/entries/n/nbc.ca.json
@@ -9,7 +9,9 @@
       "twitter": "nationalbank"
     },
     "categories": [
-      "finance"
+      "banking",
+      "finance",
+      "insurance"
     ],
     "regions": [
       "ca"

--- a/entries/n/noridianmedicareportal.com.json
+++ b/entries/n/noridianmedicareportal.com.json
@@ -8,7 +8,7 @@
     ],
     "documentation": "https://med.noridianmedicare.com/web/portalguide/registration/multi-factor-authentication",
     "categories": [
-      "health"
+      "insurance"
     ],
     "regions": [
       "us"

--- a/entries/n/northwesternmutual.com.json
+++ b/entries/n/northwesternmutual.com.json
@@ -8,7 +8,8 @@
     ],
     "documentation": "https://www.northwesternmutual.com/security-and-privacy/",
     "categories": [
-      "finance"
+      "finance",
+      "insurance"
     ],
     "regions": [
       "us"

--- a/entries/p/principal.com.json
+++ b/entries/p/principal.com.json
@@ -9,7 +9,8 @@
     ],
     "documentation": "https://secure02.principal.com/publicvsupply/GetFile?fm=ww42&ty=VOP&EXT=.VOP",
     "categories": [
-      "finance"
+      "finance",
+      "insurance"
     ],
     "regions": [
       "us"

--- a/entries/p/progressive.com.json
+++ b/entries/p/progressive.com.json
@@ -1,13 +1,12 @@
 {
   "Progressive": {
     "domain": "progressive.com",
-    "url": "https://www.progressive.com",
     "contact": {
       "facebook": "progressive",
       "twitter": "Progressive"
     },
     "categories": [
-      "finance"
+      "insurance"
     ],
     "regions": [
       "us"

--- a/entries/r/rest.com.au.json
+++ b/entries/r/rest.com.au.json
@@ -1,15 +1,16 @@
 {
-    "Rest Super": {
-        "domain": "rest.com.au",
-        "tfa": [
-            "sms"
-        ],
-        "categories": [
-            "investing",
-            "finance"
-        ],
-        "regions": [
-            "au"
-        ]
-    }
+  "Rest Super": {
+    "domain": "rest.com.au",
+    "tfa": [
+      "sms"
+    ],
+    "categories": [
+      "finance",
+      "investing",
+      "insurance"
+    ],
+    "regions": [
+      "au"
+    ]
+  }
 }

--- a/entries/s/statefarm.com.json
+++ b/entries/s/statefarm.com.json
@@ -1,17 +1,18 @@
 {
   "State Farm": {
     "domain": "statefarm.com",
-    "url": "https://www.statefarm.com/",
     "tfa": [
       "sms",
       "email"
     ],
-    "documentation": "https://www.statefarm.com/customer-care/privacy-security-center/identity-verification",
+    "documentation": "https://www.statefarm.com/customer-care/privacy-security/security",
+    "categories": [
+      "banking",
+      "insurance",
+      "investing"
+    ],
     "regions": [
       "us"
-    ],
-    "categories": [
-      "banking"
     ]
   }
 }

--- a/entries/s/suncorp.com.au.json
+++ b/entries/s/suncorp.com.au.json
@@ -7,11 +7,11 @@
       "twitter": "Suncorp",
       "email": "customer.relations@suncorp.com.au"
     },
+    "categories": [
+      "insurance"
+    ],
     "regions": [
       "au"
-    ],
-    "categories": [
-      "finance"
     ]
   }
 }

--- a/entries/s/swisslife.ch.json
+++ b/entries/s/swisslife.ch.json
@@ -1,12 +1,12 @@
 {
   "Swiss Life": {
     "domain": "swisslife.ch",
-    "url": "https://www.swisslife.ch",
     "tfa": [
       "sms"
     ],
     "categories": [
-      "finance"
+      "finance",
+      "insurance"
     ],
     "regions": [
       "ch"

--- a/entries/t/tk.de.json
+++ b/entries/t/tk.de.json
@@ -9,7 +9,8 @@
     ],
     "documentation": "https://www.tk.de/techniker/unternehmensseiten/unternehmen/die-tk-app/2023678",
     "categories": [
-      "finance"
+      "insurance",
+      "health"
     ],
     "regions": [
       "de"

--- a/entries/t/trustage.com.json
+++ b/entries/t/trustage.com.json
@@ -8,7 +8,8 @@
       ],
       "documentation": "https://www.trustage.com/my-account/help/online-account-information-faqs",
       "categories": [
-        "finance"
+        "finance",
+        "insurance"
       ],
       "regions": [
         "us"

--- a/entries/v/vitality.co.uk.json
+++ b/entries/v/vitality.co.uk.json
@@ -1,13 +1,12 @@
 {
   "Vitality": {
     "domain": "vitality.co.uk",
-    "url": "https://www.vitality.co.uk",
     "contact": {
       "facebook": "VitalityUK",
       "twitter": "Vitality_UK"
     },
     "categories": [
-      "finance"
+      "insurance"
     ],
     "regions": [
       "gb"

--- a/entries/y/youi.com.au.json
+++ b/entries/y/youi.com.au.json
@@ -5,7 +5,7 @@
       "sms"
     ],
     "categories": [
-      "finance"
+      "insurance"
     ],
     "regions": [
       "au"


### PR DESCRIPTION
Dependent on 2factorauth/2fa.directory#62

The insurance category was proposed in [#8098](https://github.com/2factorauth/twofactorauth/pull/8098#issuecomment-2172082569). If any sites are missing from this list, please let me know. I have also removed some `url`s where they are not needed and updated the categories.

A few questions:
- Regarding Cigna, should we change the domain to `cigna.com` instead of `my.cigna.com` (`my.cigna.com` is the insurance portal)?
- Does [Independer](https://independer.nl) ([entry](https://github.com/2factorauth/twofactorauth/blob/master/entries/i/independer.nl.json)) count as insurance? I think it does, but I'd like to know your opinions.