### PR TITLE
Remove region from Let's Do This

### DIFF
--- a/entries/l/letsdothis.com.json
+++ b/entries/l/letsdothis.com.json
@@ -7,10 +7,6 @@
     "documentation": "https://intercom.help/ldt-partner-help/en/articles/9423487",
     "categories": [
       "tickets"
-    ],
-    "regions": [
-      "gb",
-      "us"
     ]
   }
 }


### PR DESCRIPTION
Let's Do This is expanding into more regions globally, so the regions field does not make sense anymore.

