### PR TITLE
Update Progressive to show 2FA support

### DIFF
--- a/entries/p/progressive.com.json
+++ b/entries/p/progressive.com.json
@@ -1,10 +1,10 @@
 {
   "Progressive": {
     "domain": "progressive.com",
-    "contact": {
-      "facebook": "progressive",
-      "twitter": "Progressive"
-    },
+    "tfa": [
+      "sms",
+      "email"
+    ],
     "categories": [
       "insurance"
     ],


### PR DESCRIPTION
Progressive now supports text/email 2FA:

![image](https://github.com/user-attachments/assets/537d2728-03c3-4414-893a-57ab5b813ef2)
