### PR TITLE
Update Australian Retirement Trust

### DIFF
--- a/entries/a/australianretirementtrust.com.au.json
+++ b/entries/a/australianretirementtrust.com.au.json
@@ -9,6 +9,7 @@
       "sms",
       "email"
     ],
+    "notes": "Requires contacting customer service to activate",
     "categories": [
       "investing"
     ],

--- a/entries/a/australianretirementtrust.com.au.json
+++ b/entries/a/australianretirementtrust.com.au.json
@@ -5,11 +5,10 @@
       "sunsuper.com.au",
       "qsuper.qld.gov.au"
     ],
-    "contact": {
-      "facebook": "AustralianRetirementTrust",
-      "twitter": "Ausretiretrust",
-      "form": "https://www.australianretirementtrust.com.au/contact-us/email-us"
-    },
+    "tfa": [
+      "sms",
+      "email"
+    ],
     "categories": [
       "investing"
     ],


### PR DESCRIPTION
Australian Retirement Trust (ART) supports SMS and email multi-factor authentication (MFA). 
No public documentation is available. Here is a secondary source: [Multi-Factor Authentication (MFA) can be enabled for Australian Retirement Trust](https://www.reddit.com/r/AusFinance/comments/1dqa7q9/multifactor_authentication_mfa_can_be_enabled_for/)
Members must contact ART by phone to enable, disable, or change MFA. 