### PR TITLE
Add SMS to Lufthansa

### DIFF
--- a/entries/l/lufthansa.com.json
+++ b/entries/l/lufthansa.com.json
@@ -1,7 +1,11 @@
 {
   "Lufthansa": {
     "domain": "lufthansa.com",
+    "additional-domains": [
+      "miles-and-more.com"
+    ],
     "tfa": [
+      "sms",
       "totp"
     ],
     "documentation": "https://www.miles-and-more.com/row/en/general-information/help-and-contact/help/2-factor-authentication.html",


### PR DESCRIPTION
Lufthansa also supports SMS.
See: https://www.miles-and-more.com/row/en/general-information/help-and-contact/help/faqs-2fa-activation.html