### PR TITLE
Update PR-validator hook

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -71,5 +71,5 @@ jobs:
     steps:
       - name: Call PR Validator
         run: |
-          curl -s --fail-with-body "https://pr-validator.2fa.directory/${{ github.event.repository.name }}/${{ github.event.number }}/" \
-          -H "Content-Type: application/json"
+          OUTPUT=$(curl -s --fail-with-body "https://pr-validator.2fa.directory/${{ github.event.repository.name }}/${{ github.event.number }}/)"
+          echo "$OUTPUT"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -71,5 +71,5 @@ jobs:
     steps:
       - name: Call PR Validator
         run: |
-          OUTPUT=$(curl -s --fail-with-body "https://pr-validator.2fa.directory/${{ github.event.repository.name }}/${{ github.event.number }}/)"
+          OUTPUT=$(curl -s --fail-with-body "https://pr-validator.2fa.directory/${{ github.event.repository.name }}/${{ github.event.number }}/")
           echo "$OUTPUT"


### PR DESCRIPTION
Update to the PR-validator webhook.
I opted to store the data in a variable `$OUTPUT` instead of outputting it directly as this could be useful later on if we decide to create a  [job summary](https://github.blog/news-insights/product-news/supercharging-github-actions-with-job-summaries/).

> [!Important]
> __This pull request depends on 2factorauth/pr-validator/pull/7__

