### PR TITLE
Update myGov

### DIFF
--- a/entries/m/my.gov.au.json
+++ b/entries/m/my.gov.au.json
@@ -3,12 +3,9 @@
     "domain": "my.gov.au",
     "tfa": [
       "sms",
-      "custom-software"
+      "totp"
     ],
-    "custom-software": [
-      "myGov Code Generator"
-    ],
-    "documentation": "https://my.gov.au/en/about/help/mygov-account/help-using-your-account/manage-sign-in-details",
+    "documentation": "https://my.gov.au/en/about/help/mygov-website/sign-in-to-mygov/use-an-authenticator",
     "categories": [
       "government"
     ],


### PR DESCRIPTION
As per [this doco](https://my.gov.au/en/about/help/mygov-website/sign-in-to-mygov/use-an-authenticator#:~:text=The%20myGov%20Code%20Generator%20app,Generator%20app%20will%20be%20retired.), the myGov Code Generator app is being retired.