### PR TITLE
Updated 123-Reg.co.uk to include TOTP Support

### DIFF
--- a/entries/1/123-reg.co.uk.json
+++ b/entries/1/123-reg.co.uk.json
@@ -1,6 +1,10 @@
 {
   "123 Reg": {
     "domain": "123-reg.co.uk",
+    "tfa": [
+      "totp"
+    ],
+    "documentation": "https://www.123-reg.co.uk/support/my-account/how-do-i-enable-2-step-verification-on-my-account/",
     "contact": {
       "facebook": "123regfans",
       "twitter": "123reg"


### PR DESCRIPTION
Updated 123-Reg.co.uk to include TOTP Support + Support URL for 2FA

<img width="537" alt="Screenshot 2024-08-31 at 01 10 20" src="https://github.com/user-attachments/assets/3a3cba3b-5e6e-4494-b85f-711090c5b481">
