### PR TITLE
Update ameriprise.com.json

### DIFF
--- a/entries/a/ameriprise.com.json
+++ b/entries/a/ameriprise.com.json
@@ -2,9 +2,10 @@
   "Ameriprise Financial": {
     "domain": "ameriprise.com",
     "tfa": [
-      "sms"
+      "sms",
+      "totp"
     ],
-    "documentation": "https://www.ameriprise.com/privacy-security-fraud/how-we-protect-information/#02",
+    "documentation": "https://www.ameriprise.com/customer-service/2-step-verification-faq",
     "categories": [
       "banking"
     ],

--- a/entries/a/ameriprise.com.json
+++ b/entries/a/ameriprise.com.json
@@ -3,7 +3,11 @@
     "domain": "ameriprise.com",
     "tfa": [
       "sms",
-      "totp"
+      "totp",
+      "custom-software"
+    ],
+    "custom-software": [
+      "Ameriprise Financial app"
     ],
     "documentation": "https://www.ameriprise.com/customer-service/2-step-verification-faq",
     "categories": [


### PR DESCRIPTION
Ameriprise supports TOTP (Google Authenticator) which isn't noted yet on 2fa.directory. 

Additionally, I found a better documentation link which goes directly to the 2FA configuration settings, rather than needing to click a link in the 1st documentation page to be send to the 2nd documentation page.

Thank you for maintaining this, I can't even imagine how many people this has saved by making them aware of more secure options!