### PR TITLE
Remove Glassdoor docs

### DIFF
--- a/entries/g/glassdoor.com.json
+++ b/entries/g/glassdoor.com.json
@@ -5,7 +5,6 @@
       "totp",
       "sms"
     ],
-    "documentation": "https://help.glassdoor.com/article/Manage-Two-Factor-Authentication/",
     "categories": [
       "social"
     ]


### PR DESCRIPTION
Glassdoor's docs link seems to be dead