### PR TITLE
Remove CF hook

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -82,6 +82,3 @@ jobs:
 
       - name: Deploy to GitHub Pages
         uses: actions/deploy-pages@v4
-
-      - name: Send webhook to Cloudflare
-        run: curl -X POST -IL "${{ secrets.WEBHOOK }}" -o /dev/null -w '%{http_code}\n' -s


### PR DESCRIPTION
New frontend no longer needs to be rebuilt when changes occur in this repository. This PR removes the hook to rebuild the frontend.