### PR TITLE
Remove SMS from UC San Diego

### DIFF
--- a/entries/u/ucsd.edu.json
+++ b/entries/u/ucsd.edu.json
@@ -2,7 +2,6 @@
   "University of California, San Diego": {
     "domain": "ucsd.edu",
     "tfa": [
-      "sms",
       "u2f",
       "custom-hardware",
       "custom-software"


### PR DESCRIPTION
UC San Diego announced that they're removing SMS as of February 12.

*See:* [status](https://status.ucsd.edu/incidents/j44pmt7qfsy0), [MFA documentation](https://blink.ucsd.edu/technology/security/services/two-step-login/index.html)