### PR TITLE
Update Duke MFA options

### DIFF
--- a/entries/d/duke.edu.json
+++ b/entries/d/duke.edu.json
@@ -1,10 +1,7 @@
 {
   "Duke University": {
     "domain": "duke.edu",
-    "url": "https://www.duke.edu",
     "tfa": [
-      "sms",
-      "call",
       "custom-software",
       "custom-hardware"
     ],


### PR DESCRIPTION
Duke University no longer supports SMS and phone calls for MFA as of February 28 (faculty and staff) and March 18 (students) per [their page on online security measures](https://oit.duke.edu/services-tools/security/dukes-online-security-measures/).

Also, should we switch the documentation page from the current help page at https://idms-mfa.oit.duke.edu/mfa/help to [the online security measures page](https://oit.duke.edu/services-tools/security/dukes-online-security-measures/)? The current page is more of an FAQ, but the security measures page also has videos.