### PR TITLE
Add banking to wealthsimple

### DIFF
--- a/entries/w/wealthsimple.com.json
+++ b/entries/w/wealthsimple.com.json
@@ -10,6 +10,7 @@
     ],
     "documentation": "https://help.wealthsimple.com/hc/en-ca/articles/360056584134",
     "categories": [
+      "banking",
       "finance",
       "investing"
     ],


### PR DESCRIPTION
[Wealthsimple](https://www.wealthsimple.com) wrote [Popular online banks in Canada](https://www.wealthsimple.com/en-ca/learn/best-online-banks-canada#online_banks_and_financial_institutions_in_canada)

> To help you consider which online bank might be right for you, we’ve rounded up a list (in alphabetical order) of Canada’s online-only banks and financial institutions with chequing and spending accounts. All statistics are verified as of November 2025. We’re not going to say which one is the best for your needs - that’s for you to determine - but we’ve tried to make it easier for you to make an informed decision. Just so you know, we don’t include promotional rates in the chart below. What you see is what you usually get.

In the list, they include:
* [tangerine.ca](https://github.com/2factorauth/twofactorauth/blob/5df49622b735f562e221120fe8073e5d11060558/entries/t/tangerine.ca.json#L12)
* themselves

I think that's sufficient to justify their inclusion in the `banking` category.

General information about [chequing](https://www.wealthsimple.com/en-ca/chequing)