### PR TITLE
Fix U.S. Department of Veterans Affairs

### DIFF
--- a/entries/v/va.gov.json
+++ b/entries/v/va.gov.json
@@ -6,8 +6,7 @@
       "call",
       "totp",
       "u2f",
-      "custom-software",
-      "custom-hardware"
+      "custom-software"
     ],
     "custom-software": [
       "ID.me Authenticator"


### PR DESCRIPTION
The new site fails to display the entry because of the missing `custom-hardware` object. This PR removes the  method because neither Login.gov nor ID.me support any custom hardware methods.

myHealtheVet doesn't appear to support any MFA and support for logging through it lasts until January 31, 2025.
DS Logon (milConnect) supports TOTP only and support for logging in through it lasts until September 30, 2025.