### PR TITLE
Add TOTP method for NASA Federal Credit Union

### DIFF
--- a/entries/n/nasafcu.com.json
+++ b/entries/n/nasafcu.com.json
@@ -5,7 +5,8 @@
     "tfa": [
       "sms",
       "call",
-      "email"
+      "email",
+      "totp"
     ],
     "documentation": "https://www.nasafcu.com/img/newebranch/ebranch_new.html",
     "regions": [


### PR DESCRIPTION
Minimal pull request to address issue #8390 by adding the `totp` 2FA method for NASA Federal Credit Union.