### PR TITLE
Update Meraki

### DIFF
--- a/entries/m/meraki.cisco.com.json
+++ b/entries/m/meraki.cisco.com.json
@@ -1,6 +1,9 @@
 {
   "Cisco Meraki": {
     "domain": "meraki.cisco.com",
+    "additional-domains": [
+      "meraki.com"
+    ],
     "tfa": [
       "sms",
       "totp"


### PR DESCRIPTION
Update the additional domain of meraki.cisco.com
meraki.com redirects to meraki.cisco.com