### PR TITLE
Update Fidelity

### DIFF
--- a/entries/f/fidelity.com.json
+++ b/entries/f/fidelity.com.json
@@ -5,14 +5,9 @@
     "tfa": [
       "sms",
       "call",
-      "totp",
-      "custom-software"
-    ],
-    "custom-software": [
-      "Symantec VIP Access"
+      "totp"
     ],
     "documentation": "https://www.fidelity.com/security/extra-security-login",
-    "notes": "Specific support varies between account types",
     "categories": [
       "investing"
     ],


### PR DESCRIPTION
No mentions of Symantec VIP access in linked documentation.  custom-software entry conflicting with 1Password ability to use totp QR codes.  Other methods may be available with Fidelity Netbenefits, which has its own entry within the directory.