### PR TITLE
Remove contact element in APIv4

### DIFF
--- a/scripts/APIv4.js
+++ b/scripts/APIv4.js
@@ -59,12 +59,6 @@ const processEntries = async (files) => {
       const data = await readJSONFile(file);
       const entry = data[Object.keys(data)[0]];
 
-      // Rename contact.twitter to contact.x if it exists
-      if (entry.contact && entry.contact.twitter) {
-        entry.contact.x = entry.contact.twitter;
-        delete entry.contact.twitter;
-      }
-
       // Add the main domain entry
       entries[entry.domain] = entry;
 
@@ -93,7 +87,6 @@ const generateApi = async (entries) => {
     Object.entries(entries).map(async ([domain, entry]) => {
       const apiEntry = {
         methods: entry["tfa"],
-        contact: entry.contact,
         "custom-software": entry["custom-software"],
         "custom-hardware": entry["custom-hardware"],
         documentation: entry.documentation,

--- a/tests/schemas/APIv4.json
+++ b/tests/schemas/APIv4.json
@@ -23,33 +23,6 @@
             ]
           }
         },
-        "contact": {
-          "type": "object",
-          "description": "Contact information for the service.",
-          "properties": {
-            "email": {
-              "type": "string",
-              "format": "email"
-            },
-            "facebook": {
-              "type": "string",
-              "minLength": 1
-            },
-            "x": {
-              "type": "string",
-              "pattern": "^(\\w){1,15}$"
-            },
-            "form": {
-              "type": "string",
-              "format": "uri"
-            },
-            "language": {
-              "type": "string",
-              "pattern": "^[a-z]{2}$"
-            }
-          },
-          "additionalProperties": false
-        },
         "custom-software": {
           "type": "array",
           "description": "Custom software 2FA solutions used by the service.",


### PR DESCRIPTION
PR to remove the contact details for sites without 2FA in API v4. This is reflected in the documentation of 2factorauth/2fa.directory/pull/64.