### PR TITLE
Update Robinhood

### DIFF
--- a/entries/r/robinhood.com.json
+++ b/entries/r/robinhood.com.json
@@ -1,12 +1,14 @@
 {
   "Robinhood": {
     "domain": "robinhood.com",
-    "url": "https://www.robinhood.com/",
     "tfa": [
       "sms",
-      "totp"
+      "custom-software"
     ],
-    "documentation": "https://support.robinhood.com/hc/en-us/articles/360001213783",
+    "custom-software": [
+      "Robinhood app"
+    ],
+    "documentation": "https://robinhood.com/support/articles/verifying-its-you/",
     "categories": [
       "investing"
     ],


### PR DESCRIPTION
Resolves #8387 

Robinhood changed their documentation URL and removed TOTP support from [their website](https://robinhood.com/support/articles/verifying-its-you/).

> Every time you log in or make changes to your Robinhood account, you’ll get a request for another form of verification in addition to your password, such as:
> - Device approval request
> - SMS one-time-code
> - Bank verification
> - A three-point selfie
> - A photo of the front and back of a valid government ID