### PR TITLE
Add TFA info and documentation for impots.gouv.fr

### DIFF
--- a/entries/i/impots.gouv.fr.json
+++ b/entries/i/impots.gouv.fr.json
@@ -2,11 +2,10 @@
   "impots.gouv.fr": {
     "domain": "impots.gouv.fr",
     "url": "https://www.impots.gouv.fr",
-    "contact": {
-      "facebook": "Direction-générale-des-Finances-publiques-250996308359760",
-      "twitter": "dgfip_officiel",
-      "language": "fr"
-    },
+    "tfa": [
+      "email"
+    ],
+    "documentation": "https://www.impots.gouv.fr/actualite/la-securite-de-votre-espace-particulier-se-renforce",
     "categories": [
       "government"
     ],


### PR DESCRIPTION
Update impots.gouv.fr: add TFA method and security documentation

- Removed obsolete contact info (social media)
- Added "tfa": ["email"]
- Linked official documentation confirming 2FA: https://www.impots.gouv.fr/actualite/la-securite-de-votre-espace-particulier-se-renforce

