### PR TITLE
Update Blockchain.com

### DIFF
--- a/entries/b/blockchain.com.json
+++ b/entries/b/blockchain.com.json
@@ -1,6 +1,9 @@
 {
   "Blockchain.com": {
     "domain": "blockchain.com",
+    "additional-domains": [
+      "blockchain.info"
+    ],
     "tfa": [
       "sms",
       "totp",


### PR DESCRIPTION
Update the additional domain name of blockchain.com, blockchain.info redirects to blockchain.com.