### PR TITLE
Add `u2f` to openai.com

### DIFF
--- a/entries/o/openai.com.json
+++ b/entries/o/openai.com.json
@@ -5,7 +5,8 @@
         	"chatgpt.com"
         ],
         "tfa": [
-          "totp"
+          "totp",
+          "u2f"
         ],
         "documentation": "https://help.openai.com/articles/7967234",
         "categories": [


### PR DESCRIPTION
OpenAI now supports hardware keys.

https://help.openai.com/en/articles/20001039-passkeys-to-secure-your-openai-account