### PR TITLE
Add Overclock.net

### DIFF
--- a/entries/o/overclock.net.json
+++ b/entries/o/overclock.net.json
@@ -1,0 +1,12 @@
+{
+  "Overclock": {
+    "domain": "overclock.net",
+    "tfa": [
+      "totp",
+      "email"
+    ],
+    "categories": [
+      "social"
+    ]
+  }
+}


### PR DESCRIPTION
I know forums are generally not included, but I'm giving this one a try since it's been a pretty popular forum for hardware enthusiasts for over 10 years, and shows up in the Similarweb top 200k.

I could not find a good SVG image for this site unfortunately.

I also could not find a documentation URL, so here is a screenshot of the account settings page:
![image](https://github.com/user-attachments/assets/baeae900-7fe1-4dc1-9874-6d056682cc09)
