### PR TITLE
Added additional adguard domains

### DIFF
--- a/entries/a/adguard.com.json
+++ b/entries/a/adguard.com.json
@@ -1,6 +1,10 @@
 {
   "AdGuard": {
     "domain": "adguard.com",
+    "additional-domains": [
+      "adguard-vpn.com",
+      "adguard-dns.io"
+    ],
     "tfa": [
       "totp"
     ],


### PR DESCRIPTION
Adguard has 2 additonal domains covering their DNS and VPN products., which are all accessed via a single 'Adguard Account'.

adguard-dns.io
adguard-vpn.com

Added domains to adguard entry. 