### PR TITLE
Update WhatsApp

### DIFF
--- a/entries/w/whatsapp.com.json
+++ b/entries/w/whatsapp.com.json
@@ -3,7 +3,12 @@
     "domain": "whatsapp.com",
     "tfa": [
       "sms",
-      "call"
+      "call",
+      "email",
+      "custom-software"
+    ],
+    "custom-software": [
+      "WhatsApp PIN"
     ],
     "documentation": "https://www.whatsapp.com/faq/en/general/26000021",
     "categories": [

--- a/entries/w/whatsapp.com.json
+++ b/entries/w/whatsapp.com.json
@@ -4,11 +4,7 @@
     "tfa": [
       "sms",
       "call",
-      "email",
-      "custom-software"
-    ],
-    "custom-software": [
-      "WhatsApp PIN"
+      "email"
     ],
     "documentation": "https://www.whatsapp.com/faq/en/general/26000021",
     "categories": [


### PR DESCRIPTION
Resolves #8435 

Documentation URLs are in the linked issue.

I added WhatsApp's PIN as custom software, but I can change that if there is a better place for it.

> When enabling this feature, you create and confirm a unique PIN that’s required to access your account. The two-step verification PIN is different from the 6-digit registration code you receive via SMS or phone call. For security purposes, when you re-register an existing account, there may be a delay before you can turn on two-step verification.