### PR TITLE
Fix RBC Caribbean

### DIFF
--- a/entries/c/caribbean.rbcroyalbank.com.json
+++ b/entries/c/caribbean.rbcroyalbank.com.json
@@ -7,10 +7,11 @@
       "custom-hardware"
     ],
     "custom-software": [
-      "RBC Caribbean app"
-    ],
-    "custom-software": [
+      "RBC Caribbean app",
       "Entrust Identity Guard"
+    ],
+    "custom-hardware": [
+      "RSA SecurID"
     ],
     "notes": "Hardware 2FA methods are only available for business customers.",
     "documentation": "https://www.rbcroyalbank.com/caribbean/digital-hub/security-two-factor.html",


### PR DESCRIPTION
The new site fails to display the entry because of the missing `custom-hardware` object. This PR adds the object and fixes the duplicate `custom-software` object.

I used "RSA SecurID" as the hardware token based on [this user guide from RBC Express](https://www.rbcroyalbank.com/rbcexpress/hard-token-user-guide.pdf) (found through a search for "rbc caribbean hard token") as RBC Caribbean's documentation only lists "Hard Token".