### PR TITLE
Change frontend repo url

### DIFF
--- a/tests/categories.js
+++ b/tests/categories.js
@@ -5,7 +5,7 @@ async function main() {
   let errors = false;
   const files = process.argv.slice(2);
   const res = await fetch(
-    "https://raw.githubusercontent.com/2factorauth/frontend/master/data/categories.json",
+    "https://raw.githubusercontent.com/2factorauth/2fa.directory/master/data/categories.json",
     {
       accept: "application/json",
       "user-agent": "2factorauth/twofactorauth +https://2fa.directory/bots",


### PR DESCRIPTION
The script relied on our old repository name for the frontend (2fa.directory) repository. Apparently, the old name still works, but the content of the files isn't updated.