### PR TITLE
Update monzo.com.json to include Ireland and note about magic links

### DIFF
--- a/entries/m/monzo.com.json
+++ b/entries/m/monzo.com.json
@@ -6,7 +6,9 @@
       "facebook": "monzobank",
       "twitter": "monzo"
     },
+    "notes": "Only supports magic link login, so 2FA is transitive through your email",
     "regions": [
+      "ie",
       "gb",
       "us"
     ],


### PR DESCRIPTION
Include note that explains that Monzo only uses magic links, so 2FA work transitively