### PR TITLE
Update PayPal

### DIFF
--- a/entries/p/paypal.com.json
+++ b/entries/p/paypal.com.json
@@ -5,7 +5,8 @@
       "paypal-search.com"
     ],
     "tfa": [
-      "totp"
+      "totp",
+      "security_key"
     ],
     "notes": "2FA can only be setup in web browser and not through the PayPal App.",
     "documentation": "https://www.paypal.com/us/cshelp/article/help167",


### PR DESCRIPTION
  ## 背景
   PayPal 现在在帐号安全设置里支持 **安全密钥 (U2F / WebAuthn)**，但 2FA 目录的条目只列出了 `totp`，导致信息不完整。

   ## 改动
   - 在 `entries/p/paypal.com.json` 的 `tfa` 数组中加入 `"security_key"`，表明 PayPal 支持硬件安全密钥。

   ## 验证依据
   - 截图（来自 Issue #8582）显示 PayPal 在安全设置页面有 “Security key” 选项。
     ![PayPal security‑key screenshot](https://github.com/user-attachments/assets/e8f50cf4-725f-4367-9081-d72d501d9020)

   ## 付款信息
   完成后请在 PR 描述中注明 **PayPal 收款邮箱**：`517519609@qq.com`，以便通过 PayPal 支付报酬。