### PR TITLE
Update Fidelity

### DIFF
--- a/entries/f/fidelity.com.json
+++ b/entries/f/fidelity.com.json
@@ -5,12 +5,13 @@
     "tfa": [
       "sms",
       "call",
+      "totp",
       "custom-software"
     ],
     "custom-software": [
       "Symantec VIP Access"
     ],
-    "documentation": "https://www.fidelity.com/security/how-two-factor-authentication-works",
+    "documentation": "https://www.fidelity.com/security/extra-security-login",
     "notes": "Specific support varies between account types",
     "categories": [
       "investing"


### PR DESCRIPTION
This adds 'totp' as an option for Fidelity. They announced support for this a couple of weeks ago
(https://www.reddit.com/r/fidelityinvestments/comments/1esv55g/its_here_you_can_now_use_most_authenticator_apps/).

This updates the documentation link. The old link still works, but it redirects to the new link. This now links directly to the canonical link.

This continues to list Symantec VIP Access as an option. I think Fidelity officially recommends standard TOTP authenticator apps over Symatec VIP Access and has removed the latter from the public documentation, however the Reddit announcement confirms both are still supported.