### PR TITLE
Update GOV.UK

### DIFF
--- a/entries/g/gov.uk.json
+++ b/entries/g/gov.uk.json
@@ -1,11 +1,10 @@
 {
-  "UK Companies House": {
+  "GOV.UK One Login": {
     "domain": "gov.uk",
-    "url": "https://www.gov.uk/companieshouse",
-    "contact": {
-      "facebook": "CompaniesHouse",
-      "twitter": "CompaniesHouse"
-    },
+    "tfa": [
+      "sms",
+      "totp"
+    ],
     "categories": [
       "government"
     ],

--- a/entries/g/gov.uk.json
+++ b/entries/g/gov.uk.json
@@ -1,5 +1,5 @@
 {
-  "GOV.UK One Login": {
+  "GOV.UK": {
     "domain": "gov.uk",
     "tfa": [
       "sms",


### PR DESCRIPTION
Companies House [recently announced](https://www.gov.uk/government/news/companies-house-to-join-govuk-one-login) they are moving to GOV.UK One Login, which seems like the UK equivalent of Login.gov to me, and [many other services](https://www.gov.uk/using-your-gov-uk-one-login/services) are already there. One Login also has the URL `gov.uk/account`, which redirects to `signin.account.gov.uk` or `home.account.gov.uk` depending on your login status.

> In the future, you’ll be able to use it to access all services on GOV.UK.

The best part is One Login requires MFA through either SMS or TOTP.

> You’ll need:
> - an email address
> - a way to get security codes - this can be a mobile phone number or an authenticator app