### PR TITLE
Update Harvard MFA options

### DIFF
--- a/entries/h/harvard.edu.json
+++ b/entries/h/harvard.edu.json
@@ -1,15 +1,17 @@
 {
   "Harvard University": {
     "domain": "harvard.edu",
-    "url": "https://www.harvard.edu",
     "tfa": [
       "sms",
       "call",
+      "u2f",
+      "totp",
       "custom-software",
       "custom-hardware"
     ],
     "custom-software": [
-      "Duo"
+      "Duo",
+      "Okta Verify"
     ],
     "custom-hardware": [
       "Yubico OTP"


### PR DESCRIPTION
Harvard University is transitioning away from Duo to Okta with estimated completion in March 2026. Security keys, passkeys, and Okta Verify have been added as MFA options. See [the transition page](https://www.huit.harvard.edu/okta) for more details.