### PR TITLE
Adjust note on Vanguard 2FA, SMS backup is not required

### DIFF
--- a/entries/v/vanguard.com.json
+++ b/entries/v/vanguard.com.json
@@ -13,7 +13,7 @@
       "Voice Verification"
     ],
     "documentation": "https://investor.vanguard.com/security/security-keys",
-    "notes": "Hardware based 2FA requires SMS / Phone call 2FA as a backup.",
+    "notes": "Hardware based 2FA requires two separate security keys or SMS / Phone call 2FA as a backup. Security keys can not be used to log in to mobile app or mobile website unless \"Preview as Desktop\" is enabled.",
     "categories": [
       "investing"
     ],

--- a/entries/v/vanguard.com.json
+++ b/entries/v/vanguard.com.json
@@ -13,7 +13,7 @@
       "Voice Verification"
     ],
     "documentation": "https://investor.vanguard.com/security/security-keys",
-    "notes": "Hardware based 2FA requires two separate security keys or SMS / Phone call 2FA as a backup. Security keys can not be used to log in to mobile app or mobile website unless \"Preview as Desktop\" is enabled.",
+    "notes": "Security keys can not be used to log in to mobile app or mobile website.",
     "categories": [
       "investing"
     ],


### PR DESCRIPTION
On Vanguard Brokerage 2FA, you do not need an SMS backup if you have multiple hardware keys (i.e. two yubikeys). However doing so will break the mobile app and the mobile website login, they will say something like "Your login method is not supported on this device). If you view the mobile website in "Desktop Preview" however, login does in fact work, and you can then go back to non-preview and be okay. I've updated the note on Vanguard to include both of these factoids. I removed my SMS myself and it's working. 

Here's public a source (just an online forum): https://www.bogleheads.org/forum/viewtopic.php?t=349826

I think someone in that forum mentions that they could bypass 2FA, on mobile with security questions instead of Security Keys, but this does not appear to be the case anymore.

Let me know if there's anything else I can do! Could provide some screenshots if needed.
