### PR TITLE
update United

### DIFF
--- a/entries/u/united.com.json
+++ b/entries/u/united.com.json
@@ -6,7 +6,6 @@
       "email",
       "sms",
       "call",
-      "totp",
       "custom-software"
     ],
      "custom-software": [

--- a/entries/u/united.com.json
+++ b/entries/u/united.com.json
@@ -10,8 +10,6 @@
      "custom-software": [
       "United App"
     ],
-    "documentation":"https://www.united.com/en/us/fly/mileageplus/protect-your-account.html",
-    "notes": "Requires E-Mail address to establish 2FA, TOTP only available through United app",
    "categories": [
       "transport"
     ]

--- a/entries/u/united.com.json
+++ b/entries/u/united.com.json
@@ -2,11 +2,18 @@
   "United": {
     "domain": "united.com",
     "url": "https://www.united.com/",
-    "contact": {
-      "facebook": "United",
-      "twitter": "united"
-    },
-    "categories": [
+    "tfa": [
+      "email",
+      "sms",
+      "call",
+      "custom-software"
+    ],
+     "custom-software": [
+      "United App"
+    ],
+    "documentation":"https://www.united.com/en/us/fly/mileageplus/protect-your-account.html",
+    "notes": "Requires E-Mail address to establish 2FA",
+   "categories": [
       "transport"
     ]
   }

--- a/entries/u/united.com.json
+++ b/entries/u/united.com.json
@@ -10,7 +10,7 @@
      "custom-software": [
       "United App"
     ],
-   "categories": [
+    "categories": [
       "transport"
     ]
   }

--- a/entries/u/united.com.json
+++ b/entries/u/united.com.json
@@ -6,13 +6,14 @@
       "email",
       "sms",
       "call",
+      "totp",
       "custom-software"
     ],
      "custom-software": [
       "United App"
     ],
     "documentation":"https://www.united.com/en/us/fly/mileageplus/protect-your-account.html",
-    "notes": "Requires E-Mail address to establish 2FA",
+    "notes": "Requires E-Mail address to establish 2FA, TOTP only available through United app",
    "categories": [
       "transport"
     ]

--- a/entries/u/united.com.json
+++ b/entries/u/united.com.json
@@ -1,7 +1,6 @@
 {
   "United": {
     "domain": "united.com",
-    "url": "https://www.united.com/",
     "tfa": [
       "email",
       "sms",


### PR DESCRIPTION
Documentation linked does not provide any details of the 2FA process at all right now. It might later....

Images below describe the process (during sign-in from an unregistered browser)

initial defaults to SMS - can choose others.
NOTE: First time setup of 2-factor authentication defaults to e-mail address.
![image](https://github.com/user-attachments/assets/45d63a26-7dc9-4463-b93f-e25945e0f562)

Can choose their app for TOTP, but only on computers.
![image](https://github.com/user-attachments/assets/d81fb856-d2ec-4df0-9fc4-3c6f4d7026f0)

TOTP procedure
![image](https://github.com/user-attachments/assets/8fae84be-d758-4365-a148-50d3c361dcdf)

TOTP can be used offline if device is trusted (you tell it not to authenticate)
![image](https://github.com/user-attachments/assets/c146531c-61d1-4f4a-b72e-a173ee356b0c)

# United App Auth Code access
Auth Codes are available to use - even offline - to log into the United.com web page on a computer.  
On the app, tap "Account", then scroll down and tap "Account Security" under the "Help and Settings".

![IMG_6436](https://github.com/user-attachments/assets/3c9ab87f-66b7-4415-87c1-4bbc5a75b16c)

Tap "Verification Code"
![IMG_6437](https://github.com/user-attachments/assets/aa7259a2-960e-42ec-8ae7-afeac3aeae17)

The rotating code will appear. After use, tap the "X" to return to the menu
![IMG_6438](https://github.com/user-attachments/assets/29ba428c-3ec8-4597-8143-6e6d7b1213d6)
