### PR TITLE
Update Dyn

### DIFF
--- a/entries/d/dyn.com.json
+++ b/entries/d/dyn.com.json
@@ -1,12 +1,9 @@
 {
   "Dyn": {
     "domain": "dyn.com",
-    "tfa": [
-      "sms",
-      "totp"
-    ],
-    "documentation": "https://help.dyn.com/2-factor-authentication/",
-    "notes": "Currently only supported for the Managed DNS & Email Delivery platforms (via DynID). Eventually DynID (and 2FA) will be rolled out to all platforms (no ETA).",
+    "contact": {
+      "twitter": "OracleCloud"
+    },
     "categories": [
       "domains"
     ]


### PR DESCRIPTION
Resolves #8496

Dyn's Twitter page says that they "are now part of @​OracleCloud" and the contact support link on [their account page](https://account.dyn.com/) requires an account.