### PR TITLE
Update eBay

### DIFF
--- a/entries/e/ebay.com.json
+++ b/entries/e/ebay.com.json
@@ -14,7 +14,6 @@
       "ebay.ie",
       "ebay.it",
       "ebay.co.jp",
-      "gmarket.co.kr",
       "ebay.com.my",
       "ebay.nl",
       "ebay.ph",


### PR DESCRIPTION
`gmarket.co.kr` does not use `ebay.com` accounts.