### PR TITLE
Update links for ubc.ca

### DIFF
--- a/entries/u/ubc.ca.json
+++ b/entries/u/ubc.ca.json
@@ -14,7 +14,8 @@
     "custom-hardware": [
       "Duo token"
     ],
-    "documentation": "https://privacymatters.ubc.ca/test-faqs",
+    "documentation": "https://ubc.service-now.com/kb_view.do?sysparm_article=KB0018724",
+    "recovery": "https://ubc.service-now.com/kb_view.do?sysparm_article=KB0018759"
     "categories": [
       "universities"
     ],

--- a/entries/u/ubc.ca.json
+++ b/entries/u/ubc.ca.json
@@ -15,7 +15,7 @@
       "Duo token"
     ],
     "documentation": "https://it.ubc.ca/mfa",
-    "recovery": "https://ubc.service-now.com/kb_view.do?sysparm_article=KB0018759"
+    "recovery": "https://ubc.service-now.com/kb_view.do?sysparm_article=KB0018759",
     "categories": [
       "universities"
     ],

--- a/entries/u/ubc.ca.json
+++ b/entries/u/ubc.ca.json
@@ -14,7 +14,7 @@
     "custom-hardware": [
       "Duo token"
     ],
-    "documentation": "https://ubc.service-now.com/kb_view.do?sysparm_article=KB0018724",
+    "documentation": "https://it.ubc.ca/mfa",
     "recovery": "https://ubc.service-now.com/kb_view.do?sysparm_article=KB0018759"
     "categories": [
       "universities"


### PR DESCRIPTION
The current link (https://privacymatters.ubc.ca/test-faqs) is now 404, so I have updated it to https://it.ubc.ca/mfa (redirects to [ServiceNow](https://ubc.service-now.com/kb_view.do?sysparm_article=KB0018724&ga=)) and added recovery https://ubc.service-now.com/kb_view.do?sysparm_article=KB0018759.

Other options:
* https://it.ubc.ca/services/accounts-passwords/multi-factor-authentication-mfa
  - Not chosen as it provides less info than the ServiceNow page
* https://privacymatters.ubc.ca/i-want/learn-about-mfa
  - No actual information; only links to ServiceNow